### PR TITLE
Rework Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,15 +22,21 @@ env:
     - KUBECONFIG=$HOME/.kube/config
     - NUODB_PRINT_TO_STDOUT=true
 
+cache:
+  directories:
+    - $GOPATH/pkg/dep
+
 before_install:
   - sudo apt-get update
   - sudo apt-get install socat
-  - curl https://raw.githubusercontent.com/golang/dep/v${DEP_VERSION}/install.sh | sh
-  - dep ensure -v
   - chmod +x scripts/ci/install_deps.sh
   - scripts/ci/install_deps.sh
   - docker pull nuodb/nuodb-ce:latest
   - helm version
+
+install:
+  - go get -u github.com/golang/dep/cmd/dep
+  - dep ensure -v
 
 script:
   - test/test_suite.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ install:
   - dep ensure -v
 
 script:
-  - 'if [ "TEST_SUITE" != "basic"  ]; then test/test_suite.sh; fi'
-  - 'if [ "TEST_SUITE" != "basic"  ]; then go test -timeout 10m -v ./test/integration; fi'
-  - 'if [ "TEST_SUITE" != "minikube-short"  ]; then go test -timeout 60m -v ./test/minikube -tags=short; fi'
-  - 'if [ "TEST_SUITE" != "minikube-long"  ]; then go test -timeout 60m -v ./test/minikube -tags=long; fi'
+  - 'if [ "$TEST_SUITE" != "basic"  ]; then test/test_suite.sh; fi'
+  - 'if [ "$TEST_SUITE" != "basic"  ]; then go test -timeout 10m -v ./test/integration; fi'
+  - 'if [ "$TEST_SUITE" != "minikube-short"  ]; then go test -timeout 60m -v ./test/minikube -tags=short; fi'
+  - 'if [ "$TEST_SUITE" != "minikube-long"  ]; then go test -timeout 60m -v ./test/minikube -tags=long; fi'

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,5 +41,4 @@ install:
 script:
   - test/test_suite.sh
   - go test -timeout 10m -v ./test/integration
-  - go test -timeout 60m -v ./test/minikube
-  - 'if [ "$TRAVIS_PULL_REQUEST" != "false" -o "$TRAVIS_BRANCH" = "master" ]; then go test -timeout 60m -v ./test/minikube -tags=long; fi'
+  - 'if [ "$TRAVIS_PULL_REQUEST" != "false" -o "$TRAVIS_BRANCH" = "master" ]; then go test -timeout 60m -v ./test/minikube -tags=long; else; go test -timeout 60m -v ./test/minikube; fi'

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,9 @@ env:
     - CHANGE_MINIKUBE_NONE_USER=true
     - KUBECONFIG=$HOME/.kube/config
     - NUODB_PRINT_TO_STDOUT=true
+  - TEST_SUITE="basic"
+  - TEST_SUITE="minikube-short"
+  - TEST_SUITE="minikube-long"
 
 cache:
   directories:
@@ -39,6 +42,7 @@ install:
   - dep ensure -v
 
 script:
-  - test/test_suite.sh
-  - go test -timeout 10m -v ./test/integration
-  - 'if [ "$TRAVIS_PULL_REQUEST" != "false" -o "$TRAVIS_BRANCH" = "master" ]; then go test -timeout 60m -v ./test/minikube -tags=long; else; go test -timeout 60m -v ./test/minikube; fi'
+  - 'if [ "TEST_SUITE" != "basic"  ]; then test/test_suite.sh; fi'
+  - 'if [ "TEST_SUITE" != "basic"  ]; then go test -timeout 10m -v ./test/integration; fi'
+  - 'if [ "TEST_SUITE" != "minikube-short"  ]; then go test -timeout 60m -v ./test/minikube -tags=short; fi'
+  - 'if [ "TEST_SUITE" != "minikube-long"  ]; then go test -timeout 60m -v ./test/minikube -tags=long; fi'

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,3 +42,4 @@ script:
   - test/test_suite.sh
   - go test -timeout 10m -v ./test/integration
   - go test -timeout 60m -v ./test/minikube
+  - 'if [ "$TRAVIS_PULL_REQUEST" != "false" -o "$TRAVIS_BRANCH" = "master" ]; then go test -timeout 60m -v ./test/minikube -tags=long; fi'

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ go:
 env:
   jobs:
     - TEST_SUITE=basic
-    - TEST_SUITE=minikube-short
-    - TEST_SUITE=minikube-long
+    - TEST_SUITE=minikube-short REQUIRES_MINIKUBE=true
+    - TEST_SUITE=minikube-long REQUIRES_MINIKUBE=true
   global:
     - HELM_VERSION="v2.14.3"
     - DEP_VERSION=0.5.4
@@ -35,15 +35,11 @@ before_install:
   - sudo apt-get install socat
   - chmod +x scripts/ci/install_deps.sh
   - scripts/ci/install_deps.sh
-  - docker pull nuodb/nuodb-ce:latest
-  - helm version
 
 install:
   - go get -u github.com/golang/dep/cmd/dep
   - dep ensure -v
 
 script:
-  - 'if [ "$TEST_SUITE" != "basic"  ]; then test/test_suite.sh; fi'
-  - 'if [ "$TEST_SUITE" != "basic"  ]; then go test -timeout 10m -v ./test/integration; fi'
-  - 'if [ "$TEST_SUITE" != "minikube-short"  ]; then go test -timeout 60m -v ./test/minikube -tags=short; fi'
-  - 'if [ "$TEST_SUITE" != "minikube-long"  ]; then go test -timeout 60m -v ./test/minikube -tags=long; fi'
+  - chmod +x scripts/ci/determine_and_run_tests.sh
+  - scripts/ci/determine_and_run_tests.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,10 @@ go:
   - 1.12.x
 
 env:
+  jobs:
+    - TEST_SUITE=basic
+    - TEST_SUITE=minikube-short
+    - TEST_SUITE=minikube-long
   global:
     - HELM_VERSION="v2.14.3"
     - DEP_VERSION=0.5.4
@@ -21,9 +25,6 @@ env:
     - CHANGE_MINIKUBE_NONE_USER=true
     - KUBECONFIG=$HOME/.kube/config
     - NUODB_PRINT_TO_STDOUT=true
-  - TEST_SUITE="basic"
-  - TEST_SUITE="minikube-short"
-  - TEST_SUITE="minikube-long"
 
 cache:
   directories:

--- a/scripts/ci/determine_and_run_tests.sh
+++ b/scripts/ci/determine_and_run_tests.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+echo "Running $TEST_SUITE"
+
+if [[ $TEST_SUITE = "basic"  ]]; then
+  ./test/test_suite.sh
+  go test -timeout 10m -v ./test/integration
+elif [[ $TEST_SUITE = "minikube-short"  ]]; then
+  go test -timeout 30m -v ./test/minikube -tags=short
+elif [[ $TEST_SUITE = "minikube-long"  ]]; then
+  go test -timeout 30m -v ./test/minikube -tags=long
+fi

--- a/scripts/ci/install_deps.sh
+++ b/scripts/ci/install_deps.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-if [[ ! -v REQUIRES_MINIKUBE ]]; then
+if [[ -z "$REQUIRES_MINIKUBE" ]]; then
     echo "skipping installation step"
     exit 0
 fi

--- a/scripts/ci/install_deps.sh
+++ b/scripts/ci/install_deps.sh
@@ -1,12 +1,17 @@
 #!/usr/bin/env bash
 
+# Download kubectl, which is a requirement for using minikube.
+curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v"${KUBERNETES_VERSION}"/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
+
+# Download Helm and Tiller
+wget http://storage.googleapis.com/kubernetes-helm/helm-"${HELM_VERSION}"-linux-amd64.tar.gz -O /tmp/helm.tar.gz
+tar xzf /tmp/helm.tar.gz -C /tmp --strip-components=1 && chmod +x /tmp/helm && sudo mv /tmp/helm /usr/local/bin
+
 if [[ -z "$REQUIRES_MINIKUBE" ]]; then
-    echo "skipping installation step"
+    echo "Skipping minikube installation step"
     exit 0
 fi
 
-# Download kubectl, which is a requirement for using minikube.
-curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v"${KUBERNETES_VERSION}"/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
 # Download minikube.
 curl -Lo minikube https://storage.googleapis.com/minikube/releases/v"${MINIKUBE_VERSION}"/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
 mkdir -p "$HOME"/.kube "$HOME"/.minikube
@@ -17,9 +22,7 @@ sudo minikube start --vm-driver=none --kubernetes-version=v"${KUBERNETES_VERSION
 sudo chown -R travis: /home/travis/.minikube/
 kubectl cluster-info
 
-# install Helm and Tiller
-wget http://storage.googleapis.com/kubernetes-helm/helm-"${HELM_VERSION}"-linux-amd64.tar.gz -O /tmp/helm.tar.gz
-tar xzf /tmp/helm.tar.gz -C /tmp --strip-components=1 && chmod +x /tmp/helm && sudo mv /tmp/helm /usr/local/bin
+# install helm
 helm init
 
 # get the image to speed up tests

--- a/scripts/ci/install_deps.sh
+++ b/scripts/ci/install_deps.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+if [[ ! -v REQUIRES_MINIKUBE ]]; then
+    echo "skipping installation step"
+    exit 0
+fi
+
 # Download kubectl, which is a requirement for using minikube.
 curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v"${KUBERNETES_VERSION}"/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
 # Download minikube.
@@ -16,3 +21,9 @@ kubectl cluster-info
 wget http://storage.googleapis.com/kubernetes-helm/helm-"${HELM_VERSION}"-linux-amd64.tar.gz -O /tmp/helm.tar.gz
 tar xzf /tmp/helm.tar.gz -C /tmp --strip-components=1 && chmod +x /tmp/helm && sudo mv /tmp/helm /usr/local/bin
 helm init
+
+# get the image to speed up tests
+docker pull nuodb/nuodb-ce:latest
+
+# print some info
+helm version

--- a/test/minikube/minikube_base_admin_test.go
+++ b/test/minikube/minikube_base_admin_test.go
@@ -9,47 +9,10 @@ import (
 	"time"
 
 	"github.com/nuodb/nuodb-helm-charts/test/testlib"
-
-	"gotest.tools/assert"
-
 	"github.com/gruntwork-io/terratest/modules/helm"
 	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/gruntwork-io/terratest/modules/random"
 )
-
-func verifyLoadBalancer(t *testing.T, namespaceName string, balancerName string) {
-	kubectlOptions := k8s.NewKubectlOptions("", "")
-	kubectlOptions.Namespace = namespaceName
-
-	balancerService := k8s.GetService(t, kubectlOptions, balancerName)
-	assert.Equal(t, balancerService.Name, balancerName)
-}
-
-func verifyLBPolicy(t *testing.T, namespaceName string, podName string) {
-	testlib.AwaitBalancerTerminated(t, namespaceName, "job-lb-policy")
-	testlib.VerifyPolicyInstalled(t, namespaceName, podName)
-}
-
-func verifyPodKill(t *testing.T, namespaceName string, podName string, helmChartReleaseName string, nrReplicasExpected int) {
-	testlib.KillAdminPod(t, namespaceName, podName)
-	testlib.AwaitNrReplicasScheduled(t, namespaceName, helmChartReleaseName, nrReplicasExpected)
-	testlib.AwaitAdminPodUp(t, namespaceName, podName, 100*time.Second)
-}
-
-func verifyKillProcess(t *testing.T, namespaceName string, podName string, helmChartReleaseName string, nrReplicasExpected int) {
-	testlib.KillAdminProcess(t, namespaceName, podName)
-	testlib.AwaitNrReplicasScheduled(t, namespaceName, helmChartReleaseName, nrReplicasExpected)
-	testlib.AwaitAdminPodUp(t, namespaceName, podName, 100*time.Second)
-}
-
-func verifyAdminService(t *testing.T, namespaceName string, podName string) {
-	serviceName := "nuodb"
-
-	adminService := testlib.GetService(t, namespaceName, serviceName)
-	assert.Equal(t, adminService.Name, serviceName)
-
-	testlib.PingService(t, namespaceName, serviceName, podName)
-}
 
 func TestKubernetesBasicAdminSingleReplica(t *testing.T) {
 	testlib.AwaitTillerUp(t)

--- a/test/minikube/minikube_base_admin_test.go
+++ b/test/minikube/minikube_base_admin_test.go
@@ -72,66 +72,6 @@ func TestKubernetesBasicAdminSingleReplica(t *testing.T) {
 	t.Run("verifyProcessKill", func(t *testing.T) { verifyKillProcess(t, namespaceName, admin0, helmChartReleaseName, 1) })
 	t.Run("verifyAdminService", func(t *testing.T) { verifyAdminService(t, namespaceName, admin0) })
 }
-func TestKubernetesBasicAdminThreeReplicas(t *testing.T) {
-	testlib.AwaitTillerUp(t)
-
-	options := helm.Options{
-		SetValues: map[string]string{"admin.replicas": "3"},
-	}
-
-	defer testlib.Teardown(testlib.TEARDOWN_ADMIN)
-
-	helmChartReleaseName, namespaceName := testlib.StartAdmin(t, &options, 3, "")
-
-	admin0 := fmt.Sprintf("%s-nuodb-0", helmChartReleaseName)
-	lbName := fmt.Sprintf("%s-nuodb-balancer", helmChartReleaseName)
-
-	t.Run("verifyAdminState", func(t *testing.T) { testlib.VerifyAdminState(t, namespaceName, admin0) })
-	t.Run("verifyOrderedLicensing", func(t *testing.T) {
-		testlib.VerifyLicenseIsCommunity(t, namespaceName, admin0)
-		testlib.VerifyLicensingErrorsInLog(t, namespaceName, admin0, false) // no error
-	})
-	t.Run("verifyLoadBalancer", func(t *testing.T) { verifyLoadBalancer(t, namespaceName, lbName) })
-	t.Run("verifyLBPolicy", func(t *testing.T) { verifyLBPolicy(t, namespaceName, admin0) })
-	t.Run("verifyPodKill", func(t *testing.T) { verifyPodKill(t, namespaceName, admin0, helmChartReleaseName, 3) })
-	t.Run("verifyProcessKill", func(t *testing.T) { verifyKillProcess(t, namespaceName, admin0, helmChartReleaseName, 3) })
-	t.Run("verifyAdminService", func(t *testing.T) { verifyAdminService(t, namespaceName, admin0) })
-}
-
-func TestKubernetesUpgradeAdmin(t *testing.T) {
-	testlib.AwaitTillerUp(t)
-
-	options := helm.Options{
-		SetValues: map[string]string{"nuodb.image.tag": "4.0"},
-	}
-
-	defer testlib.Teardown(testlib.TEARDOWN_ADMIN)
-
-	helmChartReleaseName, namespaceName := testlib.StartAdmin(t, &options, 1, "")
-
-	admin0 := fmt.Sprintf("%s-nuodb-0", helmChartReleaseName)
-	lbName := fmt.Sprintf("%s-nuodb-balancer", helmChartReleaseName)
-
-	testlib.AwaitBalancerTerminated(t, namespaceName, "job-lb-policy")
-
-	// all jobs need to be deleted before an upgrade can be performed
-	// so far we have not found an automated way to delete them as part of a pre-upgrade hook
-	// if we find it, this line can be removed and the test should still pass
-	testlib.DeletePod(t, namespaceName, "jobs/job-lb-policy-nearest")
-
-	upgradedOptions := &helm.Options{
-		SetValues: map[string]string{"nuodb.image.tag": "4.0.1"},
-	}
-
-	helm.Upgrade(t, upgradedOptions, testlib.ADMIN_HELM_CHART_PATH, helmChartReleaseName)
-
-	testlib.AwaitAdminPodUpgraded(t, namespaceName, admin0, "docker.io/nuodb/nuodb-ce:4.0.1", 300*time.Second)
-	testlib.AwaitAdminPodUp(t, namespaceName, admin0, 300*time.Second)
-
-	t.Run("verifyAdminState", func(t *testing.T) { testlib.VerifyAdminState(t, namespaceName, admin0) })
-	t.Run("verifyLoadBalancer", func(t *testing.T) { verifyLoadBalancer(t, namespaceName, lbName) })
-	t.Run("verifyLBPolicy", func(t *testing.T) { verifyLBPolicy(t, namespaceName, admin0) })
-}
 
 func TestKubernetesInvalidLicense(t *testing.T) {
 	testlib.AwaitTillerUp(t)

--- a/test/minikube/minikube_base_admin_test.go
+++ b/test/minikube/minikube_base_admin_test.go
@@ -1,3 +1,5 @@
+// +build short
+
 package minikube
 
 import (

--- a/test/minikube/minikube_base_database_test.go
+++ b/test/minikube/minikube_base_database_test.go
@@ -1,3 +1,5 @@
+// +build short
+
 package minikube
 
 import (

--- a/test/minikube/minikube_base_thp_test.go
+++ b/test/minikube/minikube_base_thp_test.go
@@ -1,3 +1,5 @@
+// +build short
+
 package minikube
 
 import (

--- a/test/minikube/minikube_long_admin_test.go
+++ b/test/minikube/minikube_long_admin_test.go
@@ -1,0 +1,74 @@
+// +build long
+
+package minikube
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/nuodb/nuodb-helm-charts/test/testlib"
+
+	"github.com/gruntwork-io/terratest/modules/helm"
+)
+
+func TestKubernetesBasicAdminThreeReplicas(t *testing.T) {
+	testlib.AwaitTillerUp(t)
+
+	options := helm.Options{
+		SetValues: map[string]string{"admin.replicas": "3"},
+	}
+
+	defer testlib.Teardown(testlib.TEARDOWN_ADMIN)
+
+	helmChartReleaseName, namespaceName := testlib.StartAdmin(t, &options, 3, "")
+
+	admin0 := fmt.Sprintf("%s-nuodb-0", helmChartReleaseName)
+	lbName := fmt.Sprintf("%s-nuodb-balancer", helmChartReleaseName)
+
+	t.Run("verifyAdminState", func(t *testing.T) { testlib.VerifyAdminState(t, namespaceName, admin0) })
+	t.Run("verifyOrderedLicensing", func(t *testing.T) {
+		testlib.VerifyLicenseIsCommunity(t, namespaceName, admin0)
+		testlib.VerifyLicensingErrorsInLog(t, namespaceName, admin0, false) // no error
+	})
+	t.Run("verifyLoadBalancer", func(t *testing.T) { verifyLoadBalancer(t, namespaceName, lbName) })
+	t.Run("verifyLBPolicy", func(t *testing.T) { verifyLBPolicy(t, namespaceName, admin0) })
+	t.Run("verifyPodKill", func(t *testing.T) { verifyPodKill(t, namespaceName, admin0, helmChartReleaseName, 3) })
+	t.Run("verifyProcessKill", func(t *testing.T) { verifyKillProcess(t, namespaceName, admin0, helmChartReleaseName, 3) })
+	t.Run("verifyAdminService", func(t *testing.T) { verifyAdminService(t, namespaceName, admin0) })
+}
+
+func TestKubernetesUpgradeAdmin(t *testing.T) {
+	testlib.AwaitTillerUp(t)
+
+	options := helm.Options{
+		SetValues: map[string]string{"nuodb.image.tag": "4.0"},
+	}
+
+	defer testlib.Teardown(testlib.TEARDOWN_ADMIN)
+
+	helmChartReleaseName, namespaceName := testlib.StartAdmin(t, &options, 1, "")
+
+	admin0 := fmt.Sprintf("%s-nuodb-0", helmChartReleaseName)
+	lbName := fmt.Sprintf("%s-nuodb-balancer", helmChartReleaseName)
+
+	testlib.AwaitBalancerTerminated(t, namespaceName, "job-lb-policy")
+
+	// all jobs need to be deleted before an upgrade can be performed
+	// so far we have not found an automated way to delete them as part of a pre-upgrade hook
+	// if we find it, this line can be removed and the test should still pass
+	testlib.DeletePod(t, namespaceName, "jobs/job-lb-policy-nearest")
+
+	upgradedOptions := &helm.Options{
+		SetValues: map[string]string{"nuodb.image.tag": "4.0.1"},
+	}
+
+	helm.Upgrade(t, upgradedOptions, testlib.ADMIN_HELM_CHART_PATH, helmChartReleaseName)
+
+	testlib.AwaitAdminPodUpgraded(t, namespaceName, admin0, "docker.io/nuodb/nuodb-ce:4.0.1", 300*time.Second)
+	testlib.AwaitAdminPodUp(t, namespaceName, admin0, 300*time.Second)
+
+	t.Run("verifyAdminState", func(t *testing.T) { testlib.VerifyAdminState(t, namespaceName, admin0) })
+	t.Run("verifyLoadBalancer", func(t *testing.T) { verifyLoadBalancer(t, namespaceName, lbName) })
+	t.Run("verifyLBPolicy", func(t *testing.T) { verifyLBPolicy(t, namespaceName, admin0) })
+}

--- a/test/minikube/minikube_test_test.go
+++ b/test/minikube/minikube_test_test.go
@@ -1,3 +1,5 @@
+// +build short
+
 package minikube
 
 import (

--- a/test/minikube/minikube_tls_admin_test.go
+++ b/test/minikube/minikube_tls_admin_test.go
@@ -1,3 +1,5 @@
+// +build long
+
 package minikube
 
 import (
@@ -15,14 +17,6 @@ import (
 )
 
 const ENGINE_CERTIFICATE_LOG_TEMPLATE = `Engine Certificate: Certificate #%d CN %s`
-
-func verifySecretFields(t *testing.T, namespaceName string, secretName string, fields ...string) {
-	secret := testlib.GetSecret(t, namespaceName, secretName)
-	for _, field := range fields {
-		_, ok := secret.Data[field]
-		assert.Check(t, ok)
-	}
-}
 
 func verifyKeystore(t *testing.T, namespace string, podName string, keystore string, password string, matches string) {
 	options := k8s.NewKubectlOptions("", "")

--- a/test/minikube/minikube_tls_rotation_test.go
+++ b/test/minikube/minikube_tls_rotation_test.go
@@ -1,3 +1,5 @@
+// +build long
+
 package minikube
 
 import (

--- a/test/minikube/verify_utility.go
+++ b/test/minikube/verify_utility.go
@@ -1,0 +1,43 @@
+package minikube
+
+import (
+	"github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/nuodb/nuodb-helm-charts/test/testlib"
+	"testing"
+	"time"
+	"gotest.tools/assert"
+)
+
+func verifyLoadBalancer(t *testing.T, namespaceName string, balancerName string) {
+	kubectlOptions := k8s.NewKubectlOptions("", "")
+	kubectlOptions.Namespace = namespaceName
+
+	balancerService := k8s.GetService(t, kubectlOptions, balancerName)
+	assert.Equal(t, balancerService.Name, balancerName)
+}
+
+func verifyLBPolicy(t *testing.T, namespaceName string, podName string) {
+	testlib.AwaitBalancerTerminated(t, namespaceName, "job-lb-policy")
+	testlib.VerifyPolicyInstalled(t, namespaceName, podName)
+}
+
+func verifyPodKill(t *testing.T, namespaceName string, podName string, helmChartReleaseName string, nrReplicasExpected int) {
+	testlib.KillAdminPod(t, namespaceName, podName)
+	testlib.AwaitNrReplicasScheduled(t, namespaceName, helmChartReleaseName, nrReplicasExpected)
+	testlib.AwaitAdminPodUp(t, namespaceName, podName, 100*time.Second)
+}
+
+func verifyKillProcess(t *testing.T, namespaceName string, podName string, helmChartReleaseName string, nrReplicasExpected int) {
+	testlib.KillAdminProcess(t, namespaceName, podName)
+	testlib.AwaitNrReplicasScheduled(t, namespaceName, helmChartReleaseName, nrReplicasExpected)
+	testlib.AwaitAdminPodUp(t, namespaceName, podName, 100*time.Second)
+}
+
+func verifyAdminService(t *testing.T, namespaceName string, podName string) {
+	serviceName := "nuodb"
+
+	adminService := testlib.GetService(t, namespaceName, serviceName)
+	assert.Equal(t, adminService.Name, serviceName)
+
+	testlib.PingService(t, namespaceName, serviceName, podName)
+}


### PR DESCRIPTION
- add caching (saves around 2 min per build)
- split tests into basic/short/long and parallelize builds (saves around 15 min)
- annotate minikube tests with short or long. When building locally I recommend setting both.