### PR TITLE
[DB-28313] Enable passing of certificates directly to the engine

### DIFF
--- a/stable/database/README.md
+++ b/stable/database/README.md
@@ -169,6 +169,9 @@ The following tables list the configurable parameters for the `admin` option of 
 | `namespace` | Namespace where admin is deployed; when peering to an existing admin cluster provide its project name | `nuodb` |
 | `tlsCACert.secret` | TLS CA certificate secret name | `nil` |
 | `tlsCACert.key` | TLS CA certificate secret key | `nil` |
+| `tlsKeyStore.secret` | TLS keystore secret name | `nil` |
+| `tlsKeyStore.key` | TLS keystore secret key | `nil` |
+| `tlsKeyStore.password` | TLS keystore secret password | `nil` |
 | `tlsClientPEM.secret` | TLS client PEM secret name | `nil` |
 | `tlsClientPEM.key` | TLS client PEM secret key | `nil` |
 
@@ -226,12 +229,14 @@ The following tables list the configurable parameters of the `database` chart an
 | `te.resources` | Labels to apply to all resources | `{}` |
 | `te.affinity` | Affinity rules for NuoDB TE | `{}` |
 | `te.nodeSelector` | Node selector rules for NuoDB TE | `{}` |
-| `te.tolerations` | Tolerations for NuoDB TE | `[]` |||
-| `sm.affinityNoHotCopyDS` | Affinity rules for non-hot-copy SMs (DaemonSet) | `{}` |||
-| `sm.affinityHotCopyDS` | Affinity rules for hot-copy enabled SMs (DaemonSet) | `{}` |||
-| `sm.nodeSelectorHotCopyDS` | Node selector rules for hot-copy enabled SMs (DaemonSet) | `{}` |||
-| `sm.nodeSelectorNoHotCopyDS` | Node selector rules for non-hot-copy SMs (DaemonSet) | `{}` |||
-| `sm.tolerationsDS` | Tolerations for SMs (DaemonSet) | `[]` |||
+| `te.tolerations` | Tolerations for NuoDB TE | `[]` |
+| `te.otherOptions` | Additional key/value Docker options | `{}` |
+| `sm.affinityNoHotCopyDS` | Affinity rules for non-hot-copy SMs (DaemonSet) | `{}` |
+| `sm.affinityHotCopyDS` | Affinity rules for hot-copy enabled SMs (DaemonSet) | `{}` |
+| `sm.nodeSelectorHotCopyDS` | Node selector rules for hot-copy enabled SMs (DaemonSet) | `{}` |
+| `sm.nodeSelectorNoHotCopyDS` | Node selector rules for non-hot-copy SMs (DaemonSet) | `{}` |
+| `sm.tolerationsDS` | Tolerations for SMs (DaemonSet) | `[]` |
+| `sm.otherOptions` | Additional key/value Docker options | `{}` |
 
 ### Running
 

--- a/stable/database/templates/daemonset.yaml
+++ b/stable/database/templates/daemonset.yaml
@@ -62,6 +62,10 @@ spec:
           - "--database-options"
           - "{{- range $opt, $val := .Values.database.options -}} {{$opt}} {{$val}} {{end}}"
 {{- end }}
+{{- range $opt, $val := .Values.database.sm.otherOptions }}
+          - "--{{$opt}}"
+          - "{{$val}}"
+{{- end}}
     {{- include "database.envFrom" . | indent 8 }}
         env:
         - name: NODE_NAME
@@ -123,6 +127,11 @@ spec:
           mountPath: /etc/nuodb/keys/nuocmd.pem
           subPath: {{ .Values.admin.tlsClientPEM.key }}
         {{- end }}
+        {{- if .Values.admin.tlsKeyStore }}
+        - name: tls-keystore
+          mountPath: /etc/nuodb/keys/nuoadmin.p12
+          subPath: {{ .Values.admin.tlsKeyStore.key }}
+        {{- end }}
 {{- include "nuodb.imagePullSecrets" . | indent 6 }}
       volumes:
       - name: log-volume
@@ -144,6 +153,12 @@ spec:
       - name: tls-client-pem
         secret:
           secretName: {{ .Values.admin.tlsClientPEM.secret }}
+          defaultMode: 0440
+      {{- end }}
+      {{- if .Values.admin.tlsKeyStore }}
+      - name: tls-keystore
+        secret:
+          secretName: {{ .Values.admin.tlsKeyStore.secret }}
           defaultMode: 0440
       {{- end }}
       dnsPolicy: ClusterFirst
@@ -213,6 +228,10 @@ spec:
           - "--database-options"
           - "{{- range $opt, $val := .Values.database.options}} {{$opt}} {{$val}} {{- end}}"
     {{- end}}
+{{- range $opt, $val := .Values.database.sm.otherOptions }}
+          - "--{{$opt}}"
+          - "{{$val}}"
+{{- end}}
     {{- include "database.envFrom" . | indent 8 }}
         env:
         - name: NODE_NAME
@@ -282,6 +301,11 @@ spec:
           mountPath: /etc/nuodb/keys/nuocmd.pem
           subPath: {{ .Values.admin.tlsClientPEM.key }}
         {{- end }}
+        {{- if .Values.admin.tlsKeyStore }}
+        - name: tls-keystore
+          mountPath: /etc/nuodb/keys/nuoadmin.p12
+          subPath: {{ .Values.admin.tlsKeyStore.key }}
+        {{- end }}
 {{- include "nuodb.imagePullSecrets" . | indent 6 }}
       volumes:
       - name: log-volume
@@ -306,6 +330,12 @@ spec:
       - name: tls-client-pem
         secret:
           secretName: {{ .Values.admin.tlsClientPEM.secret }}
+          defaultMode: 0440
+      {{- end }}
+      {{- if .Values.admin.tlsKeyStore }}
+      - name: tls-keystore
+        secret:
+          secretName: {{ .Values.admin.tlsKeyStore.secret }}
           defaultMode: 0440
       {{- end }}
       dnsPolicy: ClusterFirst

--- a/stable/database/templates/daemonset.yaml
+++ b/stable/database/templates/daemonset.yaml
@@ -104,6 +104,11 @@ spec:
         - { name: NUOCMD_API_SERVER,   value: "{{ template "admin.address" . }}:8888" }
         - { name: PEER_ADDRESS,        value: "{{ template "admin.address" . }}" }
         - { name: NUDOB_ARCHIVEDIR,    value: "/var/opt/nuodb/archive/${NODE_NAME}" }
+    {{- if .Values.admin.tlsKeyStore }}
+      {{- if .Values.admin.tlsKeyStore.password }}
+        - { name: NUODB_KEYSTORE_PASSWORD,    value: {{ .Values.admin.tlsKeyStore.password | quote }} }
+      {{- end }}
+    {{- end }}
         ports:
         - containerPort: 48006
           protocol: TCP
@@ -276,6 +281,11 @@ spec:
         - { name: PEER_ADDRESS,        value: "{{ template "admin.address" . }}" }
         - { name: NUDOB_ARCHIVEDIR,    value: "/var/opt/nuodb/archive/${NODE_NAME}" }
         - { name: NUODB_IMPORT_STRIP_LEVELS, value: "{{ default "1" .Values.database.import.stripLevels }}"}
+    {{- if .Values.admin.tlsKeyStore }}
+      {{- if .Values.admin.tlsKeyStore.password }}
+        - { name: NUODB_KEYSTORE_PASSWORD,    value: {{ .Values.admin.tlsKeyStore.password | quote }} }
+      {{- end }}
+    {{- end }}
         ports:
         - containerPort: 48006
           protocol: TCP

--- a/stable/database/templates/daemonset.yaml
+++ b/stable/database/templates/daemonset.yaml
@@ -106,7 +106,7 @@ spec:
         - { name: NUDOB_ARCHIVEDIR,    value: "/var/opt/nuodb/archive/${NODE_NAME}" }
     {{- if .Values.admin.tlsKeyStore }}
       {{- if .Values.admin.tlsKeyStore.password }}
-        - { name: NUODB_KEYSTORE_PASSWORD,    value: {{ .Values.admin.tlsKeyStore.password | quote }} }
+        - { name: NUODOCKER_KEYSTORE_PASSWORD,    value: {{ .Values.admin.tlsKeyStore.password | quote }} }
       {{- end }}
     {{- end }}
         ports:
@@ -283,7 +283,7 @@ spec:
         - { name: NUODB_IMPORT_STRIP_LEVELS, value: "{{ default "1" .Values.database.import.stripLevels }}"}
     {{- if .Values.admin.tlsKeyStore }}
       {{- if .Values.admin.tlsKeyStore.password }}
-        - { name: NUODB_KEYSTORE_PASSWORD,    value: {{ .Values.admin.tlsKeyStore.password | quote }} }
+        - { name: NUODOCKER_KEYSTORE_PASSWORD,    value: {{ .Values.admin.tlsKeyStore.password | quote }} }
       {{- end }}
     {{- end }}
         ports:

--- a/stable/database/templates/deployment.yaml
+++ b/stable/database/templates/deployment.yaml
@@ -56,6 +56,10 @@ spec:
           - "mem {{ .Values.database.te.memoryOption}} {{- range $opt, $val := .Values.database.te.engineOptions }} {{$opt}} {{$val}} {{- end}}"
           - "--labels"
           - "{{- range $opt, $val := .Values.database.te.labels }} {{$opt}} {{$val}} {{- end}}"
+{{- range $opt, $val := .Values.database.te.otherOptions }}
+          - "--{{$opt}}"
+          - "{{$val}}"
+{{- end}}
     {{- include "database.envFrom" . | indent 8 }}
         env:
           - name: NODE_NAME
@@ -96,6 +100,11 @@ spec:
           mountPath: /etc/nuodb/keys/nuocmd.pem
           subPath: {{ .Values.admin.tlsClientPEM.key }}
         {{- end }}
+        {{- if .Values.admin.tlsKeyStore }}
+        - name: tls-keystore
+          mountPath: /etc/nuodb/keys/nuoadmin.p12
+          subPath: {{ .Values.admin.tlsKeyStore.key }}
+        {{- end }}
 {{- include "nuodb.imagePullSecrets" . | indent 6 }}
       volumes:
         - name: logdir
@@ -114,6 +123,12 @@ spec:
         - name: tls-client-pem
           secret:
             secretName: {{ .Values.admin.tlsClientPEM.secret }}
+            defaultMode: 0440
+        {{- end }}
+        {{- if .Values.admin.tlsKeyStore }}
+        - name: tls-keystore
+          secret:
+            secretName: {{ .Values.admin.tlsKeyStore.secret }}
             defaultMode: 0440
         {{- end }}
       dnsPolicy: ClusterFirst

--- a/stable/database/templates/deployment.yaml
+++ b/stable/database/templates/deployment.yaml
@@ -79,7 +79,7 @@ spec:
           - { name: PEER_ADDRESS,        value: "{{ template "admin.address" . }}" }
       {{- if .Values.admin.tlsKeyStore }}
         {{- if .Values.admin.tlsKeyStore.password }}
-          - { name: NUODB_KEYSTORE_PASSWORD,    value: {{ .Values.admin.tlsKeyStore.password | quote }} }
+          - { name: NUODOCKER_KEYSTORE_PASSWORD,    value: {{ .Values.admin.tlsKeyStore.password | quote }} }
         {{- end }}
       {{- end }}
         ports:

--- a/stable/database/templates/deployment.yaml
+++ b/stable/database/templates/deployment.yaml
@@ -77,6 +77,11 @@ spec:
           - { name: DB_NAME,             value: {{ .Values.database.name | quote }} }
           - { name: NUOCMD_API_SERVER,   value: "{{ template "admin.address" . }}:8888" }
           - { name: PEER_ADDRESS,        value: "{{ template "admin.address" . }}" }
+      {{- if .Values.admin.tlsKeyStore }}
+        {{- if .Values.admin.tlsKeyStore.password }}
+          - { name: NUODB_KEYSTORE_PASSWORD,    value: {{ .Values.admin.tlsKeyStore.password | quote }} }
+        {{- end }}
+      {{- end }}
         ports:
         - containerPort: 48006
           protocol: TCP

--- a/stable/database/templates/deploymentconfig.yaml
+++ b/stable/database/templates/deploymentconfig.yaml
@@ -55,6 +55,10 @@ spec:
           - "mem {{ .Values.database.te.memoryOption}} {{- range $opt, $val := .Values.database.te.engineOptions }} {{$opt}} {{$val}} {{- end}}"
           - "--labels"
           - "{{- range $opt, $val := .Values.database.te.labels }} {{$opt}} {{$val}} {{- end}}"
+{{- range $opt, $val := .Values.database.te.otherOptions }}
+          - "--{{$opt}}"
+          - "{{$val}}"
+{{- end}}
     {{- include "database.envFrom" . | indent 8 }}
         env:
         - name: NODE_NAME
@@ -95,6 +99,11 @@ spec:
           mountPath: /etc/nuodb/keys/nuocmd.pem
           subPath: {{ .Values.admin.tlsClientPEM.key }}
         {{- end }}
+        {{- if .Values.admin.tlsKeyStore }}
+        - name: tls-keystore
+          mountPath: /etc/nuodb/keys/nuoadmin.p12
+          subPath: {{ .Values.admin.tlsKeyStore.key }}
+        {{- end }}
 {{- include "nuodb.imagePullSecrets" . | indent 6 }}
       volumes:
         - name: logdir
@@ -113,6 +122,12 @@ spec:
         - name: tls-client-pem
           secret:
             secretName: {{ .Values.admin.tlsClientPEM.secret }}
+            defaultMode: 0440
+        {{- end }}
+        {{- if .Values.admin.tlsKeyStore }}
+        - name: tls-keystore
+          secret:
+            secretName: {{ .Values.admin.tlsKeyStore.secret }}
             defaultMode: 0440
         {{- end }}
       dnsPolicy: ClusterFirst

--- a/stable/database/templates/deploymentconfig.yaml
+++ b/stable/database/templates/deploymentconfig.yaml
@@ -78,7 +78,7 @@ spec:
         - { name: PEER_ADDRESS,        value: "{{ template "admin.address" . }}" }
     {{- if .Values.admin.tlsKeyStore }}
       {{- if .Values.admin.tlsKeyStore.password }}
-        - { name: NUODB_KEYSTORE_PASSWORD,    value: {{ .Values.admin.tlsKeyStore.password | quote }} }
+        - { name: NUODOCKER_KEYSTORE_PASSWORD,    value: {{ .Values.admin.tlsKeyStore.password | quote }} }
       {{- end }}
     {{- end }}
         ports:

--- a/stable/database/templates/deploymentconfig.yaml
+++ b/stable/database/templates/deploymentconfig.yaml
@@ -76,6 +76,11 @@ spec:
         - { name: DB_NAME,             value: {{ .Values.database.name | quote }} }
         - { name: NUOCMD_API_SERVER,   value: "{{ template "admin.address" . }}:8888" }
         - { name: PEER_ADDRESS,        value: "{{ template "admin.address" . }}" }
+    {{- if .Values.admin.tlsKeyStore }}
+      {{- if .Values.admin.tlsKeyStore.password }}
+        - { name: NUODB_KEYSTORE_PASSWORD,    value: {{ .Values.admin.tlsKeyStore.password | quote }} }
+      {{- end }}
+    {{- end }}
         ports:
         - containerPort: 48006
           protocol: TCP

--- a/stable/database/templates/statefulset.yaml
+++ b/stable/database/templates/statefulset.yaml
@@ -122,6 +122,11 @@ spec:
         - { name: NUODB_DOMAIN,        value: "{{ .Values.admin.domain }}" }
         - { name: NUOCMD_API_SERVER,   value: "{{ template "admin.address" . }}:8888" }
         - { name: PEER_ADDRESS,        value: "{{ template "admin.address" . }}" }
+    {{- if .Values.admin.tlsKeyStore }}
+      {{- if .Values.admin.tlsKeyStore.password }}
+        - { name: NUODB_KEYSTORE_PASSWORD,    value: {{ .Values.admin.tlsKeyStore.password | quote }} }
+      {{- end }}
+    {{- end }}
         ports:
         - containerPort: 48006
           protocol: TCP
@@ -336,6 +341,11 @@ spec:
         - { name: NUODB_DOMAIN,        value: "{{ .Values.admin.domain }}" }
         - { name: NUOCMD_API_SERVER,   value: "{{ template "admin.address" . }}:8888" }
         - { name: PEER_ADDRESS,        value: "{{ template "admin.address" . }}" }
+    {{- if .Values.admin.tlsKeyStore }}
+      {{- if .Values.admin.tlsKeyStore.password }}
+        - { name: NUODB_KEYSTORE_PASSWORD,    value: {{ .Values.admin.tlsKeyStore.password | quote }} }
+      {{- end }}
+    {{- end }}
         ports:
         - containerPort: 48006
           protocol: TCP

--- a/stable/database/templates/statefulset.yaml
+++ b/stable/database/templates/statefulset.yaml
@@ -81,6 +81,10 @@ spec:
           - "--database-options"
           - "{{- range $opt, $val := .Values.database.options -}} {{$opt}} {{$val}} {{end}}"
     {{- end }}
+{{- range $opt, $val := .Values.database.sm.otherOptions }}
+          - "--{{$opt}}"
+          - "{{$val}}"
+{{- end}}
     {{- include "database.envFrom" . | indent 8 }}
         env:
         - name: NODE_NAME
@@ -141,6 +145,11 @@ spec:
           mountPath: /etc/nuodb/keys/nuocmd.pem
           subPath: {{ .Values.admin.tlsClientPEM.key }}
         {{- end }}
+        {{- if .Values.admin.tlsKeyStore }}
+        - name: tls-keystore
+          mountPath: /etc/nuodb/keys/nuoadmin.p12
+          subPath: {{ .Values.admin.tlsKeyStore.key }}
+        {{- end }}
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
 {{- include "nuodb.imagePullSecrets" . | indent 6 }}
@@ -161,6 +170,12 @@ spec:
       - name: tls-client-pem
         secret:
           secretName: {{ .Values.admin.tlsClientPEM.secret }}
+          defaultMode: 0440
+      {{- end }}
+      {{- if .Values.admin.tlsKeyStore }}
+      - name: tls-keystore
+        secret:
+          secretName: {{ .Values.admin.tlsKeyStore.secret }}
           defaultMode: 0440
       {{- end }}
   volumeClaimTemplates:
@@ -275,6 +290,10 @@ spec:
           - "--database-options"
           - "{{- range $opt, $val := .Values.database.options -}} {{$opt}} {{$val}} {{end}}"
 {{- end}}
+{{- range $opt, $val := .Values.database.sm.otherOptions }}
+          - "--{{$opt}}"
+          - "{{$val}}"
+{{- end}}
     {{- include "database.envFrom" . | indent 8 }}
         env:
         - name: NODE_NAME
@@ -342,6 +361,11 @@ spec:
           mountPath: /etc/nuodb/keys/nuocmd.pem
           subPath: {{ .Values.admin.tlsClientPEM.key }}
         {{- end }}
+        {{- if .Values.admin.tlsKeyStore }}
+        - name: tls-keystore
+          mountPath: /etc/nuodb/keys/nuoadmin.p12
+          subPath: {{ .Values.admin.tlsKeyStore.key }}
+        {{- end }}
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
 {{- include "nuodb.imagePullSecrets" . | indent 6 }}
@@ -362,6 +386,12 @@ spec:
       - name: tls-client-pem
         secret:
           secretName: {{ .Values.admin.tlsClientPEM.secret }}
+          defaultMode: 0440
+      {{- end }}
+      {{- if .Values.admin.tlsKeyStore }}
+      - name: tls-keystore
+        secret:
+          secretName: {{ .Values.admin.tlsKeyStore.secret }}
           defaultMode: 0440
       {{- end }}
   volumeClaimTemplates:

--- a/stable/database/templates/statefulset.yaml
+++ b/stable/database/templates/statefulset.yaml
@@ -124,7 +124,7 @@ spec:
         - { name: PEER_ADDRESS,        value: "{{ template "admin.address" . }}" }
     {{- if .Values.admin.tlsKeyStore }}
       {{- if .Values.admin.tlsKeyStore.password }}
-        - { name: NUODB_KEYSTORE_PASSWORD,    value: {{ .Values.admin.tlsKeyStore.password | quote }} }
+        - { name: NUODOCKER_KEYSTORE_PASSWORD,    value: {{ .Values.admin.tlsKeyStore.password | quote }} }
       {{- end }}
     {{- end }}
         ports:
@@ -343,7 +343,7 @@ spec:
         - { name: PEER_ADDRESS,        value: "{{ template "admin.address" . }}" }
     {{- if .Values.admin.tlsKeyStore }}
       {{- if .Values.admin.tlsKeyStore.password }}
-        - { name: NUODB_KEYSTORE_PASSWORD,    value: {{ .Values.admin.tlsKeyStore.password | quote }} }
+        - { name: NUODOCKER_KEYSTORE_PASSWORD,    value: {{ .Values.admin.tlsKeyStore.password | quote }} }
       {{- end }}
     {{- end }}
         ports:

--- a/stable/database/values.yaml
+++ b/stable/database/values.yaml
@@ -54,6 +54,10 @@ admin:
   # tlsCACert:
   #   secret: nuodb-ca-cert
   #   key: ca.cert
+  # tlsKeyStore:
+  #   secret: nuodb-server-keystore
+  #   key: server.p12
+  #   password: changeIt
   # tlsClientPEM:
   #   secret: nuodb-client-pem
   #   key: client.pem
@@ -152,7 +156,12 @@ database:
     # labels
     # Additional Labels given to the SMs started
     labels: {}
+
     engineOptions: {}
+
+    # named key/value pairs that need to be passed to the image, such as
+    # keystore: "/etc/nuodb/keys/nuoadmin.p12"
+    otherOptions: {}
 
     # Additional Options for DaemonSets
     # affinityNoHotCopyDS: {}
@@ -179,7 +188,12 @@ database:
     # labels
     # Additional Labels given to the TEs started
     labels: {}
+
     engineOptions: {}
+
+    # named key/value pairs that need to be passed to the image, such as
+    # keystore: "/etc/nuodb/keys/nuoadmin.p12"
+    otherOptions: {}
   
   enableDaemonSet: false
   # Set to true if you are using manually created volumes or restoring

--- a/test/integration/template_database_test.go
+++ b/test/integration/template_database_test.go
@@ -274,6 +274,9 @@ func TestDatabaseOtherOptions(t *testing.T) {
 		SetValues: map[string]string{
 			"database.te.otherOptions.keystore": "/etc/nuodb/keys/nuoadmin.p12",
 			"database.sm.otherOptions.keystore": "/etc/nuodb/keys/nuoadmin.p12",
+			"admin.tlsKeyStore.secret":     "nuodb-keystore",
+			"admin.tlsKeyStore.key":        "nuoadmin.p12",
+			"admin.tlsKeyStore.password":   "changeIt",
 		},
 	}
 

--- a/test/minikube/minikube_tls_admin_test.go
+++ b/test/minikube/minikube_tls_admin_test.go
@@ -179,37 +179,39 @@ func TestKubernetesBasicAdminThreeReplicasTLS(t *testing.T) {
 	defer testlib.GetAppLog(t, namespaceName, admin1)
 	defer testlib.GetAppLog(t, namespaceName, admin2)
 
-	content, err := readAll("../../keys/default.certificate")
-	assert.NilError(t, err)
 	t.Run("verifyKeystore", func(t *testing.T) {
+		content, err := readAll("../../keys/default.certificate")
+		assert.NilError(t, err)
 		verifyKeystore(t, namespaceName, admin0, "nuoadmin.p12", "changeIt", string(content))
 	})
 
-	t.Run("startDatabase", func(t *testing.T) {
+	t.Run("testDatabaseNoDirectEngineKeys", func(t *testing.T) {
+		// make a copy
+		localOptions := *options
+		localOptions.SetValues["database.sm.resources.requests.cpu"] =    "500m"
+		localOptions.SetValues["database.sm.resources.requests.memory"] = "1Gi"
+		localOptions.SetValues["database.te.resources.requests.cpu"] =    "500m"
+		localOptions.SetValues["database.te.resources.requests.memory"] = "1Gi"
+
 		defer testlib.Teardown("database")
 
-		startDatabase(t, namespaceName, admin0,
-			helm.Options{
-				SetValues: map[string]string{
-					"database.sm.resources.requests.cpu":    "500m",
-					"database.sm.resources.requests.memory": "1Gi",
-					"database.te.resources.requests.cpu":    "500m",
-					"database.te.resources.requests.memory": "1Gi",
-					"admin.tlsCACert.secret":       "nuodb-ca-cert",
-					"admin.tlsCACert.key":          "ca.cert",
-					"admin.tlsKeyStore.secret":     "nuodb-keystore",
-					"admin.tlsKeyStore.key":        "nuoadmin.p12",
-					"admin.tlsKeyStore.password":   "changeIt",
-					"admin.tlsTrustStore.secret":   "nuodb-truststore",
-					"admin.tlsTrustStore.key":      "nuoadmin-truststore.p12",
-					"admin.tlsTrustStore.password": "changeIt",
-					"admin.tlsClientPEM.secret":    "nuodb-client-pem",
-					"admin.tlsClientPEM.key":       "nuocmd.pem",
-					"database.te.otherOptions.keystore": "/etc/nuodb/keys/nuoadmin.p12",
-					"database.sm.otherOptions.keystore": "/etc/nuodb/keys/nuoadmin.p12",
-				},
-			},
-		)
+		startDatabase(t, namespaceName, admin0, localOptions)
+	})
+
+	t.Run("testDatabaseDirectEngineKeys", func(t *testing.T) {
+		// make a copy
+		localOptions := *options
+		localOptions.SetValues["database.sm.resources.requests.cpu"] =    "500m"
+		localOptions.SetValues["database.sm.resources.requests.memory"] = "1Gi"
+		localOptions.SetValues["database.te.resources.requests.cpu"] =    "500m"
+		localOptions.SetValues["database.te.resources.requests.memory"] = "1Gi"
+
+		localOptions.SetValues["database.te.otherOptions.keystore"] = "/etc/nuodb/keys/nuoadmin.p12"
+		localOptions.SetValues["database.sm.otherOptions.keystore"] = "/etc/nuodb/keys/nuoadmin.p12"
+
+		defer testlib.Teardown("database")
+
+		startDatabase(t, namespaceName, admin0, localOptions)
 	})
 }
 

--- a/test/minikube/minikube_tls_admin_test.go
+++ b/test/minikube/minikube_tls_admin_test.go
@@ -184,6 +184,33 @@ func TestKubernetesBasicAdminThreeReplicasTLS(t *testing.T) {
 	t.Run("verifyKeystore", func(t *testing.T) {
 		verifyKeystore(t, namespaceName, admin0, "nuoadmin.p12", "changeIt", string(content))
 	})
+
+	t.Run("startDatabase", func(t *testing.T) {
+		defer testlib.Teardown("database")
+
+		startDatabase(t, namespaceName, admin0,
+			helm.Options{
+				SetValues: map[string]string{
+					"database.sm.resources.requests.cpu":    "500m",
+					"database.sm.resources.requests.memory": "1Gi",
+					"database.te.resources.requests.cpu":    "500m",
+					"database.te.resources.requests.memory": "1Gi",
+					"admin.tlsCACert.secret":       "nuodb-ca-cert",
+					"admin.tlsCACert.key":          "ca.cert",
+					"admin.tlsKeyStore.secret":     "nuodb-keystore",
+					"admin.tlsKeyStore.key":        "nuoadmin.p12",
+					"admin.tlsKeyStore.password":   "changeIt",
+					"admin.tlsTrustStore.secret":   "nuodb-truststore",
+					"admin.tlsTrustStore.key":      "nuoadmin-truststore.p12",
+					"admin.tlsTrustStore.password": "changeIt",
+					"admin.tlsClientPEM.secret":    "nuodb-client-pem",
+					"admin.tlsClientPEM.key":       "nuocmd.pem",
+					"database.te.otherOptions.keystore": "/etc/nuodb/keys/nuoadmin.p12",
+					"database.sm.otherOptions.keystore": "/etc/nuodb/keys/nuoadmin.p12",
+				},
+			},
+		)
+	})
 }
 
 const TLS_SECRET_PASSWORD_YAML_TEMPLATE = `---


### PR DESCRIPTION
Allow the passing of certificates directly to the engine (docker) without using the CSR signing capabilities of the admin.

This allows the use of CA=false certificates created by things like Vault.

To start an engine with the same certificate as the admin provide the following option:
database.te.otherOptions.keyStore = <KEYSTORE_PATH>

Next steps:
- expand on our documentation and explain what the different models are
- verify the use of certificate vs CSR in the admin (requires change to how logging is done)
- re-test with CA=false certificates
