### PR TITLE
DB-28838 Make nuoadmin configuration options available in helm values

### DIFF
--- a/stable/admin/templates/statefulset.yaml
+++ b/stable/admin/templates/statefulset.yaml
@@ -88,7 +88,13 @@ spec:
         - { name: NUODB_TRUSTSTORE_PASSWORD,  value: {{ .Values.admin.tlsTrustStore.password | quote }} }
         {{- end }}
       {{- end }}
-        args: [ "nuoadmin", "--", "pendingReconnectTimeout=60000" ]
+        args:
+          - "nuoadmin"
+          - "--"
+          - "pendingReconnectTimeout=60000"
+          {{- range $opt, $val := .Values.admin.options}}
+          - "{{$opt}}={{$val}}" 
+          {{- end}}
         livenessProbe:
           initialDelaySeconds: 30
           periodSeconds: 15

--- a/stable/admin/values.yaml
+++ b/stable/admin/values.yaml
@@ -82,9 +82,13 @@ admin:
     capabilities: []
 
   ## Specify one or more configMaps to import Environment Variables from
-  # Ex:  from: [ configMapRef: { name: myConfigMap } ]
-  env:
-    from: []
+  # Ex:  envFrom: [ configMapRef: { name: myConfigMap } ]
+  envFrom: []
+  
+  ## Admin options
+  # These are applied using the nuoadmin startup command
+  # Add these values as appropriate for this domain
+  options: {}
 
   ## nuodb-admin resource requests and limits
   ## Ref: http://kubernetes.io/docs/user-guide/compute-resources/

--- a/test/integration/template_admin_test.go
+++ b/test/integration/template_admin_test.go
@@ -97,6 +97,7 @@ func TestAdminStatefulSetVPNRenders(t *testing.T) {
 		SetValues: map[string]string{
 			"admin.securityContext.capabilities": "[ NET_ADMIN ]",
 			"admin.envFrom[0].configMapRef.name": "test-config",
+			"admin.options.leaderAssignmentTimeout": "30000",
 		},
 	}
 
@@ -119,6 +120,10 @@ func TestAdminStatefulSetVPNRenders(t *testing.T) {
 		adminContainer := object.Spec.Template.Spec.Containers[0]
 		assert.Check(t, adminContainer.SecurityContext.Capabilities.Add[0] == "NET_ADMIN")
 		assert.Check(t, adminContainer.EnvFrom[0].ConfigMapRef.LocalObjectReference.Name == "test-config")
+		assert.Check(t, adminContainer.Args[0] == "nuoadmin")
+		assert.Check(t, adminContainer.Args[1] == "--")
+		assert.Check(t, adminContainer.Args[2] == "pendingReconnectTimeout=60000")
+		assert.Check(t, adminContainer.Args[3] == "leaderAssignmentTimeout=30000")
 	}
 }
 


### PR DESCRIPTION
- Added new admin.options in values.yaml to pass  config options to nuoadmin args
- Fixed incorrect env: from: in values.yaml (template and tests use envFrom:)

Note I have left pendingReconnectTimeout as a hardcoded template value - was not sure if this was determined to be mandatory in all k8s deployments.  Alternatively, can move to values.yaml and have it as a pre-filled option.

The original driver for the change - to add leaderAssignmentTimeout - has been left completely optional - I believe it will only be needed in multi-cloud scenarios or anywhere there is a large discrepancy between SM's coming online.