### PR TITLE
fix license negative test

### DIFF
--- a/test/testlib/minikube_utilities.go
+++ b/test/testlib/minikube_utilities.go
@@ -296,7 +296,7 @@ func VerifyLicensingErrorsInLog(t *testing.T, namespace string, podName string, 
 
 	fullLog := string(buf)
 
-	assert.Equal(t, expectError, strings.Contains(fullLog, "Unable to verify configured license"), fullLog)
+	assert.Equal(t, expectError, strings.Contains(fullLog, "Unable to verify license"), fullLog)
 }
 
 func VerifyCertificateInLog(t *testing.T, namespace string, podName string, expectedLogLine string) {


### PR DESCRIPTION
**Cause**

Turns out there must have been a Nuo Admin product change.

The error message is NOW the following `Unable to verify license in %s: Unexpected format for base64-encoded data...`, and NOT `Unable to verify configured license`; OR this branch of code never actually got exercised, and since I enabled the modification of ANY config file, opened up this branch of code showing off the error in the test for the first time.

**Change**
Update string searched for in log.