### PR TITLE
Add certificates backup in case of test failure

### DIFF
--- a/test/minikube/minikube_tls_rotation_test.go
+++ b/test/minikube/minikube_tls_rotation_test.go
@@ -47,7 +47,6 @@ func startDomainWithTLSCertificates(t *testing.T, options *helm.Options, namespa
 	// create initial certs...
 	certGeneratorPodName, _ := testlib.GenerateTLSConfiguration(t, namespaceName, tlsCommands, "")
 
-	t.Fatal()
 	adminReleaseName, namespaceName := testlib.StartAdmin(t, options, adminReplicaCount, namespaceName)
 	admin0 := fmt.Sprintf("%s-nuodb-0", adminReleaseName)
 	databaseReleaseName := testlib.StartDatabase(t, namespaceName, admin0, options)

--- a/test/minikube/minikube_tls_rotation_test.go
+++ b/test/minikube/minikube_tls_rotation_test.go
@@ -47,6 +47,7 @@ func startDomainWithTLSCertificates(t *testing.T, options *helm.Options, namespa
 	// create initial certs...
 	certGeneratorPodName, _ := testlib.GenerateTLSConfiguration(t, namespaceName, tlsCommands, "")
 
+	t.Fatal()
 	adminReleaseName, namespaceName := testlib.StartAdmin(t, options, adminReplicaCount, namespaceName)
 	admin0 := fmt.Sprintf("%s-nuodb-0", adminReleaseName)
 	databaseReleaseName := testlib.StartDatabase(t, namespaceName, admin0, options)
@@ -123,7 +124,7 @@ func TestKubernetesTLSRotation(t *testing.T) {
 	defer testlib.Teardown(testlib.TEARDOWN_DATABASE)
 
 	certGeneratorPodName, adminReleaseName, databaseReleaseName := startDomainWithTLSCertificates(t, &options, namespaceName, initialTLSCommands)
-	
+
 	// create the new certs...
 	testlib.GenerateCustomCertificates(t, certGeneratorPodName, namespaceName, newTLSCommands)
 	newTLSKeysLocation := testlib.CopyCertificatesToControlHost(t, certGeneratorPodName, namespaceName)

--- a/test/testlib/constants.go
+++ b/test/testlib/constants.go
@@ -32,5 +32,7 @@ const DATABASE_HELM_CHART_PATH = "../../stable/database"
 const RESTORE_HELM_CHART_PATH = "../../stable/restore"
 const THP_HELM_CHART_PATH = "../../stable/transparent-hugepage"
 
+const RESULT_DIR = "../../results"
+
 const LAST_BACKUP_PREFIX string = "nuodb-backup/last_created"
 const IMPORT_ARCHIVE_URL = "http://download.nuohub.org/ce_releases/restore.bak.tz"

--- a/test/testlib/minikube_utilities.go
+++ b/test/testlib/minikube_utilities.go
@@ -25,8 +25,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-var RESULT_DIR = "results"
-
 var teardownLists = make(map[string][]func())
 
 /**
@@ -394,7 +392,7 @@ func shouldPrintToStdout() bool {
 }
 
 func GetAppLog(t *testing.T, namespace string, podName string) {
-	dirPath := filepath.Join("..", "..", RESULT_DIR, namespace)
+	dirPath := filepath.Join(RESULT_DIR, namespace)
 	filePath := filepath.Join(dirPath, podName)
 
 	_ = os.MkdirAll(dirPath, 0700)


### PR DESCRIPTION
**Changes**
- backup generated certificates in case of test failure so that they could be used to reproduce the problem

**Why**
- Requested by @vegichan by one of his comments in https://github.com/nuodb/nuodb-helm-charts/pull/11

**Testing Performed**
- Local automation tests with minikube