### PR TITLE
DB-28724 - Add TLS certificate rotation tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,6 @@ before_install:
   - dep ensure -v
   - chmod +x scripts/ci/install_deps.sh
   - scripts/ci/install_deps.sh
-  - scripts/ci/generate_keys.sh
   - docker pull nuodb/nuodb-ce:latest
   - helm version
 

--- a/test/minikube/minikube_tls_admin_test.go
+++ b/test/minikube/minikube_tls_admin_test.go
@@ -1,44 +1,17 @@
 package minikube
 
 import (
-	"bufio"
-	"encoding/base64"
 	"fmt"
-	"github.com/nuodb/nuodb-helm-charts/test/testlib"
-	"gotest.tools/assert"
-	"io/ioutil"
-	"os"
-	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/nuodb/nuodb-helm-charts/test/testlib"
+	"gotest.tools/assert"
 
 	"github.com/gruntwork-io/terratest/modules/helm"
 	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/gruntwork-io/terratest/modules/random"
 )
-
-const TLS_SECRET_PASSWORD_YAML_TEMPLATE = `---
-apiVersion: v1
-kind: Secret
-metadata:
-  name: %s
-  namespace: %s
-apiVersion: v1
-data:
-  %s: %s
-  password: %s
-`
-
-const TLS_SECRET_NO_PASSWORD_YAML_TEMPLATE = `---
-apiVersion: v1
-kind: Secret
-metadata:
-  name: %s
-  namespace: %s
-apiVersion: v1
-data:
-  %s: %s
-`
 
 const ENGINE_CERTIFICATE_LOG_TEMPLATE = `Engine Certificate: Certificate #%d CN %s`
 
@@ -48,50 +21,6 @@ func verifySecretFields(t *testing.T, namespaceName string, secretName string, f
 		_, ok := secret.Data[field]
 		assert.Check(t, ok)
 	}
-}
-
-func readAll(path string) ([]byte, error) {
-	file, ferr := os.Open(path)
-	if ferr != nil {
-		return nil, ferr
-	}
-	defer file.Close()
-
-	reader := bufio.NewReader(file)
-	content, rerr := ioutil.ReadAll(reader)
-	if rerr != nil {
-		return nil, rerr
-	}
-	return content, nil
-}
-
-func readAsBase64(path string) (string, error) {
-	content, err := readAll(path)
-	if err != nil {
-		return "", err
-	}
-	encoded := base64.StdEncoding.EncodeToString(content)
-	return encoded, nil
-}
-
-func createSecretDecl(path string, namespace string, name string, key string) (string, error) {
-	base64, err := readAsBase64(path)
-	if err != nil {
-		return "", err
-	}
-	text := fmt.Sprintf(TLS_SECRET_NO_PASSWORD_YAML_TEMPLATE,
-		name, namespace, key, base64)
-	return text, nil
-}
-
-func createSecretPassDecl(path string, namespace string, name string, key string, password string) (string, error) {
-	base64, err := readAsBase64(path)
-	if err != nil {
-		return "", err
-	}
-	text := fmt.Sprintf(TLS_SECRET_PASSWORD_YAML_TEMPLATE,
-		name, namespace, key, base64, password)
-	return text, nil
 }
 
 func verifyKeystore(t *testing.T, namespace string, podName string, keystore string, password string, matches string) {
@@ -107,40 +36,6 @@ func verifyKeystore(t *testing.T, namespace string, podName string, keystore str
 	assert.Assert(t, strings.Compare(output, matches) != 0)
 }
 
-func createSecret(t *testing.T, namespaceName string, certName string, secretName string) {
-	kubectlOptions := k8s.NewKubectlOptions("", "")
-	kubectlOptions.Namespace = namespaceName
-
-	keyDir := filepath.Join("..", "..", "keys")
-	keyFile := filepath.Join(keyDir, certName)
-
-	secretString, err := createSecretDecl(keyFile, namespaceName, secretName, certName)
-	assert.NilError(t, err)
-
-	k8s.KubectlApplyFromString(t, kubectlOptions, secretString)
-	testlib.AddTeardown(testlib.TEARDOWN_SECRETS, func() { k8s.KubectlDeleteFromString(t, kubectlOptions, secretString) })
-
-	fields := []string{certName}
-	verifySecretFields(t, namespaceName, secretName, fields...)
-}
-
-func createSecretWithPassword(t *testing.T, namespaceName string, certName string, secretName string, password string) {
-	kubectlOptions := k8s.NewKubectlOptions("", "")
-	kubectlOptions.Namespace = namespaceName
-
-	keyDir := filepath.Join("..", "..", "keys")
-	keyFile := filepath.Join(keyDir, certName)
-
-	secretString, err := createSecretPassDecl(keyFile, namespaceName, secretName, certName, password)
-	assert.NilError(t, err)
-
-	k8s.KubectlApplyFromString(t, kubectlOptions, secretString)
-	testlib.AddTeardown(testlib.TEARDOWN_SECRETS, func() { k8s.KubectlDeleteFromString(t, kubectlOptions, secretString) })
-
-	fields := []string{certName, "password"}
-	verifySecretFields(t, namespaceName, secretName, fields...)
-}
-
 func TestKubernetesTLS(t *testing.T) {
 	testlib.AwaitTillerUp(t)
 
@@ -154,10 +49,10 @@ func TestKubernetesTLS(t *testing.T) {
 
 	defer testlib.Teardown(testlib.TEARDOWN_SECRETS)
 	// create the certs...
-	createSecret(t, namespaceName, testlib.CA_CERT_FILE, testlib.CA_CERT_SECRET)
-	createSecret(t, namespaceName, testlib.NUOCMD_FILE, testlib.NUOCMD_SECRET)
-	createSecretWithPassword(t, namespaceName, testlib.KEYSTORE_FILE, testlib.KEYSTORE_SECRET, testlib.SECRET_PASSWORD)
-	createSecretWithPassword(t, namespaceName, testlib.TRUSTSTORE_FILE, testlib.TRUSTSTORE_SECRET, testlib.SECRET_PASSWORD)
+	testlib.CreateSecret(t, namespaceName, testlib.CA_CERT_FILE, testlib.CA_CERT_SECRET, "")
+	testlib.CreateSecret(t, namespaceName, testlib.NUOCMD_FILE, testlib.NUOCMD_SECRET, "")
+	testlib.CreateSecretWithPassword(t, namespaceName, testlib.KEYSTORE_FILE, testlib.KEYSTORE_SECRET, testlib.SECRET_PASSWORD, "")
+	testlib.CreateSecretWithPassword(t, namespaceName, testlib.TRUSTSTORE_FILE, testlib.TRUSTSTORE_SECRET, testlib.SECRET_PASSWORD, "")
 
 	options := helm.Options{
 		SetValues: map[string]string{
@@ -177,10 +72,9 @@ func TestKubernetesTLS(t *testing.T) {
 
 	defer testlib.Teardown(testlib.TEARDOWN_ADMIN)
 
-	helmChartReleaseName, namespaceName := startAdmin(t, &options, 3, namespaceName)
+	helmChartReleaseName, namespaceName := testlib.StartAdmin(t, &options, 3, namespaceName)
 
 	admin0 := fmt.Sprintf("%s-nuodb-0", helmChartReleaseName)
-
 
 	t.Run("verifyKeystore", func(t *testing.T) {
 		content, err := readAll("../../keys/default.certificate")
@@ -191,14 +85,14 @@ func TestKubernetesTLS(t *testing.T) {
 	t.Run("testDatabaseNoDirectEngineKeys", func(t *testing.T) {
 		// make a copy
 		localOptions := options
-		localOptions.SetValues["database.sm.resources.requests.cpu"] =    "500m"
+		localOptions.SetValues["database.sm.resources.requests.cpu"] = "500m"
 		localOptions.SetValues["database.sm.resources.requests.memory"] = "1Gi"
-		localOptions.SetValues["database.te.resources.requests.cpu"] =    "500m"
+		localOptions.SetValues["database.te.resources.requests.cpu"] = "500m"
 		localOptions.SetValues["database.te.resources.requests.memory"] = "1Gi"
 
 		defer testlib.Teardown("database")
 
-		databaseReleaseName := startDatabase(t, namespaceName, admin0, &localOptions)
+		databaseReleaseName := testlib.StartDatabase(t, namespaceName, admin0, &localOptions)
 
 		tePodNameTemplate := fmt.Sprintf("te-%s", databaseReleaseName)
 		tePodName := testlib.GetPodName(t, namespaceName, tePodNameTemplate)
@@ -213,9 +107,9 @@ func TestKubernetesTLS(t *testing.T) {
 	t.Run("testDatabaseDirectEngineKeys", func(t *testing.T) {
 		// make a copy
 		localOptions := options
-		localOptions.SetValues["database.sm.resources.requests.cpu"] =    "500m"
+		localOptions.SetValues["database.sm.resources.requests.cpu"] = "500m"
 		localOptions.SetValues["database.sm.resources.requests.memory"] = "1Gi"
-		localOptions.SetValues["database.te.resources.requests.cpu"] =    "500m"
+		localOptions.SetValues["database.te.resources.requests.cpu"] = "500m"
 		localOptions.SetValues["database.te.resources.requests.memory"] = "1Gi"
 
 		localOptions.SetValues["database.te.otherOptions.keystore"] = "/etc/nuodb/keys/nuoadmin.p12"
@@ -223,7 +117,7 @@ func TestKubernetesTLS(t *testing.T) {
 
 		defer testlib.Teardown("database")
 
-		databaseReleaseName := startDatabase(t, namespaceName, admin0, &localOptions)
+		databaseReleaseName := testlib.StartDatabase(t, namespaceName, admin0, &localOptions)
 
 		tePodNameTemplate := fmt.Sprintf("te-%s", databaseReleaseName)
 		tePodName := testlib.GetPodName(t, namespaceName, tePodNameTemplate)

--- a/test/minikube/minikube_tls_admin_test.go
+++ b/test/minikube/minikube_tls_admin_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"path/filepath"
 
 	"github.com/nuodb/nuodb-helm-charts/test/testlib"
 	"gotest.tools/assert"
@@ -53,8 +54,9 @@ func TestKubernetesTLS(t *testing.T) {
 	tlsCommands := []string{
 		"export DEFAULT_PASSWORD='" + testlib.SECRET_PASSWORD + "'",
 		"setup-keys.sh",
+		"nuocmd show certificate --keystore " + testlib.KEYSTORE_FILE + " --store-password \"$DEFAULT_PASSWORD\" > nuoadmin.cert",
 	}
-	testlib.GenerateTLSConfiguration(t, namespaceName, tlsCommands, "")
+	_, keysLocation := testlib.GenerateTLSConfiguration(t, namespaceName, tlsCommands, "")
 
 	options := helm.Options{
 		SetValues: map[string]string{
@@ -79,7 +81,7 @@ func TestKubernetesTLS(t *testing.T) {
 	admin0 := fmt.Sprintf("%s-nuodb-0", helmChartReleaseName)
 
 	t.Run("verifyKeystore", func(t *testing.T) {
-		content, err := testlib.ReadAll("../../keys/default.certificate")
+		content, err := testlib.ReadAll(filepath.Join(keysLocation, "nuoadmin.cert"))
 		assert.NilError(t, err)
 		verifyKeystore(t, namespaceName, admin0, testlib.KEYSTORE_FILE, testlib.SECRET_PASSWORD, string(content))
 	})

--- a/test/minikube/minikube_tls_admin_test.go
+++ b/test/minikube/minikube_tls_admin_test.go
@@ -29,12 +29,14 @@ func verifyKeystore(t *testing.T, namespace string, podName string, keystore str
 	options.Namespace = namespace
 
 	output, err := k8s.RunKubectlAndGetOutputE(t, options, "exec", podName, "--", "nuocmd", "show", "certificate", "--keystore", keystore, "--store-password", password)
+	output = testlib.RemoveEmptyLines(output)
+	matches = testlib.RemoveEmptyLines(matches)
 
-	t.Log(output)
-	t.Log(matches)
+	t.Log("<" + output + ">")
+	t.Log("<" + matches + ">")
 
 	assert.NilError(t, err)
-	assert.Assert(t, strings.Compare(output, matches) != 0)
+	assert.Assert(t, strings.Compare(output, matches) == 0)
 }
 
 func TestKubernetesTLS(t *testing.T) {

--- a/test/minikube/minikube_tls_rotation_test.go
+++ b/test/minikube/minikube_tls_rotation_test.go
@@ -58,7 +58,7 @@ func TestKubernetesTLSRotation(t *testing.T) {
 	}
 
 	// As nuodocker/nuoadmin wrapper is using peer insead of initialMembership, 
-	//   we need to use persistance for admin Raft logs during the rolling upgrade.
+	//   we need to use persistence for admin Raft logs during the rolling upgrade.
 	options := helm.Options{
 		SetValues: map[string]string{
 			"admin.persistence.enabled":             "true",
@@ -74,9 +74,9 @@ func TestKubernetesTLSRotation(t *testing.T) {
 			"admin.tlsClientPEM.secret":             testlib.NUOCMD_SECRET,
 			"admin.tlsClientPEM.key":                testlib.NUOCMD_FILE,
 			"database.sm.resources.requests.cpu":    "500m",
-			"database.sm.resources.requests.memory": "500m",
+			"database.sm.resources.requests.memory": "500Mi",
 			"database.te.resources.requests.cpu":    "500m",
-			"database.te.resources.requests.memory": "500m",
+			"database.te.resources.requests.memory": "500Mi",
 		},
 	}
 

--- a/test/minikube/minikube_tls_rotation_test.go
+++ b/test/minikube/minikube_tls_rotation_test.go
@@ -1,0 +1,84 @@
+package minikube
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nuodb/nuodb-helm-charts/test/testlib"
+
+	"github.com/gruntwork-io/terratest/modules/helm"
+	"github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/gruntwork-io/terratest/modules/random"
+)
+
+func TestKubernetesTLSRotation(t *testing.T) {
+	testlib.AwaitTillerUp(t)
+
+	randomSuffix := strings.ToLower(random.UniqueId())
+
+	namespaceName := fmt.Sprintf("test-tls-rotation-%s", randomSuffix)
+	kubectlOptions := k8s.NewKubectlOptions("", "")
+	k8s.CreateNamespace(t, kubectlOptions, namespaceName)
+
+	defer k8s.DeleteNamespace(t, kubectlOptions, namespaceName)
+
+	kubectlOptions.Namespace = namespaceName
+
+	defer testlib.Teardown(testlib.TEARDOWN_SECRETS)
+
+	initialTLSCommands := []string{
+		"export DEFAULT_PASSWORD='" + testlib.SECRET_PASSWORD + "'",
+		"setup-keys.sh",
+	}
+
+	options := helm.Options{
+		SetValues: map[string]string{
+			"admin.replicas":                        "3",
+			"admin.tlsCACert.secret":                testlib.CA_CERT_SECRET,
+			"admin.tlsCACert.key":                   testlib.CA_CERT_FILE,
+			"admin.tlsKeyStore.secret":              testlib.KEYSTORE_SECRET,
+			"admin.tlsKeyStore.key":                 testlib.KEYSTORE_FILE,
+			"admin.tlsKeyStore.password":            testlib.SECRET_PASSWORD,
+			"admin.tlsTrustStore.secret":            testlib.TRUSTSTORE_SECRET,
+			"admin.tlsTrustStore.key":               testlib.TRUSTSTORE_FILE,
+			"admin.tlsTrustStore.password":          testlib.SECRET_PASSWORD,
+			"admin.tlsClientPEM.secret":             testlib.NUOCMD_SECRET,
+			"admin.tlsClientPEM.key":                testlib.NUOCMD_FILE,
+			"database.sm.resources.requests.cpu":    "500m",
+			"database.sm.resources.requests.memory": "500m",
+			"database.te.resources.requests.cpu":    "500m",
+			"database.te.resources.requests.memory": "500m",
+		},
+	}
+
+	defer testlib.Teardown(testlib.TEARDOWN_ADMIN)
+	defer testlib.Teardown(testlib.TEARDOWN_DATABASE)
+
+	newTLSCommands := []string{
+		"export DEFAULT_PASSWORD='" + testlib.SECRET_PASSWORD + "'",
+		"nuocmd create keypair --keystore ca.p12 --store-password \"$DEFAULT_PASSWORD\" --dname \"CN=ca.nuodb.com, OU=Eng, O=NuoDB, L=Boston, ST=MA, C=US, SERIALNUMBER=123456\" --validity 36500 --ca",
+		"nuocmd create keypair --keystore " + testlib.KEYSTORE_FILE + " --store-password \"$DEFAULT_PASSWORD\" --dname \"CN=nuoadmin.nuodb.com, OU=Eng, O=NuoDB, L=Boston, ST=MA, C=US, SERIALNUMBER=67890\"",
+		"nuocmd sign certificate --keystore " + testlib.KEYSTORE_FILE + " --store-password \"$DEFAULT_PASSWORD\" --ca-keystore ca.p12 --ca-store-password \"$DEFAULT_PASSWORD\" --validity 36500 --ca --update",
+		"nuocmd show certificate --keystore ca.p12 --store-password \"$DEFAULT_PASSWORD\" --cert-only > " + testlib.CA_CERT_FILE_NEW,
+		"cp " + filepath.Join(testlib.CERTIFICATES_BACKUP_PATH, testlib.TRUSTSTORE_FILE) + " " + testlib.CERTIFICATES_GENERATION_PATH,
+		"cp " + filepath.Join(testlib.CERTIFICATES_BACKUP_PATH, testlib.NUOCMD_FILE) + " " + testlib.CERTIFICATES_GENERATION_PATH,
+		"cat " + filepath.Join(testlib.CERTIFICATES_BACKUP_PATH, testlib.CA_CERT_FILE) + " > ca.cert",
+		"cat " + testlib.CA_CERT_FILE_NEW + " >> ca.cert",
+	}
+
+	upgradedOptions := options
+	upgradedOptions.SetValues = make(map[string]string, len(options.SetValues))
+	for k, v := range options.SetValues {
+		upgradedOptions.SetValues[k] = v
+	}
+	upgradedOptions.SetValues["admin.tlsCACert.secret"] = testlib.CA_CERT_SECRET_NEW
+	upgradedOptions.SetValues["admin.tlsKeyStore.secret"] = testlib.KEYSTORE_SECRET_NEW
+
+	adminReleaseName, _ := testlib.RotateTLSCertificates(t, &options, &upgradedOptions, kubectlOptions, initialTLSCommands, newTLSCommands)
+	admin0 := fmt.Sprintf("%s-nuodb-0", adminReleaseName)
+
+	output, _ := k8s.RunKubectlAndGetOutputE(t, kubectlOptions, "exec", admin0, "--", "nuocmd", "--show-json", "get", "certificate-info")
+	fmt.Println(output)
+}

--- a/test/testlib/constants.go
+++ b/test/testlib/constants.go
@@ -1,10 +1,13 @@
 package testlib
 
 const CA_CERT_FILE = "ca.cert"
+const CA_CERT_FILE_NEW = "ca_new.cert"
 const CA_CERT_SECRET = "nuodb-ca-cert"
+const CA_CERT_SECRET_NEW = "nuodb-ca-cert-new"
 
 const KEYSTORE_FILE = "nuoadmin.p12"
 const KEYSTORE_SECRET = "nuodb-keystore"
+const KEYSTORE_SECRET_NEW = "nuodb-keystore-new"
 
 const TRUSTSTORE_FILE = "nuoadmin-truststore.p12"
 const TRUSTSTORE_SECRET = "nuodb-truststore"
@@ -14,19 +17,20 @@ const NUOCMD_SECRET = "nuodb-client-pem"
 
 const SECRET_PASSWORD = "changeIt"
 
+const CERTIFICATES_GENERATION_PATH = "/tmp/keys"
+const CERTIFICATES_BACKUP_PATH = "/tmp/keys_backup"
+
 const TEARDOWN_ADMIN = "admin"
 const TEARDOWN_BACKUP = "backup"
 const TEARDOWN_DATABASE = "database"
 const TEARDOWN_RESTORE = "database"
 const TEARDOWN_SECRETS = "secrets"
 
-
 const ADMIN_HELM_CHART_PATH = "../../stable/admin"
 const BACKUP_HELM_CHART_PATH = "../../stable/backup"
 const DATABASE_HELM_CHART_PATH = "../../stable/database"
 const RESTORE_HELM_CHART_PATH = "../../stable/restore"
 const THP_HELM_CHART_PATH = "../../stable/transparent-hugepage"
-
 
 const LAST_BACKUP_PREFIX string = "nuodb-backup/last_created"
 const IMPORT_ARCHIVE_URL = "http://download.nuohub.org/ce_releases/restore.bak.tz"

--- a/test/testlib/minikube_utilities.go
+++ b/test/testlib/minikube_utilities.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"regexp"
 
 	"github.com/gruntwork-io/terratest/modules/helm"
 	"github.com/gruntwork-io/terratest/modules/k8s"
@@ -74,6 +75,17 @@ func VerifyTeardown(t *testing.T) {
 
 func standardizeSpaces(s string) string {
 	return strings.Join(strings.Fields(s), " ")
+}
+
+func RemoveEmptyLines(s string) string {
+	regex, err := regexp.Compile("(\r|\r\n|\n){2,}")
+    if err != nil {
+        return s
+    }
+    s = regex.ReplaceAllString(s, "\n")
+	s = strings.TrimRight(s, "\n")
+	
+	return s
 }
 
 func arePodConditionsMet(pod *corev1.Pod, condition corev1.PodConditionType,
@@ -477,25 +489,25 @@ func RunSQL(t *testing.T, namespace string, podName string, databaseName string,
 	return result, err
 }
 
-func executeCommandsInPod(t *testing.T, podName string, namespaceName string, commands []string) {
+func ExecuteCommandsInPod(t *testing.T, podName string, namespaceName string, commands []string) {
 	tmpfile, err := ioutil.TempFile("", "script")
 	if err != nil {
-		t.Fatal(err)
+		assert.NilError(t, err)
 	}
 
 	defer os.Remove(tmpfile.Name()) // clean up
 
 	if _, err := tmpfile.WriteString("set -ev" + "\n"); err != nil {
-		t.Fatal(err)
+		assert.NilError(t, err)
 	}
 
 	for _, item := range commands {
 		if _, err := tmpfile.WriteString(item + "\n"); err != nil {
-			t.Fatal(err)
+			assert.NilError(t, err)
 		}
 	}
 	if err := tmpfile.Close(); err != nil {
-		t.Fatal(err)
+		assert.NilError(t, err)
 	}
 
 	options := k8s.NewKubectlOptions("", "")

--- a/test/testlib/nuodb_admin_utilities.go
+++ b/test/testlib/nuodb_admin_utilities.go
@@ -1,0 +1,71 @@
+package testlib
+
+import (
+	"fmt"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gruntwork-io/terratest/modules/helm"
+	"github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/gruntwork-io/terratest/modules/random"
+)
+
+func getFunctionCallerName() string {
+	pc, _, _, _ := runtime.Caller(2)
+	nameFull := runtime.FuncForPC(pc).Name() // main.foo
+	nameEnd := filepath.Ext(nameFull)        // .foo
+	name := strings.TrimPrefix(nameEnd, ".") // foo
+
+	return name
+}
+
+func StartAdmin(t *testing.T, options *helm.Options, replicaCount int, namespace string) (helmChartReleaseName string, namespaceName string) {
+	randomSuffix := strings.ToLower(random.UniqueId())
+
+	// Path to the helm chart we will test
+	helmChartPath := ADMIN_HELM_CHART_PATH
+	helmChartReleaseName = fmt.Sprintf("admin-%s", randomSuffix)
+
+	adminNames := make([]string, replicaCount)
+
+	for i := 0; i < replicaCount; i++ {
+		adminNames[i] = fmt.Sprintf("%s-nuodb-%d", helmChartReleaseName, i)
+	}
+
+	kubectlOptions := k8s.NewKubectlOptions("", "")
+	options.KubectlOptions = kubectlOptions
+
+	if namespace == "" {
+		callerName := getFunctionCallerName()
+		namespaceName = fmt.Sprintf("%s-%s", strings.ToLower(callerName), randomSuffix)
+		k8s.CreateNamespace(t, kubectlOptions, namespaceName)
+		AddTeardown(TEARDOWN_ADMIN, func() { k8s.DeleteNamespace(t, kubectlOptions, namespaceName) })
+	} else {
+		namespaceName = namespace
+	}
+
+	options.KubectlOptions.Namespace = namespaceName
+
+	helm.Install(t, options, helmChartPath, helmChartReleaseName)
+
+	AddTeardown("admin", func() { helm.Delete(t, options, helmChartReleaseName, true) })
+
+	AwaitNrReplicasScheduled(t, namespaceName, helmChartReleaseName, replicaCount)
+
+	for i := 0; i < replicaCount; i++ {
+		adminName := adminNames[i] // array will be out of scope for defer
+
+		// first await could be pulling the image from the repo
+		AwaitAdminPodUp(t, namespaceName, adminName, 300*time.Second)
+		AddTeardown("admin", func() { GetAppLog(t, namespaceName, adminName) })
+	}
+
+	for i := 0; i < replicaCount; i++ {
+		AwaitAdminFullyConnected(t, namespaceName, adminNames[i], replicaCount)
+	}
+
+	return
+}

--- a/test/testlib/nuodb_database_utilities.go
+++ b/test/testlib/nuodb_database_utilities.go
@@ -1,0 +1,47 @@
+package testlib
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gruntwork-io/terratest/modules/helm"
+	"github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/gruntwork-io/terratest/modules/random"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func StartDatabase(t *testing.T, namespaceName string, adminPod string, options *helm.Options) (helmChartReleaseName string) {
+	randomSuffix := strings.ToLower(random.UniqueId())
+
+	helmChartReleaseName = fmt.Sprintf("database-%s", randomSuffix)
+	tePodNameTemplate := fmt.Sprintf("te-%s", helmChartReleaseName)
+	smPodName := fmt.Sprintf("sm-%s-nuodb-demo", helmChartReleaseName)
+
+	kubectlOptions := k8s.NewKubectlOptions("", "")
+	options.KubectlOptions = kubectlOptions
+	options.KubectlOptions.Namespace = namespaceName
+
+	// with Async actions which do not return a cleanup method, create the teardown(s) first
+	AddTeardown(TEARDOWN_DATABASE, func() {
+		helm.Delete(t, options, helmChartReleaseName, true)
+		AwaitNoPods(t, namespaceName, "database")
+		DeleteDatabase(t, namespaceName, "demo", adminPod)
+	})
+
+	helm.Install(t, options, DATABASE_HELM_CHART_PATH, helmChartReleaseName)
+
+	AwaitNrReplicasScheduled(t, namespaceName, tePodNameTemplate, 1)
+	AwaitNrReplicasScheduled(t, namespaceName, smPodName, 1)
+
+	tePodName := GetPodName(t, namespaceName, tePodNameTemplate)
+	AwaitPodStatus(t, namespaceName, tePodName, corev1.PodReady, corev1.ConditionTrue, 120*time.Second)
+
+	smPodName0 := GetPodName(t, namespaceName, smPodName)
+	AwaitPodStatus(t, namespaceName, smPodName0, corev1.PodReady, corev1.ConditionTrue, 120*time.Second)
+
+	AwaitDatabaseUp(t, namespaceName, adminPod, "demo")
+
+	return
+}

--- a/test/testlib/secrets.go
+++ b/test/testlib/secrets.go
@@ -1,0 +1,127 @@
+package testlib
+
+import (
+	"bufio"
+	"encoding/base64"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/k8s"
+	"gotest.tools/assert"
+)
+
+const TLS_SECRET_PASSWORD_YAML_TEMPLATE = `---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: %s
+  namespace: %s
+apiVersion: v1
+data:
+  %s: %s
+  password: %s
+`
+
+const TLS_SECRET_NO_PASSWORD_YAML_TEMPLATE = `---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: %s
+  namespace: %s
+apiVersion: v1
+data:
+  %s: %s
+`
+
+func ReadAll(path string) ([]byte, error) {
+	file, ferr := os.Open(path)
+	if ferr != nil {
+		return nil, ferr
+	}
+	defer file.Close()
+
+	reader := bufio.NewReader(file)
+	content, rerr := ioutil.ReadAll(reader)
+	if rerr != nil {
+		return nil, rerr
+	}
+	return content, nil
+}
+
+func readAsBase64(path string) (string, error) {
+	content, err := ReadAll(path)
+	if err != nil {
+		return "", err
+	}
+	encoded := base64.StdEncoding.EncodeToString(content)
+	return encoded, nil
+}
+
+func createSecretDecl(path string, namespace string, name string, key string) (string, error) {
+	base64, err := readAsBase64(path)
+	if err != nil {
+		return "", err
+	}
+	text := fmt.Sprintf(TLS_SECRET_NO_PASSWORD_YAML_TEMPLATE,
+		name, namespace, key, base64)
+	return text, nil
+}
+
+func createSecretPassDecl(path string, namespace string, name string, key string, password string) (string, error) {
+	base64, err := readAsBase64(path)
+	if err != nil {
+		return "", err
+	}
+	text := fmt.Sprintf(TLS_SECRET_PASSWORD_YAML_TEMPLATE,
+		name, namespace, key, base64, password)
+	return text, nil
+}
+
+func verifySecretFields(t *testing.T, namespaceName string, secretName string, fields ...string) {
+	secret := GetSecret(t, namespaceName, secretName)
+	for _, field := range fields {
+		_, ok := secret.Data[field]
+		assert.Check(t, ok)
+	}
+}
+
+func CreateSecret(t *testing.T, namespaceName string, certName string, secretName string, keyDir string) {
+	kubectlOptions := k8s.NewKubectlOptions("", "")
+	kubectlOptions.Namespace = namespaceName
+
+	if keyDir == "" {
+		keyDir = filepath.Join("..", "..", "keys")
+	}
+	keyFile := filepath.Join(keyDir, certName)
+
+	secretString, err := createSecretDecl(keyFile, namespaceName, secretName, certName)
+	assert.NilError(t, err)
+
+	k8s.KubectlApplyFromString(t, kubectlOptions, secretString)
+	AddTeardown(TEARDOWN_SECRETS, func() { k8s.KubectlDeleteFromString(t, kubectlOptions, secretString) })
+
+	fields := []string{certName}
+	verifySecretFields(t, namespaceName, secretName, fields...)
+}
+
+func CreateSecretWithPassword(t *testing.T, namespaceName string, certName string, secretName string, password string, keyDir string) {
+	kubectlOptions := k8s.NewKubectlOptions("", "")
+	kubectlOptions.Namespace = namespaceName
+
+	if keyDir == "" {
+		keyDir = filepath.Join("..", "..", "keys")
+	}
+	keyFile := filepath.Join(keyDir, certName)
+
+	secretString, err := createSecretPassDecl(keyFile, namespaceName, secretName, certName, password)
+	assert.NilError(t, err)
+
+	k8s.KubectlApplyFromString(t, kubectlOptions, secretString)
+	AddTeardown(TEARDOWN_SECRETS, func() { k8s.KubectlDeleteFromString(t, kubectlOptions, secretString) })
+
+	fields := []string{certName, "password"}
+	verifySecretFields(t, namespaceName, secretName, fields...)
+}

--- a/test/testlib/tls.go
+++ b/test/testlib/tls.go
@@ -51,7 +51,6 @@ func createTLSGeneratorPod(t *testing.T, namespaceName string, image string, tim
 }
 
 func verifyCertificateFiles(t *testing.T, directory string) {
-
 	expectedFiles := []string{
 		KEYSTORE_FILE,
 		TRUSTSTORE_FILE,
@@ -68,11 +67,8 @@ func verifyCertificateFiles(t *testing.T, directory string) {
 		t.Logf("Found generated certificate file: %s", file.Name())
 	}
 	for _, expectedFile := range expectedFiles {
-		if !set[expectedFile] {
-			t.Fatalf("Unable to find certificate file %s in path %s", expectedFile, directory)
-		}
+		assert.Assert(t, set[expectedFile] == true, "Unable to find certificate file %s in path %s", expectedFile, directory)
 	}
-
 }
 
 func GenerateCustomCertificates(t *testing.T, podName string, namespaceName string, commands []string) {
@@ -84,7 +80,7 @@ func GenerateCustomCertificates(t *testing.T, podName string, namespaceName stri
 	}
 	finalCommands := append(prependCommands, commands...)
 	// Execute certificate generation commands
-	executeCommandsInPod(t, podName, namespaceName, finalCommands)
+	ExecuteCommandsInPod(t, podName, namespaceName, finalCommands)
 }
 
 func CopyCertificatesToControlHost(t *testing.T, podName string, namespaceName string) string {

--- a/test/testlib/tls.go
+++ b/test/testlib/tls.go
@@ -141,7 +141,7 @@ func RotateTLSCertificates(t *testing.T, options *helm.Options,
 
 	k8s.RunKubectl(t, kubectlOptions, "cp", filepath.Join(newTLSKeysLocation, CA_CERT_FILE_NEW), admin0+":/tmp")
 	err = k8s.RunKubectlE(t, kubectlOptions, "exec", admin0, "--", "nuocmd", "add", "trusted-certificate",
-		"--alias", "ca_prime", "--cert", "/tmp/"+CA_CERT_FILE_NEW, "--timeout", "10")
+		"--alias", "ca_prime", "--cert", "/tmp/"+CA_CERT_FILE_NEW, "--timeout", "60")
 	assert.NilError(t, err, "add trusted-certificate failed")
 
 	// Upgrade admin release

--- a/test/testlib/tls.go
+++ b/test/testlib/tls.go
@@ -1,0 +1,161 @@
+package testlib
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gruntwork-io/terratest/modules/helm"
+	"github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/gruntwork-io/terratest/modules/random"
+	"gotest.tools/assert"
+	corev1 "k8s.io/api/core/v1"
+)
+
+const TLS_GENERATOR_POD_TEMPLATE = `---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  containers:
+  - name: generate-tls-certs
+    image: %s
+    command: ['tail', '-f', '/dev/null']
+`
+
+func createTLSGeneratorPod(t *testing.T, namespaceName string, image string, timeout time.Duration) string {
+	if image == "" {
+		image = "docker.io/nuodb/nuodb-ce:latest"
+	}
+
+	podName := "tls-generator-" + strings.ToLower(random.UniqueId())
+	podTemplateString := fmt.Sprintf(TLS_GENERATOR_POD_TEMPLATE,
+		podName, namespaceName, image)
+
+	kubectlOptions := k8s.NewKubectlOptions("", "")
+	kubectlOptions.Namespace = namespaceName
+
+	k8s.KubectlApplyFromString(t, kubectlOptions, podTemplateString)
+	AddTeardown(TEARDOWN_SECRETS, func() { k8s.KubectlDeleteFromString(t, kubectlOptions, podTemplateString) })
+
+	AwaitPodStatus(t, namespaceName, podName, corev1.PodReady, corev1.ConditionTrue, timeout)
+
+	return podName
+}
+
+func verifyCertificateFiles(t *testing.T, directory string) {
+
+	expectedFiles := []string{
+		KEYSTORE_FILE,
+		TRUSTSTORE_FILE,
+		CA_CERT_FILE,
+		NUOCMD_FILE,
+	}
+
+	files, err := ioutil.ReadDir(directory)
+	assert.NilError(t, err)
+
+	set := make(map[string]bool)
+	for _, file := range files {
+		set[file.Name()] = true
+		t.Logf("Found generated certificate file: %s", file.Name())
+	}
+	for _, expectedFile := range expectedFiles {
+		if !set[expectedFile] {
+			t.Fatalf("Unable to find certificate file %s in path %s", expectedFile, directory)
+		}
+	}
+
+}
+
+func GenerateCustomCertificates(t *testing.T, podName string, namespaceName string, commands []string) {
+	prependCommands := []string{
+		"[ -d " + CERTIFICATES_GENERATION_PATH + " ] && rm -rf " + CERTIFICATES_BACKUP_PATH + " && mv " + CERTIFICATES_GENERATION_PATH + " " + CERTIFICATES_BACKUP_PATH,
+		"rm -rf " + CERTIFICATES_GENERATION_PATH,
+		"mkdir -p " + CERTIFICATES_GENERATION_PATH,
+		"cd " + CERTIFICATES_GENERATION_PATH,
+	}
+	finalCommands := append(prependCommands, commands...)
+	// Execute certificate generation commands
+	executeCommandsInPod(t, podName, namespaceName, finalCommands)
+}
+
+func CopyCertificatesToControlHost(t *testing.T, podName string, namespaceName string) string {
+	options := k8s.NewKubectlOptions("", "")
+	options.Namespace = namespaceName
+
+	prefix := "tls-keys"
+	targetDirectory, err := ioutil.TempDir("", prefix)
+	assert.NilError(t, err, "Unable to create TMP directory with prefix ", prefix)
+	AddTeardown(TEARDOWN_SECRETS, func() { os.RemoveAll(targetDirectory) })
+
+	realTargetDirectory, err := filepath.EvalSymlinks(targetDirectory)
+	assert.NilError(t, err)
+
+	k8s.RunKubectl(t, options, "cp", podName+":"+CERTIFICATES_GENERATION_PATH, realTargetDirectory)
+	t.Logf("Certificates are copied in: %s\n", realTargetDirectory)
+
+	verifyCertificateFiles(t, realTargetDirectory)
+
+	return realTargetDirectory
+}
+
+func GenerateTLSConfiguration(t *testing.T, namespaceName string, commands []string, image string) (string, string) {
+	podName := createTLSGeneratorPod(t, namespaceName, image, 20*time.Second)
+	GenerateCustomCertificates(t, podName, namespaceName, commands)
+	keysLocation := CopyCertificatesToControlHost(t, podName, namespaceName)
+
+	CreateSecret(t, namespaceName, CA_CERT_FILE, CA_CERT_SECRET, keysLocation)
+	CreateSecret(t, namespaceName, NUOCMD_FILE, NUOCMD_SECRET, keysLocation)
+	CreateSecretWithPassword(t, namespaceName, KEYSTORE_FILE, KEYSTORE_SECRET, SECRET_PASSWORD, keysLocation)
+	CreateSecretWithPassword(t, namespaceName, TRUSTSTORE_FILE, TRUSTSTORE_SECRET, SECRET_PASSWORD, keysLocation)
+
+	return podName, keysLocation
+}
+
+func RotateTLSCertificates(t *testing.T, options *helm.Options,
+	upgradedOptions *helm.Options, kubectlOptions *k8s.KubectlOptions,
+	initialTLSCommands []string, newTLSCommands []string) (string, string) {
+
+	namespaceName := kubectlOptions.Namespace
+	adminReplicaCount, err := strconv.Atoi(options.SetValues["admin.replicas"])
+	assert.NilError(t, err, "Unable to find/convert admin.replicas value")
+
+	// create initial certs...
+	certGeneratorPodName, _ := GenerateTLSConfiguration(t, namespaceName, initialTLSCommands, "")
+
+	adminReleaseName, namespaceName := StartAdmin(t, options, adminReplicaCount, namespaceName)
+	admin0 := fmt.Sprintf("%s-nuodb-0", adminReleaseName)
+	databaseReleaseName := StartDatabase(t, namespaceName, admin0, options)
+
+	// create the new certs...
+	GenerateCustomCertificates(t, certGeneratorPodName, namespaceName, newTLSCommands)
+	newTLSKeysLocation := CopyCertificatesToControlHost(t, certGeneratorPodName, namespaceName)
+	CreateSecret(t, namespaceName, CA_CERT_FILE, CA_CERT_SECRET_NEW, newTLSKeysLocation)
+	CreateSecretWithPassword(t, namespaceName, KEYSTORE_FILE, KEYSTORE_SECRET_NEW, SECRET_PASSWORD, newTLSKeysLocation)
+
+	k8s.RunKubectl(t, kubectlOptions, "cp", filepath.Join(newTLSKeysLocation, CA_CERT_FILE_NEW), admin0+":/tmp")
+	err = k8s.RunKubectlE(t, kubectlOptions, "exec", admin0, "--", "nuocmd", "add", "trusted-certificate",
+		"--alias", "ca_prime", "--cert", "/tmp/"+CA_CERT_FILE_NEW, "--timeout", "10")
+	assert.NilError(t, err, "add trusted-certificate failed")
+
+	DeletePod(t, namespaceName, "jobs/job-lb-policy-nearest")
+	helm.Upgrade(t, upgradedOptions, ADMIN_HELM_CHART_PATH, adminReleaseName)
+
+	adminPodsPrefix := fmt.Sprintf("%s-nuodb", adminReleaseName)
+	AwaitNrReplicasReady(t, namespaceName, adminPodsPrefix, adminReplicaCount)
+	AwaitAdminFullyConnected(t, namespaceName, admin0, adminReplicaCount)
+
+	helm.Upgrade(t, upgradedOptions, DATABASE_HELM_CHART_PATH, databaseReleaseName)
+
+	AwaitDatabaseUp(t, namespaceName, admin0, "demo")
+
+	return adminReleaseName, databaseReleaseName
+}


### PR DESCRIPTION
**Changes**

- Testing TLS certificate rotation with 3 replicas admin service
- Testing certificate generation with utilities provided with `nuocmd` and documented in our documentation
- Implemented a common way of generating certificates using standalone POD
- Moved some of the common functions into separate files so that they are shared between the tests

**Why**

- This is automated part of DB-28724 task

**Drawbacks**

- The certificate rotation test runs for a quite a long time (~5min) as the admin stateful set needs to be rollover-ed. 

**Testing Performed**

- Local automation tests with minikube
- Travis integration --- pending
- Manual testing - documented in https://docs.google.com/document/d/1maoMlvEOJMxGi45G6qwPyHxUoppBt_xtuN9M70l-ljM/edit?usp=sharing