### PR TITLE
[DB-28964] Externalize config files using generalized idiomatic approaches.

### DIFF
--- a/stable/admin/README.md
+++ b/stable/admin/README.md
@@ -175,7 +175,8 @@ The following tables list the configurable parameters for the `admin` option of 
 | `affinity` | Affinity rules for NuoDB Admin | `{}` |
 | `nodeSelector` | Node selector rules for NuoDB Admin | `{}` |
 | `tolerations` | Tolerations for NuoDB Admin | `[]` |
-| `configFiles.nuodb.lic` | NuoDB license file content; defaults to NuoDB CE Edition | `nil` |
+| `configFilesPath` | Directory path where `configFiles.*` are found | `/etc/nuodb/` |
+| `configFiles.*` | See below. | `{}` |
 | `persistence.enabled` | Whether or not persistent storage is enabled for admin RAFT state | `false` |
 | `persistence.accessModes` | Volume access modes enabled (must match capabilities of the storage class) | `ReadWriteMany` |
 | `persistence.size` | Amount of disk space allocated for admin RAFT state | `10Gi` |
@@ -200,6 +201,18 @@ For example, when using GlusterFS storage class, you would supply the following 
   --set admin.persistence.storageClass=glusterfs
   ...
 ```
+
+#### admin.configFiles.*
+
+The purpose of this section is to specify replacement NuoDB configuration files.
+
+Any file located in `admin.configFilesPath` can be replaced; the YAML key corresponds to the file name being created or replaced.
+
+The following tables list the configurable parameters for the `admin` option of the admin chart and their default values.
+
+| Key | Description | Default |
+| ----- | ----------- | ------ |
+| `nuodb.lic` | NuoDB license file content; defaults to NuoDB CE Edition | `nil` |
 
 ### Running
 

--- a/stable/admin/templates/configmap.yaml
+++ b/stable/admin/templates/configmap.yaml
@@ -1,17 +1,3 @@
-kind: ConfigMap
-apiVersion: v1
-metadata:
-  labels:
-    app: {{ template "admin.fullname" . }}
-    group: nuodb
-    domain: {{ .Values.admin.domain }}
-    chart: {{ template "admin.chart" . }}
-    release: {{ .Release.Name | quote }}
-  name: nuodb-license-file
-data:
-{{- if .Values.admin.configFiles }}
-{{ toYaml .Values.admin.configFiles | indent 2 }}
-{{ end }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -25,3 +11,21 @@ metadata:
   name: waitscript
 data:
 {{ (.Files.Glob "files/waitscript").AsConfig | indent 2 }}
+---
+{{- if .Values.admin.configFiles }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: {{ template "admin.fullname" . }}
+    group: nuodb
+    domain: {{ .Values.admin.domain }}
+    chart: {{ template "admin.chart" . }}
+    release: {{ .Release.Name | quote }}
+  name: {{ template "admin.fullname" . }}-configuration
+data:
+{{- range $key, $val := .Values.admin.configFiles }}
+  {{ $key }}: |-
+{{ $val | indent 4}}
+{{- end }}
+{{- end -}}

--- a/stable/admin/templates/statefulset.yaml
+++ b/stable/admin/templates/statefulset.yaml
@@ -111,8 +111,8 @@ spec:
         volumeMounts:
         - name: log-volume
           mountPath: /var/log/nuodb
-        {{- if .Values.admin.configFiles }}
-        {{- range $key, $val := .Values.admin.configFiles }}
+        {{- with .Values.admin.configFiles }}
+        {{- range $key, $val := . }}
         - name: configurations
           mountPath: {{ $.Values.admin.configFilesPath }}{{ $key }}
           subPath: {{ $key }}

--- a/stable/admin/templates/statefulset.yaml
+++ b/stable/admin/templates/statefulset.yaml
@@ -111,11 +111,13 @@ spec:
         volumeMounts:
         - name: log-volume
           mountPath: /var/log/nuodb
-{{- if hasKey .Values.admin.configFiles "nuodb.lic" }}
-        - name: nuodb-license-volume
-          mountPath: /etc/nuodb/nuodb.lic
-          subPath: nuodb.lic
-{{ end }}
+        {{- if .Values.admin.configFiles }}
+        {{- range $key, $val := .Values.admin.configFiles }}
+        - name: configurations
+          mountPath: {{ $.Values.admin.configFilesPath }}{{ $key }}
+          subPath: {{ $key }}
+        {{- end -}}
+        {{- end }}
         - name: raftlog
           mountPath: /var/opt/nuodb
         {{- if .Values.admin.tlsCACert }}
@@ -166,14 +168,11 @@ spec:
       {{- end }}
       - name: log-volume
         emptyDir: {}
-{{- if hasKey .Values.admin.configFiles "nuodb.lic" }}
-      - name: nuodb-license-volume
+      {{- if .Values.admin.configFiles }}
+      - name: configurations
         configMap:
-          name: nuodb-license-file
-          items:
-            - key: nuodb.lic
-              path: nuodb.lic
-{{ end }}
+          name: {{ template "admin.fullname" . }}-configuration
+      {{- end }}
 {{- if not .Values.admin.persistence.enabled }}
       - name: raftlog
         emptyDir: {}

--- a/stable/admin/values.yaml
+++ b/stable/admin/values.yaml
@@ -101,6 +101,9 @@ admin:
     #   cpu: 10m
     #   memory: 16Mi
 
+  # Custom NuoDB configuration files path
+  configFilesPath: /etc/nuodb/
+
   # NuoDB is a licensed product for Enterprise Edition.
   # Obtain your license from NuoDB support.
   #
@@ -114,7 +117,7 @@ admin:
   # --set admin.configFiles.nuodb\\.lic=<BASE64-TEXT-HERE>
   #
   configFiles: {}
-    # nuodb.lic: |+
+    # nuodb.lic: |-
     #   "PUT YOUR BASE64 ENCODED LICENSE CONTENT HERE"
 
   # Recommended default admin affinity:

--- a/stable/database/README.md
+++ b/stable/database/README.md
@@ -211,6 +211,8 @@ The following tables list the configurable parameters of the `database` chart an
 | `persistence.accessModes` | Volume access modes enabled (must match capabilities of the storage class) | `ReadWriteOnce` |
 | `persistence.size` | Amount of disk space allocated for database archive storage | `20Gi` |
 | `persistence.storageClass` | Storage class for volume backing database archive storage | `-` |
+| `configFilesPath` | Directory path where `configFiles.*` are found | `/etc/nuodb/` |
+| `configFiles.*` | See below. | `{}` |
 | `sm.hotCopy.replicas` | SM replicas with hot-copy enabled | `1` |
 | `sm.hotCopy.enablePod` | Create DS/SS for hot-copy enabled SMs | `true` |
 | `sm.noHotCopy.replicas` | SM replicas with hot-copy disabled | `0` |
@@ -237,6 +239,18 @@ The following tables list the configurable parameters of the `database` chart an
 | `sm.nodeSelectorNoHotCopyDS` | Node selector rules for non-hot-copy SMs (DaemonSet) | `{}` |
 | `sm.tolerationsDS` | Tolerations for SMs (DaemonSet) | `[]` |
 | `sm.otherOptions` | Additional key/value Docker options | `{}` |
+
+#### database.configFiles.*
+
+The purpose of this section is to specify replacement NuoDB configuration files.
+
+Any file located in `database.configFilesPath` can be replaced; the YAML key corresponds to the file name being created or replaced.
+
+The following tables list the configurable parameters for the `database.configFiles` option of the database chart and their default values.
+
+| Key | Description | Default |
+| ----- | ----------- | ------ |
+| `nuodb.config` | NuoDB config file. | `nil` |
 
 ### Running
 

--- a/stable/database/templates/configmap.yaml
+++ b/stable/database/templates/configmap.yaml
@@ -40,4 +40,21 @@ data:
   NUODB_IMPORT_STRIP_LEVELS: {{ default "1" .Values.database.import.stripLevels | quote }}
   NUODB_RESTORE_REQUEST_PREFIX: {{ default "/nuodb/nuosm/database" .Values.backup.requestPrefix }}
   NUODB_LATEST_BACKUP_PREFIX: {{ default "nuodb-backup/last_created" .Values.backup.latestPrefix }}
-
+---
+{{- if .Values.database.configFiles }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: {{ template "database.fullname" . }}
+    group: nuodb
+    domain: {{ .Values.admin.domain }}
+    chart: {{ template "database.chart" . }}
+    release: {{ .Release.Name | quote }}
+  name: {{ template "database.fullname" . }}-configuration
+data:
+{{- range $key, $val := .Values.database.configFiles }}
+  {{ $key }}: |-
+{{ $val | indent 4}}
+{{- end }}
+{{- end -}}

--- a/stable/database/templates/deployment.yaml
+++ b/stable/database/templates/deployment.yaml
@@ -90,6 +90,13 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:
+        {{- if .Values.database.configFiles }}
+        {{- range $key, $val := .Values.database.configFiles }}
+        - name: configurations
+          mountPath: {{ $.Values.database.configFilesPath }}{{ $key }}
+          subPath: {{ $key }}
+        {{- end -}}
+        {{- end }}
         - name: logdir
           mountPath: /var/log/nuodb
         - name: nuote
@@ -112,6 +119,11 @@ spec:
         {{- end }}
 {{- include "nuodb.imagePullSecrets" . | indent 6 }}
       volumes:
+        {{- if .Values.database.configFiles }}
+        - name: configurations
+          configMap:
+            name: {{ template "database.fullname" . }}-configuration
+        {{- end }}
         - name: logdir
           emptyDir: {}
         - name: nuote

--- a/stable/database/templates/deployment.yaml
+++ b/stable/database/templates/deployment.yaml
@@ -90,8 +90,8 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:
-        {{- if .Values.database.configFiles }}
-        {{- range $key, $val := .Values.database.configFiles }}
+        {{- with .Values.database.configFiles }}
+        {{- range $key, $val := . }}
         - name: configurations
           mountPath: {{ $.Values.database.configFilesPath }}{{ $key }}
           subPath: {{ $key }}

--- a/stable/database/templates/deploymentconfig.yaml
+++ b/stable/database/templates/deploymentconfig.yaml
@@ -89,8 +89,8 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:
-        {{- if .Values.database.configFiles }}
-        {{- range $key, $val := .Values.database.configFiles }}
+        {{- with .Values.database.configFiles }}
+        {{- range $key, $val := . }}
         - name: configurations
           mountPath: {{ $.Values.database.configFilesPath }}{{ $key }}
           subPath: {{ $key }}

--- a/stable/database/templates/deploymentconfig.yaml
+++ b/stable/database/templates/deploymentconfig.yaml
@@ -89,6 +89,13 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:
+        {{- if .Values.database.configFiles }}
+        {{- range $key, $val := .Values.database.configFiles }}
+        - name: configurations
+          mountPath: {{ $.Values.database.configFilesPath }}{{ $key }}
+          subPath: {{ $key }}
+        {{- end -}}
+        {{- end }}
         - name: logdir
           mountPath: /var/log/nuodb
         - name: nuote
@@ -111,6 +118,11 @@ spec:
         {{- end }}
 {{- include "nuodb.imagePullSecrets" . | indent 6 }}
       volumes:
+        {{- if .Values.database.configFiles }}
+        - name: configurations
+          configMap:
+            name: {{ template "database.fullname" . }}-configuration
+        {{- end }}
         - name: logdir
           emptyDir: {}
         - name: nuote

--- a/stable/database/templates/statefulset.yaml
+++ b/stable/database/templates/statefulset.yaml
@@ -133,8 +133,8 @@ spec:
         resources:
 {{ toYaml .Values.database.sm.resources | trim | indent 10 }}
         volumeMounts:
-        {{- if .Values.database.configFiles }}
-        {{- range $key, $val := .Values.database.configFiles }}
+        {{- with .Values.database.configFiles }}
+        {{- range $key, $val := . }}
         - name: configurations
           mountPath: {{ $.Values.database.configFilesPath }}{{ $key }}
           subPath: {{ $key }}
@@ -364,8 +364,8 @@ spec:
         resources:
 {{ toYaml .Values.database.sm.resources | trim | indent 10 }}
         volumeMounts:
-        {{- if .Values.database.configFiles }}
-        {{- range $key, $val := .Values.database.configFiles }}
+        {{- with .Values.database.configFiles }}
+        {{- range $key, $val := . }}
         - name: configurations
           mountPath: {{ $.Values.database.configFilesPath }}{{ $key }}
           subPath: {{ $key }}

--- a/stable/database/templates/statefulset.yaml
+++ b/stable/database/templates/statefulset.yaml
@@ -133,6 +133,13 @@ spec:
         resources:
 {{ toYaml .Values.database.sm.resources | trim | indent 10 }}
         volumeMounts:
+        {{- if .Values.database.configFiles }}
+        {{- range $key, $val := .Values.database.configFiles }}
+        - name: configurations
+          mountPath: {{ $.Values.database.configFilesPath }}{{ $key }}
+          subPath: {{ $key }}
+        {{- end -}}
+        {{- end }}
         - name: log-volume
           mountPath: /var/log/nuodb
         - name: nuosm
@@ -159,6 +166,11 @@ spec:
         terminationMessagePolicy: File
 {{- include "nuodb.imagePullSecrets" . | indent 6 }}
       volumes:
+      {{- if .Values.database.configFiles }}
+      - name: configurations
+        configMap:
+          name: {{ template "database.fullname" . }}-configuration
+      {{- end }}
       - name: log-volume
         emptyDir: {}
       - name: nuosm
@@ -352,6 +364,13 @@ spec:
         resources:
 {{ toYaml .Values.database.sm.resources | trim | indent 10 }}
         volumeMounts:
+        {{- if .Values.database.configFiles }}
+        {{- range $key, $val := .Values.database.configFiles }}
+        - name: configurations
+          mountPath: {{ $.Values.database.configFilesPath }}{{ $key }}
+          subPath: {{ $key }}
+        {{- end -}}
+        {{- end }}
         - name: log-volume
           mountPath: /var/log/nuodb
         - name: nuosm
@@ -380,6 +399,11 @@ spec:
         terminationMessagePolicy: File
 {{- include "nuodb.imagePullSecrets" . | indent 6 }}
       volumes:
+      {{- if .Values.database.configFiles }}
+      - name: configurations
+        configMap:
+          name: {{ template "database.fullname" . }}-configuration
+      {{- end }}
       - name: log-volume
         emptyDir: {}
       - name: nuosm

--- a/stable/database/values.yaml
+++ b/stable/database/values.yaml
@@ -122,6 +122,14 @@ database:
     ping-timeout: 60
     max-lost-archives: 0
 
+  # Custom NuoDB configuration files path
+  configFilesPath: /etc/nuodb/
+
+  # Custom NuoDB configuration files used to override default NuoDB settings
+  configFiles: {}
+    # nuodb.config: |-
+    #   verbose error,flush,warn
+
   # ensure all values here are strings - so quote any purely numeric values
   import:
     url: ""

--- a/test/integration/template_admin_test.go
+++ b/test/integration/template_admin_test.go
@@ -34,7 +34,7 @@ func TestAdminDefaultLicense(t *testing.T) {
 			continue
 		}
 
-		if strings.Contains(part, "nuodb-license-file") {
+		if strings.Contains(part, "nuodb-admin-configuration") {
 			found = true
 
 			var object v1.ConfigMap
@@ -45,7 +45,7 @@ func TestAdminDefaultLicense(t *testing.T) {
 
 	}
 
-	assert.Assert(t, found, "no matching config map was found")
+	assert.Assert(t, !found, "no matching config map was found")
 }
 
 func TestAdminLicenseCanBeSet(t *testing.T) {
@@ -72,7 +72,7 @@ func TestAdminLicenseCanBeSet(t *testing.T) {
 			continue
 		}
 
-		if strings.Contains(part, "nuodb-license-file") {
+		if strings.Contains(part, "nuodb-admin-configuration") {
 			found = true
 
 			var object v1.ConfigMap
@@ -95,8 +95,8 @@ func TestAdminStatefulSetVPNRenders(t *testing.T) {
 
 	options := &helm.Options{
 		SetValues: map[string]string{
-			"admin.securityContext.capabilities": "[ NET_ADMIN ]",
-			"admin.envFrom[0].configMapRef.name": "test-config",
+			"admin.securityContext.capabilities":    "[ NET_ADMIN ]",
+			"admin.envFrom[0].configMapRef.name":    "test-config",
 			"admin.options.leaderAssignmentTimeout": "30000",
 		},
 	}

--- a/test/minikube/minikube_base_admin_test.go
+++ b/test/minikube/minikube_base_admin_test.go
@@ -53,9 +53,9 @@ func verifyAdminService(t *testing.T, namespaceName string, podName string) {
 
 func getFunctionCallerName() string {
 	pc, _, _, _ := runtime.Caller(2)
-	nameFull := runtime.FuncForPC(pc).Name()    // main.foo
-	nameEnd := filepath.Ext(nameFull)           // .foo
-	name := strings.TrimPrefix(nameEnd, ".")    // foo
+	nameFull := runtime.FuncForPC(pc).Name() // main.foo
+	nameEnd := filepath.Ext(nameFull)        // .foo
+	name := strings.TrimPrefix(nameEnd, ".") // foo
 
 	return name
 }
@@ -218,10 +218,6 @@ func TestKubernetesInvalidLicense(t *testing.T) {
 	})
 	t.Run("verifyLicenseFile", func(t *testing.T) {
 		testlib.VerifyLicenseFile(t, namespaceName, admin0, licenseString)
-	})
-
-	t.Run("verifyCustomFileDoesNotGetMounted", func(t *testing.T) {
-		testlib.VerifyCustomFileDoesNotGetMounted(t, namespaceName, admin0, customFile)
 	})
 
 }


### PR DESCRIPTION
**Changes**

- Add idiomatic approach for handling configuration files to the database chart.
- Tweak the admin chart `admin.configFiles` variable to follow the same idiom.
- Add doc.
- Fixed the unit test; ONLY expose a ConfigMap IFF the `admin.configFiles` value is set.

**Test Changes Explained**

- verifyCustomFileDoesNotGetMounted in TestKubernetesInvalidLicense is no longer valid as the intent of this change is to permit ANY file in `/usr/etc/` to be overridden.
- an empty ({}) config map is pointless, so we idiomatically don't emit it (just like in MySQL, etc...)

**Testing Performed**

- Full end-to-end on GKE.
- Lint tests.
- Admin unit tests to verify common code approach.

**See Also**

The approach is very common, no need to reinvent how to do this. Lets just rip off the upstream project with known, trusted, working code...

- https://github.com/helm/charts/blob/master/stable/mysql/values.yaml
- https://github.com/helm/charts/blob/master/stable/mysql/templates/_helpers.tpl
- https://github.com/helm/charts/blob/master/stable/mysql/templates/configurationFiles-configmap.yaml
- https://github.com/helm/charts/blob/master/stable/mysql/templates/deployment.yaml