### PR TITLE
improve readiness check

### DIFF
--- a/stable/admin/templates/statefulset.yaml
+++ b/stable/admin/templates/statefulset.yaml
@@ -98,7 +98,7 @@ spec:
           initialDelaySeconds: 30
           periodSeconds: 15
           exec:
-            command: [ "nuodocker", "check", "servers" ]
+            command: [ "nuodocker", "check", "servers", "--check-connected", "--check-active", "--check-leader" ]
           failureThreshold: 30
           successThreshold: 2
           timeoutSeconds: 1


### PR DESCRIPTION
`check servers` is not a sufficient readiness check. Add all three sub-checks to make sure that RAFT is ready when the pod goes READY.