### PR TITLE
Add engine readiness probe

### DIFF
--- a/stable/admin/templates/statefulset.yaml
+++ b/stable/admin/templates/statefulset.yaml
@@ -173,10 +173,6 @@ spec:
         configMap:
           name: {{ template "admin.fullname" . }}-configuration
       {{- end }}
-{{- if not .Values.admin.persistence.enabled }}
-      - name: raftlog
-        emptyDir: {}
-{{- else }}
   volumeClaimTemplates:
   - metadata:
       name: raftlog
@@ -201,4 +197,3 @@ spec:
       resources:
         requests:
           storage: {{ .Values.admin.persistence.size }}
-{{- end }}

--- a/stable/admin/values.yaml
+++ b/stable/admin/values.yaml
@@ -65,10 +65,6 @@ admin:
   lbQuery: random(first(label(pod ${pod:-}) label(node ${node:-}) label(zone ${zone:-}) any))
 
   persistence:
-    ## If true, use a Persistent Volume Claim, If false, use emptyDir
-    ##
-    ## n.b. use ReadWriteMany if using local ssd
-    enabled: false
     size: 1Gi
     accessModes:
       - ReadWriteOnce

--- a/stable/database/files/readinessprobe
+++ b/stable/database/files/readinessprobe
@@ -1,3 +1,21 @@
 #!/bin/sh
 
-nuocmd show domain | grep `hostname` | sed 's/.*start_id = //;s/].*//' | awk '{print "check process --check-running --start-id " $1'} | xargs nuocmd
+function die() {
+  retval=$1
+  shift
+  echo "$@"
+  exit $retval
+}
+
+
+processes=`nuocmd show domain --process-format "{address} {start_id}" | grep \`hostname\` | awk '{print $2}'`
+
+if [ -z "$processes" ]
+then
+  die -1 "No process found"
+fi
+
+for start_id in $processes
+do
+  nuocmd check process --check-running --start-id $start_id || die -1 "Process reported not ready"
+done

--- a/stable/database/files/readinessprobe
+++ b/stable/database/files/readinessprobe
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+nuocmd show domain | grep `hostname` | sed 's/.*start_id = //;s/].*//' | awk '{print "check process --check-running --start-id " $1'} | xargs nuocmd

--- a/stable/database/templates/configmap.yaml
+++ b/stable/database/templates/configmap.yaml
@@ -34,6 +34,19 @@ metadata:
     domain: {{ .Values.admin.domain }}
     chart: {{ template "database.chart" . }}
     release: {{ .Release.Name | quote }}
+  name: {{ template "database.fullname" . }}-readinessprobe
+data:
+{{ (.Files.Glob "files/readinessprobe").AsConfig | indent 2 }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: {{ template "database.fullname" . }}
+    group: nuodb
+    domain: {{ .Values.admin.domain }}
+    chart: {{ template "database.chart" . }}
+    release: {{ .Release.Name | quote }}
   name: {{ template "database.fullname" . }}-restore
 data:
   NUODB_IMPORT_URL: {{ .Values.database.import.url }}

--- a/stable/database/templates/daemonset.yaml
+++ b/stable/database/templates/daemonset.yaml
@@ -120,6 +120,9 @@ spec:
         - name: nuosm
           mountPath: /usr/local/bin/nuosm
           subPath: nuosm
+        - name: readinessprobe
+          mountPath: /usr/local/bin/readinessprobe
+          subPath: readinessprobe
         - name: archive-volume
           mountPath: /var/opt/nuodb/archive
         {{- if .Values.admin.tlsCACert }}
@@ -138,12 +141,25 @@ spec:
           subPath: {{ .Values.admin.tlsKeyStore.key }}
         {{- end }}
 {{- include "nuodb.imagePullSecrets" . | indent 6 }}
+        readinessProbe:
+          initialDelaySeconds: 30
+          periodSeconds: 15
+          exec:
+            command: [ "readinessprobe" ]
+          failureThreshold: 58
+          # the SM becomes unready if it does not start within 15 minutes = 30s + 15s*58
+          successThreshold: 2
+          timeoutSeconds: 1
       volumes:
       - name: log-volume
         emptyDir: {}
       - name: nuosm
         configMap:
           name: {{ template "database.fullname" . }}-nuosm
+          defaultMode: 0777
+      - name: readinessprobe
+        configMap:
+          name: {{ template "database.fullname" . }}-readinessprobe
           defaultMode: 0777
       - name: archive-volume
         persistentVolumeClaim:
@@ -297,6 +313,9 @@ spec:
         - name: nuosm
           mountPath: /usr/local/bin/nuosm
           subPath: nuosm
+        - name: readinessprobe
+          mountPath: /usr/local/bin/readinessprobe
+          subPath: readinessprobe
         - name: archive-volume
           mountPath: /var/opt/nuodb/archive
         - name: backup-volume
@@ -317,12 +336,25 @@ spec:
           subPath: {{ .Values.admin.tlsKeyStore.key }}
         {{- end }}
 {{- include "nuodb.imagePullSecrets" . | indent 6 }}
+        readinessProbe:
+          initialDelaySeconds: 30
+          periodSeconds: 15
+          exec:
+            command: [ "readinessprobe" ]
+          failureThreshold: 58
+          # the SM becomes unready if it does not start within 15 minutes = 30s + 15s*58
+          successThreshold: 2
+          timeoutSeconds: 1
       volumes:
       - name: log-volume
         emptyDir: {}
       - name: nuosm
         configMap:
           name: {{ template "database.fullname" . }}-nuosm
+          defaultMode: 0777
+      - name: readinessprobe
+        configMap:
+          name: {{ template "database.fullname" . }}-readinessprobe
           defaultMode: 0777
       - name: archive-volume
         persistentVolumeClaim:

--- a/stable/database/templates/deployment.yaml
+++ b/stable/database/templates/deployment.yaml
@@ -102,6 +102,9 @@ spec:
         - name: nuote
           mountPath: /usr/local/bin/nuote
           subPath: nuote
+        - name: readinessprobe
+          mountPath: /usr/local/bin/readinessprobe
+          subPath: readinessprobe
         {{- if .Values.admin.tlsCACert }}
         - name: tls-ca-cert
           mountPath: /etc/nuodb/keys/ca.cert
@@ -118,6 +121,15 @@ spec:
           subPath: {{ .Values.admin.tlsKeyStore.key }}
         {{- end }}
 {{- include "nuodb.imagePullSecrets" . | indent 6 }}
+        readinessProbe:
+          initialDelaySeconds: 30
+          periodSeconds: 5
+          exec:
+            command: [ "readinessprobe" ]
+          failureThreshold: 54
+          # the TE becomes unready if it does not start within 5 minutes = 30s + 5s*54
+          successThreshold: 2
+          timeoutSeconds: 1
       volumes:
         {{- if .Values.database.configFiles }}
         - name: configurations
@@ -129,6 +141,10 @@ spec:
         - name: nuote
           configMap:
             name: {{ template "database.fullname" . }}-nuote
+            defaultMode: 0777
+        - name: readinessprobe
+          configMap:
+            name: {{ template "database.fullname" . }}-readinessprobe
             defaultMode: 0777
         {{- if .Values.admin.tlsCACert }}
         - name: tls-ca-cert

--- a/stable/database/templates/deploymentconfig.yaml
+++ b/stable/database/templates/deploymentconfig.yaml
@@ -101,6 +101,9 @@ spec:
         - name: nuote
           mountPath: /usr/local/bin/nuote
           subPath: nuote
+        - name: readinessprobe
+          mountPath: /usr/local/bin/readinessprobe
+          subPath: readinessprobe
         {{- if .Values.admin.tlsCACert }}
         - name: tls-ca-cert
           mountPath: /etc/nuodb/keys/ca.cert
@@ -117,6 +120,15 @@ spec:
           subPath: {{ .Values.admin.tlsKeyStore.key }}
         {{- end }}
 {{- include "nuodb.imagePullSecrets" . | indent 6 }}
+        readinessProbe:
+          initialDelaySeconds: 30
+          periodSeconds: 5
+          exec:
+            command: [ "readinessprobe" ]
+          failureThreshold: 54
+          # the TE becomes unready if it does not start within 5 minutes = 30s + 5s*54
+          successThreshold: 2
+          timeoutSeconds: 1
       volumes:
         {{- if .Values.database.configFiles }}
         - name: configurations
@@ -128,6 +140,10 @@ spec:
         - name: nuote
           configMap:
             name: {{ template "database.fullname" . }}-nuote
+            defaultMode: 0777
+        - name: readinessprobe
+          configMap:
+            name: {{ template "database.fullname" . }}-readinessprobe
             defaultMode: 0777
         {{- if .Values.admin.tlsCACert }}
         - name: tls-ca-cert

--- a/stable/database/templates/statefulset.yaml
+++ b/stable/database/templates/statefulset.yaml
@@ -145,6 +145,9 @@ spec:
         - name: nuosm
           mountPath: /usr/local/bin/nuosm
           subPath: nuosm
+        - name: readinessprobe
+          mountPath: /usr/local/bin/readinessprobe
+          subPath: readinessprobe
         - mountPath: /var/opt/nuodb/archive
           name: archive-volume
         {{- if .Values.admin.tlsCACert }}
@@ -165,6 +168,15 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
 {{- include "nuodb.imagePullSecrets" . | indent 6 }}
+        readinessProbe:
+          initialDelaySeconds: 30
+          periodSeconds: 15
+          exec:
+            command: [ "readinessprobe" ]
+          failureThreshold: 58
+          # the SM becomes unready if it does not start within 15 minutes = 30s + 15s*58
+          successThreshold: 2
+          timeoutSeconds: 1
       volumes:
       {{- if .Values.database.configFiles }}
       - name: configurations
@@ -176,6 +188,10 @@ spec:
       - name: nuosm
         configMap:
           name: {{ template "database.fullname" . }}-nuosm
+          defaultMode: 0777
+      - name: readinessprobe
+        configMap:
+          name: {{ template "database.fullname" . }}-readinessprobe
           defaultMode: 0777
       {{- if .Values.admin.tlsCACert }}
       - name: tls-ca-cert
@@ -376,6 +392,9 @@ spec:
         - name: nuosm
           mountPath: /usr/local/bin/nuosm
           subPath: nuosm
+        - name: readinessprobe
+          mountPath: /usr/local/bin/readinessprobe
+          subPath: readinessprobe
         - mountPath: /var/opt/nuodb/archive
           name: archive-volume
         - mountPath: /var/opt/nuodb/backup
@@ -398,6 +417,15 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
 {{- include "nuodb.imagePullSecrets" . | indent 6 }}
+        readinessProbe:
+          initialDelaySeconds: 30
+          periodSeconds: 15
+          exec:
+            command: [ "readinessprobe" ]
+          failureThreshold: 58
+          # the SM becomes unready if it does not start within 15 minutes = 30s + 15s*58
+          successThreshold: 2
+          timeoutSeconds: 1
       volumes:
       {{- if .Values.database.configFiles }}
       - name: configurations
@@ -409,6 +437,10 @@ spec:
       - name: nuosm
         configMap:
           name: {{ template "database.fullname" . }}-nuosm
+          defaultMode: 0777
+      - name: readinessprobe
+        configMap:
+          name: {{ template "database.fullname" . }}-readinessprobe
           defaultMode: 0777
       {{- if .Values.admin.tlsCACert }}
       - name: tls-ca-cert

--- a/test/minikube/minikube_base_database_test.go
+++ b/test/minikube/minikube_base_database_test.go
@@ -178,10 +178,11 @@ func TestKubernetesBasicDatabase(t *testing.T) {
 		defer testlib.Teardown(testlib.TEARDOWN_DATABASE) // ensure resources allocated in called functions are released when this function exits
 
 		testlib.StartDatabase(t, namespaceName, admin0, &helm.Options{
-			SetValues: map[string]string{"database.sm.resources.requests.cpu": "500m",
-				"database.sm.resources.requests.memory": "1Gi",
-				"database.te.resources.requests.cpu":    "500m",
-				"database.te.resources.requests.memory": "1Gi",
+			SetValues: map[string]string{
+				"database.sm.resources.requests.cpu":    testlib.MINIMAL_VIABLE_ENGINE_CPU,
+				"database.sm.resources.requests.memory": testlib.MINIMAL_VIABLE_ENGINE_MEMORY,
+				"database.te.resources.requests.cpu":    testlib.MINIMAL_VIABLE_ENGINE_CPU,
+				"database.te.resources.requests.memory": testlib.MINIMAL_VIABLE_ENGINE_MEMORY,
 				"database.te.labels.cloud":              LABEL_CLOUD,
 				"database.te.labels.region":             LABEL_REGION,
 				"database.te.labels.zone":               LABEL_ZONE,
@@ -202,10 +203,11 @@ func TestKubernetesBasicDatabase(t *testing.T) {
 
 		testlib.StartDatabase(t, namespaceName, admin0,
 			&helm.Options{
-				SetValues: map[string]string{"database.sm.resources.requests.cpu": "500m",
-					"database.sm.resources.requests.memory": "1Gi",
-					"database.te.resources.requests.cpu":    "500m",
-					"database.te.resources.requests.memory": "1Gi",
+				SetValues: map[string]string{
+					"database.sm.resources.requests.cpu":    testlib.MINIMAL_VIABLE_ENGINE_CPU,
+					"database.sm.resources.requests.memory": testlib.MINIMAL_VIABLE_ENGINE_MEMORY,
+					"database.te.resources.requests.cpu":    testlib.MINIMAL_VIABLE_ENGINE_CPU,
+					"database.te.resources.requests.memory": testlib.MINIMAL_VIABLE_ENGINE_MEMORY,
 					"database.te.labels.cloud":              LABEL_CLOUD,
 					"database.te.labels.region":             LABEL_REGION,
 					"database.te.labels.zone":               LABEL_ZONE,
@@ -241,10 +243,10 @@ func TestKubernetesBackupDatabase(t *testing.T) {
 		defer testlib.Teardown(testlib.TEARDOWN_DATABASE)
 		databaseOptions := helm.Options{
 			SetValues: map[string]string{
-				"database.sm.resources.requests.cpu":    "500m",
-				"database.sm.resources.requests.memory": "1Gi",
-				"database.te.resources.requests.cpu":    "500m",
-				"database.te.resources.requests.memory": "1Gi",
+				"database.sm.resources.requests.cpu":    testlib.MINIMAL_VIABLE_ENGINE_CPU,
+				"database.sm.resources.requests.memory": testlib.MINIMAL_VIABLE_ENGINE_MEMORY,
+				"database.te.resources.requests.cpu":    testlib.MINIMAL_VIABLE_ENGINE_CPU,
+				"database.te.resources.requests.memory": testlib.MINIMAL_VIABLE_ENGINE_MEMORY,
 				"backup.persistence.enabled":            "true",
 				"backup.persistence.size":               "1Gi",
 			},
@@ -262,10 +264,10 @@ func TestKubernetesBackupDatabase(t *testing.T) {
 		defer testlib.Teardown(testlib.TEARDOWN_DATABASE)
 		databaseOptions := helm.Options{
 			SetValues: map[string]string{
-				"database.sm.resources.requests.cpu":    "500m",
-				"database.sm.resources.requests.memory": "1Gi",
-				"database.te.resources.requests.cpu":    "500m",
-				"database.te.resources.requests.memory": "1Gi",
+				"database.sm.resources.requests.cpu":    testlib.MINIMAL_VIABLE_ENGINE_CPU,
+				"database.sm.resources.requests.memory": testlib.MINIMAL_VIABLE_ENGINE_MEMORY,
+				"database.te.resources.requests.cpu":    testlib.MINIMAL_VIABLE_ENGINE_CPU,
+				"database.te.resources.requests.memory": testlib.MINIMAL_VIABLE_ENGINE_MEMORY,
 				"backup.persistence.enabled":            "true",
 				"backup.persistence.size":               "1Gi",
 				"database.enableDaemonSet":              "true",
@@ -299,10 +301,10 @@ func TestKubernetesRestoreDatabase(t *testing.T) {
 		databaseOptions := helm.Options{
 			SetValues: map[string]string{
 				"database.name":                         "demo",
-				"database.sm.resources.requests.cpu":    "500m",
-				"database.sm.resources.requests.memory": "1Gi",
-				"database.te.resources.requests.cpu":    "500m",
-				"database.te.resources.requests.memory": "1Gi",
+				"database.sm.resources.requests.cpu":    testlib.MINIMAL_VIABLE_ENGINE_CPU,
+				"database.sm.resources.requests.memory": testlib.MINIMAL_VIABLE_ENGINE_MEMORY,
+				"database.te.resources.requests.cpu":    testlib.MINIMAL_VIABLE_ENGINE_CPU,
+				"database.te.resources.requests.memory": testlib.MINIMAL_VIABLE_ENGINE_MEMORY,
 				"backup.persistence.enabled":            "true",
 				"backup.persistence.size":               "1Gi",
 			},
@@ -353,7 +355,7 @@ func TestKubernetesRestoreDatabase(t *testing.T) {
 			"--db-name", "demo",
 		)
 
-		testlib.AwaitDatabaseUp(t, namespaceName, admin0, "demo")
+		testlib.AwaitDatabaseUp(t, namespaceName, admin0, "demo", 2)
 
 		// verify that the database contains the restored data
 		tables, err := testlib.RunSQL(t, namespaceName, admin0, "demo", "show schema User")
@@ -386,10 +388,10 @@ func TestKubernetesImportDatabase(t *testing.T) {
 		testlib.StartDatabase(t, namespaceName, admin0, &helm.Options{
 			SetValues: map[string]string{
 				"database.import.url":                   testlib.IMPORT_ARCHIVE_URL,
-				"database.sm.resources.requests.cpu":    "500m",
-				"database.sm.resources.requests.memory": "1Gi",
-				"database.te.resources.requests.cpu":    "500m",
-				"database.te.resources.requests.memory": "1Gi",
+				"database.sm.resources.requests.cpu":    testlib.MINIMAL_VIABLE_ENGINE_CPU,
+				"database.sm.resources.requests.memory": testlib.MINIMAL_VIABLE_ENGINE_MEMORY,
+				"database.te.resources.requests.cpu":    testlib.MINIMAL_VIABLE_ENGINE_CPU,
+				"database.te.resources.requests.memory": testlib.MINIMAL_VIABLE_ENGINE_MEMORY,
 				"backup.persistence.enabled":            "true",
 				"backup.persistence.size":               "1Gi",
 			},
@@ -408,10 +410,10 @@ func TestKubernetesImportDatabase(t *testing.T) {
 			&helm.Options{
 				SetValues: map[string]string{
 					"database.import.url":                   testlib.IMPORT_ARCHIVE_URL,
-					"database.sm.resources.requests.cpu":    "500m",
-					"database.sm.resources.requests.memory": "1Gi",
-					"database.te.resources.requests.cpu":    "500m",
-					"database.te.resources.requests.memory": "1Gi",
+					"database.sm.resources.requests.cpu":    testlib.MINIMAL_VIABLE_ENGINE_CPU,
+					"database.sm.resources.requests.memory": testlib.MINIMAL_VIABLE_ENGINE_MEMORY,
+					"database.te.resources.requests.cpu":    testlib.MINIMAL_VIABLE_ENGINE_CPU,
+					"database.te.resources.requests.memory": testlib.MINIMAL_VIABLE_ENGINE_MEMORY,
 					"database.enableDaemonSet":              "true",
 					// prevent non-backup SM from scheduling
 					"database.sm.nodeSelectorNoHotCopyDS.inexistantTag": "required",

--- a/test/minikube/minikube_long_admin_test.go
+++ b/test/minikube/minikube_long_admin_test.go
@@ -1,48 +1,37 @@
-// +build long
+// +build short
 
 package minikube
 
 import (
 	"fmt"
-	"testing"
-	"time"
-
 	"github.com/nuodb/nuodb-helm-charts/test/testlib"
+	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/helm"
 )
 
-func TestKubernetesUpgradeAdmin(t *testing.T) {
+func TestKubernetesBasicAdminThreeReplicas(t *testing.T) {
 	testlib.AwaitTillerUp(t)
 
 	options := helm.Options{
-		SetValues: map[string]string{"nuodb.image.tag": "4.0"},
+		SetValues: map[string]string{"admin.replicas": "3"},
 	}
 
 	defer testlib.Teardown(testlib.TEARDOWN_ADMIN)
 
-	helmChartReleaseName, namespaceName := testlib.StartAdmin(t, &options, 1, "")
+	helmChartReleaseName, namespaceName := testlib.StartAdmin(t, &options, 3, "")
 
 	admin0 := fmt.Sprintf("%s-nuodb-0", helmChartReleaseName)
 	lbName := fmt.Sprintf("%s-nuodb-balancer", helmChartReleaseName)
 
-	testlib.AwaitBalancerTerminated(t, namespaceName, "job-lb-policy")
-
-	// all jobs need to be deleted before an upgrade can be performed
-	// so far we have not found an automated way to delete them as part of a pre-upgrade hook
-	// if we find it, this line can be removed and the test should still pass
-	testlib.DeletePod(t, namespaceName, "jobs/job-lb-policy-nearest")
-
-	upgradedOptions := &helm.Options{
-		SetValues: map[string]string{"nuodb.image.tag": "4.0.1"},
-	}
-
-	helm.Upgrade(t, upgradedOptions, testlib.ADMIN_HELM_CHART_PATH, helmChartReleaseName)
-
-	testlib.AwaitPodHasVersion(t, namespaceName, admin0, "docker.io/nuodb/nuodb-ce:4.0.1", 300*time.Second)
-	testlib.AwaitAdminPodUp(t, namespaceName, admin0, 300*time.Second)
-
 	t.Run("verifyAdminState", func(t *testing.T) { testlib.VerifyAdminState(t, namespaceName, admin0) })
+	t.Run("verifyOrderedLicensing", func(t *testing.T) {
+		testlib.VerifyLicenseIsCommunity(t, namespaceName, admin0)
+		testlib.VerifyLicensingErrorsInLog(t, namespaceName, admin0, false) // no error
+	})
 	t.Run("verifyLoadBalancer", func(t *testing.T) { verifyLoadBalancer(t, namespaceName, lbName) })
 	t.Run("verifyLBPolicy", func(t *testing.T) { verifyLBPolicy(t, namespaceName, admin0) })
+	t.Run("verifyPodKill", func(t *testing.T) { verifyPodKill(t, namespaceName, admin0, helmChartReleaseName, 3) })
+	t.Run("verifyProcessKill", func(t *testing.T) { verifyKillProcess(t, namespaceName, admin0, helmChartReleaseName, 3) })
+	t.Run("verifyAdminService", func(t *testing.T) { verifyAdminService(t, namespaceName, admin0) })
 }

--- a/test/minikube/minikube_long_admin_test.go
+++ b/test/minikube/minikube_long_admin_test.go
@@ -12,32 +12,6 @@ import (
 	"github.com/gruntwork-io/terratest/modules/helm"
 )
 
-func TestKubernetesBasicAdminThreeReplicas(t *testing.T) {
-	testlib.AwaitTillerUp(t)
-
-	options := helm.Options{
-		SetValues: map[string]string{"admin.replicas": "3"},
-	}
-
-	defer testlib.Teardown(testlib.TEARDOWN_ADMIN)
-
-	helmChartReleaseName, namespaceName := testlib.StartAdmin(t, &options, 3, "")
-
-	admin0 := fmt.Sprintf("%s-nuodb-0", helmChartReleaseName)
-	lbName := fmt.Sprintf("%s-nuodb-balancer", helmChartReleaseName)
-
-	t.Run("verifyAdminState", func(t *testing.T) { testlib.VerifyAdminState(t, namespaceName, admin0) })
-	t.Run("verifyOrderedLicensing", func(t *testing.T) {
-		testlib.VerifyLicenseIsCommunity(t, namespaceName, admin0)
-		testlib.VerifyLicensingErrorsInLog(t, namespaceName, admin0, false) // no error
-	})
-	t.Run("verifyLoadBalancer", func(t *testing.T) { verifyLoadBalancer(t, namespaceName, lbName) })
-	t.Run("verifyLBPolicy", func(t *testing.T) { verifyLBPolicy(t, namespaceName, admin0) })
-	t.Run("verifyPodKill", func(t *testing.T) { verifyPodKill(t, namespaceName, admin0, helmChartReleaseName, 3) })
-	t.Run("verifyProcessKill", func(t *testing.T) { verifyKillProcess(t, namespaceName, admin0, helmChartReleaseName, 3) })
-	t.Run("verifyAdminService", func(t *testing.T) { verifyAdminService(t, namespaceName, admin0) })
-}
-
 func TestKubernetesUpgradeAdmin(t *testing.T) {
 	testlib.AwaitTillerUp(t)
 
@@ -65,7 +39,7 @@ func TestKubernetesUpgradeAdmin(t *testing.T) {
 
 	helm.Upgrade(t, upgradedOptions, testlib.ADMIN_HELM_CHART_PATH, helmChartReleaseName)
 
-	testlib.AwaitAdminPodUpgraded(t, namespaceName, admin0, "docker.io/nuodb/nuodb-ce:4.0.1", 300*time.Second)
+	testlib.AwaitPodHasVersion(t, namespaceName, admin0, "docker.io/nuodb/nuodb-ce:4.0.1", 300*time.Second)
 	testlib.AwaitAdminPodUp(t, namespaceName, admin0, 300*time.Second)
 
 	t.Run("verifyAdminState", func(t *testing.T) { testlib.VerifyAdminState(t, namespaceName, admin0) })

--- a/test/minikube/minikube_rolling_upgrade_test.go
+++ b/test/minikube/minikube_rolling_upgrade_test.go
@@ -79,7 +79,7 @@ func TestKubernetesUpgradeFullDatabaseMinorVersion(t *testing.T) {
 		SetValues: map[string]string{
 			"database.sm.resources.requests.cpu":    testlib.MINIMAL_VIABLE_ENGINE_CPU,
 			"database.sm.resources.requests.memory": testlib.MINIMAL_VIABLE_ENGINE_MEMORY,
-			"database.te.resources.requests.cpu":    testlib.MINIMAL_VIABLE_ENGINE_CPU,
+			"database.te.resources.requests.cpu":    "250m", // during upgrade we will be running 2 of these
 			"database.te.resources.requests.memory": testlib.MINIMAL_VIABLE_ENGINE_MEMORY,
 			"nuodb.image.tag":                       OLD_RELEASE,
 		},

--- a/test/minikube/minikube_rolling_upgrade_test.go
+++ b/test/minikube/minikube_rolling_upgrade_test.go
@@ -1,0 +1,177 @@
+// +build long
+
+package minikube
+
+import (
+	"fmt"
+	"github.com/gruntwork-io/terratest/modules/helm"
+	"github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/nuodb/nuodb-helm-charts/test/testlib"
+	"gotest.tools/assert"
+	"strings"
+	"testing"
+	"time"
+)
+
+const OLD_RELEASE = "4.0"
+const NEW_RELEASE = "4.0.2"
+
+func verifyAllProcessesRunning(t *testing.T, namespaceName string, adminPod string, expectedNrProcesses int) {
+	testlib.Await(t, func() bool {
+		options := k8s.NewKubectlOptions("", "")
+		options.Namespace = namespaceName
+
+		output, err := k8s.RunKubectlAndGetOutputE(t, options, "exec", adminPod, "--", "nuocmd", "show", "domain")
+		assert.NilError(t, err, "verifyAllProcessesRunning: running show domain failed")
+
+		return strings.Count(output, "MONITORED:RUNNING") == expectedNrProcesses
+	}, 30*time.Second)
+}
+
+func TestKubernetesUpgradeAdminMinorVersion(t *testing.T) {
+	testlib.AwaitTillerUp(t)
+
+	options := helm.Options{
+		SetValues: map[string]string{"nuodb.image.tag": OLD_RELEASE},
+	}
+
+	defer testlib.Teardown(testlib.TEARDOWN_ADMIN)
+
+	helmChartReleaseName, namespaceName := testlib.StartAdmin(t, &options, 1, "")
+
+	admin0 := fmt.Sprintf("%s-nuodb-0", helmChartReleaseName)
+
+	testlib.AwaitBalancerTerminated(t, namespaceName, "job-lb-policy")
+
+	// all jobs need to be deleted before an upgrade can be performed
+	// so far we have not found an automated way to delete them as part of a pre-upgrade hook
+	// if we find it, this line can be removed and the test should still pass
+	testlib.DeletePod(t, namespaceName, "jobs/job-lb-policy-nearest")
+
+	options.SetValues["nuodb.image.tag"] = NEW_RELEASE
+
+	helm.Upgrade(t, &options, testlib.ADMIN_HELM_CHART_PATH, helmChartReleaseName)
+
+	testlib.AwaitPodHasVersion(t, namespaceName, admin0, fmt.Sprintf("docker.io/nuodb/nuodb-ce:%s", NEW_RELEASE), 300*time.Second)
+	testlib.AwaitAdminPodUp(t, namespaceName, admin0, 300*time.Second)
+
+	t.Run("verifyAdminState", func(t *testing.T) { testlib.VerifyAdminState(t, namespaceName, admin0) })
+}
+
+func TestKubernetesUpgradeFullDatabaseMinorVersion(t *testing.T) {
+	testlib.AwaitTillerUp(t)
+
+	options := helm.Options{
+		SetValues: map[string]string{
+			"nuodb.image.tag": OLD_RELEASE,
+		},
+	}
+
+	defer testlib.Teardown(testlib.TEARDOWN_ADMIN)
+
+	adminHelmChartReleaseName, namespaceName := testlib.StartAdmin(t, &options, 1, "")
+
+	admin0 := fmt.Sprintf("%s-nuodb-0", adminHelmChartReleaseName)
+
+	defer testlib.Teardown(testlib.TEARDOWN_DATABASE) // ensure resources allocated in called functions are released when this function exits
+
+	databaseOptions := helm.Options{
+		SetValues: map[string]string{
+			"database.sm.resources.requests.cpu":    testlib.MINIMAL_VIABLE_ENGINE_CPU,
+			"database.sm.resources.requests.memory": testlib.MINIMAL_VIABLE_ENGINE_MEMORY,
+			"database.te.resources.requests.cpu":    testlib.MINIMAL_VIABLE_ENGINE_CPU,
+			"database.te.resources.requests.memory": testlib.MINIMAL_VIABLE_ENGINE_MEMORY,
+			"nuodb.image.tag":                       OLD_RELEASE,
+		},
+	}
+
+	databaseHelmChartReleaseName := testlib.StartDatabase(t, namespaceName, admin0, &databaseOptions)
+
+
+	testlib.AwaitBalancerTerminated(t, namespaceName, "job-lb-policy")
+	// all jobs need to be deleted before an upgrade can be performed
+	// so far we have not found an automated way to delete them as part of a pre-upgrade hook
+	// if we find it, this line can be removed and the test should still pass
+	testlib.DeletePod(t, namespaceName, "jobs/job-lb-policy-nearest")
+
+	options.SetValues["nuodb.image.tag"] = NEW_RELEASE
+
+	// get the log before the restart
+	testlib.GetAppLog(t, namespaceName, admin0)
+
+	helm.Upgrade(t, &options, testlib.ADMIN_HELM_CHART_PATH, adminHelmChartReleaseName)
+
+	testlib.AwaitPodHasVersion(t, namespaceName, admin0, fmt.Sprintf("docker.io/nuodb/nuodb-ce:%s", NEW_RELEASE), 300*time.Second)
+	testlib.AwaitAdminPodUp(t, namespaceName, admin0, 300*time.Second)
+
+	t.Run("verifyAdminState", func(t *testing.T) { testlib.VerifyAdminState(t, namespaceName, admin0) })
+
+	t.Run("expectAllEnginesReconnect", func(t *testing.T) {
+		expectedNumberReconnects := 2
+
+		testlib.Await(t, func() bool {
+			return testlib.GetStringOccurenceInLog(t, namespaceName, admin0,
+				"Reconnected with process with connectKey") == expectedNumberReconnects
+		},30*time.Second )
+
+	})
+
+	t.Run("verifyAllProcessesRunning", func(t *testing.T) {
+		verifyAllProcessesRunning(t, namespaceName, admin0, 2)
+	})
+
+	databaseOptions.SetValues["nuodb.image.tag"] = NEW_RELEASE
+
+	helm.Upgrade(t, &databaseOptions, testlib.DATABASE_HELM_CHART_PATH, databaseHelmChartReleaseName)
+
+	testlib.AwaitPodTemplateHasVersion(t, namespaceName, "sm-database", fmt.Sprintf("docker.io/nuodb/nuodb-ce:%s", NEW_RELEASE), 300*time.Second)
+	testlib.AwaitPodTemplateHasVersion(t, namespaceName, "te-database", fmt.Sprintf("docker.io/nuodb/nuodb-ce:%s", NEW_RELEASE), 300*time.Second)
+
+	testlib.AwaitDatabaseUp(t, namespaceName, admin0, "demo", 2)
+
+	t.Run("verifyAllProcessesRunning2", func(t *testing.T) {
+		verifyAllProcessesRunning(t, namespaceName, admin0, 2)
+	})
+}
+
+func TestKubernetesRollingUpgradeAdminMinorVersion(t *testing.T) {
+	testlib.AwaitTillerUp(t)
+
+	options := helm.Options{
+		SetValues: map[string]string{
+			"admin.replicas": "3",
+			"nuodb.image.tag": OLD_RELEASE,
+		},
+	}
+
+	defer testlib.Teardown(testlib.TEARDOWN_ADMIN)
+
+	helmChartReleaseName, namespaceName := testlib.StartAdmin(t, &options, 3, "")
+
+	admin0 := fmt.Sprintf("%s-nuodb-0", helmChartReleaseName)
+	admin1 := fmt.Sprintf("%s-nuodb-0", helmChartReleaseName)
+	admin2 := fmt.Sprintf("%s-nuodb-0", helmChartReleaseName)
+
+	testlib.AwaitBalancerTerminated(t, namespaceName, "job-lb-policy")
+
+	// all jobs need to be deleted before an upgrade can be performed
+	// so far we have not found an automated way to delete them as part of a pre-upgrade hook
+	// if we find it, this line can be removed and the test should still pass
+	testlib.DeletePod(t, namespaceName, "jobs/job-lb-policy-nearest")
+
+	options.SetValues["nuodb.image.tag"] = NEW_RELEASE
+
+	helm.Upgrade(t, &options, testlib.ADMIN_HELM_CHART_PATH, helmChartReleaseName)
+
+	// the rolling upgrade is done in reverse order
+	testlib.AwaitPodHasVersion(t, namespaceName, admin2, fmt.Sprintf("docker.io/nuodb/nuodb-ce:%s", NEW_RELEASE), 300*time.Second)
+	testlib.AwaitAdminPodUp(t, namespaceName, admin2, 300*time.Second)
+
+	testlib.AwaitPodHasVersion(t, namespaceName, admin1, fmt.Sprintf("docker.io/nuodb/nuodb-ce:%s", NEW_RELEASE), 300*time.Second)
+	testlib.AwaitAdminPodUp(t, namespaceName, admin1, 300*time.Second)
+
+	testlib.AwaitPodHasVersion(t, namespaceName, admin0, fmt.Sprintf("docker.io/nuodb/nuodb-ce:%s", NEW_RELEASE), 300*time.Second)
+	testlib.AwaitAdminPodUp(t, namespaceName, admin0, 300*time.Second)
+
+	t.Run("verifyAdminState", func(t *testing.T) { testlib.VerifyAdminState(t, namespaceName, admin0) })
+}

--- a/test/minikube/minikube_tls_admin_test.go
+++ b/test/minikube/minikube_tls_admin_test.go
@@ -1,4 +1,4 @@
-// +build long
+// +build short
 
 package minikube
 
@@ -85,10 +85,10 @@ func TestKubernetesTLS(t *testing.T) {
 	t.Run("testDatabaseNoDirectEngineKeys", func(t *testing.T) {
 		// make a copy
 		localOptions := options
-		localOptions.SetValues["database.sm.resources.requests.cpu"] = "500m"
-		localOptions.SetValues["database.sm.resources.requests.memory"] = "1Gi"
-		localOptions.SetValues["database.te.resources.requests.cpu"] = "500m"
-		localOptions.SetValues["database.te.resources.requests.memory"] = "1Gi"
+		localOptions.SetValues["database.sm.resources.requests.cpu"] = testlib.MINIMAL_VIABLE_ENGINE_CPU
+		localOptions.SetValues["database.sm.resources.requests.memory"] = testlib.MINIMAL_VIABLE_ENGINE_MEMORY
+		localOptions.SetValues["database.te.resources.requests.cpu"] = testlib.MINIMAL_VIABLE_ENGINE_CPU
+		localOptions.SetValues["database.te.resources.requests.memory"] = testlib.MINIMAL_VIABLE_ENGINE_MEMORY
 
 		defer testlib.Teardown("database")
 
@@ -107,10 +107,10 @@ func TestKubernetesTLS(t *testing.T) {
 	t.Run("testDatabaseDirectEngineKeys", func(t *testing.T) {
 		// make a copy
 		localOptions := options
-		localOptions.SetValues["database.sm.resources.requests.cpu"] = "500m"
-		localOptions.SetValues["database.sm.resources.requests.memory"] = "1Gi"
-		localOptions.SetValues["database.te.resources.requests.cpu"] = "500m"
-		localOptions.SetValues["database.te.resources.requests.memory"] = "1Gi"
+		localOptions.SetValues["database.sm.resources.requests.cpu"] = testlib.MINIMAL_VIABLE_ENGINE_CPU
+		localOptions.SetValues["database.sm.resources.requests.memory"] = testlib.MINIMAL_VIABLE_ENGINE_MEMORY
+		localOptions.SetValues["database.te.resources.requests.cpu"] = testlib.MINIMAL_VIABLE_ENGINE_CPU
+		localOptions.SetValues["database.te.resources.requests.memory"] = testlib.MINIMAL_VIABLE_ENGINE_MEMORY
 
 		localOptions.SetValues["database.te.otherOptions.keystore"] = "/etc/nuodb/keys/nuoadmin.p12"
 		localOptions.SetValues["database.sm.otherOptions.keystore"] = "/etc/nuodb/keys/nuoadmin.p12"

--- a/test/minikube/minikube_tls_rotation_test.go
+++ b/test/minikube/minikube_tls_rotation_test.go
@@ -78,7 +78,6 @@ func TestKubernetesTLSRotation(t *testing.T) {
 	//   we need to use persistence for admin Raft logs during the rolling upgrade.
 	options := helm.Options{
 		SetValues: map[string]string{
-			"admin.persistence.enabled":             "true",
 			"admin.replicas":                        "3",
 			"admin.tlsCACert.secret":                testlib.CA_CERT_SECRET,
 			"admin.tlsCACert.key":                   testlib.CA_CERT_FILE,
@@ -90,10 +89,10 @@ func TestKubernetesTLSRotation(t *testing.T) {
 			"admin.tlsTrustStore.password":          testlib.SECRET_PASSWORD,
 			"admin.tlsClientPEM.secret":             testlib.NUOCMD_SECRET,
 			"admin.tlsClientPEM.key":                testlib.NUOCMD_FILE,
-			"database.sm.resources.requests.cpu":    "500m",
-			"database.sm.resources.requests.memory": "500Mi",
-			"database.te.resources.requests.cpu":    "500m",
-			"database.te.resources.requests.memory": "500Mi",
+			"database.sm.resources.requests.cpu":    testlib.MINIMAL_VIABLE_ENGINE_CPU,
+			"database.sm.resources.requests.memory": testlib.MINIMAL_VIABLE_ENGINE_MEMORY,
+			"database.te.resources.requests.cpu":    testlib.MINIMAL_VIABLE_ENGINE_CPU,
+			"database.te.resources.requests.memory": testlib.MINIMAL_VIABLE_ENGINE_MEMORY,
 		},
 	}
 

--- a/test/minikube/minikube_tls_rotation_test.go
+++ b/test/minikube/minikube_tls_rotation_test.go
@@ -91,7 +91,7 @@ func TestKubernetesTLSRotation(t *testing.T) {
 			"admin.tlsClientPEM.key":                testlib.NUOCMD_FILE,
 			"database.sm.resources.requests.cpu":    testlib.MINIMAL_VIABLE_ENGINE_CPU,
 			"database.sm.resources.requests.memory": testlib.MINIMAL_VIABLE_ENGINE_MEMORY,
-			"database.te.resources.requests.cpu":    testlib.MINIMAL_VIABLE_ENGINE_CPU,
+			"database.te.resources.requests.cpu":    "250m", // during upgrade we will be running 2 of these
 			"database.te.resources.requests.memory": testlib.MINIMAL_VIABLE_ENGINE_MEMORY,
 		},
 	}

--- a/test/testlib/constants.go
+++ b/test/testlib/constants.go
@@ -34,3 +34,6 @@ const THP_HELM_CHART_PATH = "../../stable/transparent-hugepage"
 
 const LAST_BACKUP_PREFIX string = "nuodb-backup/last_created"
 const IMPORT_ARCHIVE_URL = "http://download.nuohub.org/ce_releases/restore.bak.tz"
+
+const MINIMAL_VIABLE_ENGINE_CPU = "500m"
+const MINIMAL_VIABLE_ENGINE_MEMORY = "500Mi"

--- a/test/testlib/minikube_utilities.go
+++ b/test/testlib/minikube_utilities.go
@@ -223,12 +223,33 @@ func AwaitAdminPodUp(t *testing.T, namespace string, adminPodName string, timeou
 	AwaitPodStatus(t, namespace, adminPodName, corev1.PodReady, corev1.ConditionTrue, timeout)
 }
 
-func AwaitAdminPodUpgraded(t *testing.T, namespace string, adminPodName string, expectedVersion string, timeout time.Duration) {
+
+func AwaitPodTemplateHasVersion(t *testing.T, namespace string, podNameTemplate string, expectedVersion string, timeout time.Duration) {
 	options := k8s.NewKubectlOptions("", "")
 	options.Namespace = namespace
 
 	Await(t, func() bool {
-		pod := k8s.GetPod(t, options, adminPodName)
+		podName := GetPodName(t, namespace, podNameTemplate)
+
+		pod := k8s.GetPod(t, options, podName)
+
+		for _, container := range pod.Spec.Containers {
+			t.Logf("Found container (%s) with image: %s", container.Name, container.Image)
+			if container.Image == expectedVersion {
+				return true
+			}
+		}
+
+		return false
+	}, timeout)
+}
+
+func AwaitPodHasVersion(t *testing.T, namespace string, podName string, expectedVersion string, timeout time.Duration) {
+	options := k8s.NewKubectlOptions("", "")
+	options.Namespace = namespace
+
+	Await(t, func() bool {
+		pod := k8s.GetPod(t, options, podName)
 
 		for _, container := range pod.Spec.Containers {
 			t.Logf("Found container (%s) with image: %s", container.Name, container.Image)
@@ -275,13 +296,13 @@ func AwaitAdminFullyConnected(t *testing.T, namespace string, podName string, nu
 		"--timeout", "300")
 }
 
-func AwaitDatabaseUp(t *testing.T, namespace string, podName string, databaseName string) {
+func AwaitDatabaseUp(t *testing.T, namespace string, podName string, databaseName string, numProcesses int) {
 	options := k8s.NewKubectlOptions("", "")
 	options.Namespace = namespace
 
 	k8s.RunKubectl(t, options, "exec", podName, "--", "nuocmd", "check", "database",
 		"--db-name", databaseName, "--check-running", "--check-liveness", "20",
-		"--num-processes", "2",
+		"--num-processes", strconv.Itoa(numProcesses),
 		"--timeout", "300")
 }
 
@@ -326,6 +347,16 @@ func VerifyLicensingErrorsInLog(t *testing.T, namespace string, podName string, 
 	fullLog := string(buf)
 
 	assert.Equal(t, expectError, strings.Contains(fullLog, "Unable to verify license"), fullLog)
+}
+
+func GetStringOccurenceInLog(t *testing.T, namespace string, podName string, expectedLogLine string) int {
+	buf, err := ioutil.ReadAll(getAppLogStream(t, namespace, podName))
+	assert.NilError(t, err)
+
+	fullLog := string(buf)
+
+	return strings.Count(fullLog, expectedLogLine)
+
 }
 
 func VerifyCertificateInLog(t *testing.T, namespace string, podName string, expectedLogLine string) {

--- a/test/testlib/nuodb_database_utilities.go
+++ b/test/testlib/nuodb_database_utilities.go
@@ -63,3 +63,10 @@ func StartDatabase(t *testing.T, namespaceName string, adminPod string, options 
 
 	return
 }
+
+func ShutdownDatabase(t *testing.T, namespace string, dbName string, podName string) {
+	options := k8s.NewKubectlOptions("", "")
+	options.Namespace = namespace
+
+	k8s.RunKubectl(t, options, "exec", podName, "--", "nuocmd", "shutdown", "database", "--db-name", dbName)
+}

--- a/test/testlib/secrets.go
+++ b/test/testlib/secrets.go
@@ -101,7 +101,7 @@ func CreateSecret(t *testing.T, namespaceName string, certName string, secretNam
 	assert.NilError(t, err)
 
 	k8s.KubectlApplyFromString(t, kubectlOptions, secretString)
-	AddTeardown(TEARDOWN_SECRETS, func() { k8s.KubectlDeleteFromString(t, kubectlOptions, secretString) })
+	AddTeardown(TEARDOWN_SECRETS, func() { k8s.KubectlDeleteFromStringE(t, kubectlOptions, secretString) })
 
 	fields := []string{certName}
 	verifySecretFields(t, namespaceName, secretName, fields...)
@@ -120,7 +120,7 @@ func CreateSecretWithPassword(t *testing.T, namespaceName string, certName strin
 	assert.NilError(t, err)
 
 	k8s.KubectlApplyFromString(t, kubectlOptions, secretString)
-	AddTeardown(TEARDOWN_SECRETS, func() { k8s.KubectlDeleteFromString(t, kubectlOptions, secretString) })
+	AddTeardown(TEARDOWN_SECRETS, func() { k8s.KubectlDeleteFromStringE(t, kubectlOptions, secretString) })
 
 	fields := []string{certName, "password"}
 	verifySecretFields(t, namespaceName, secretName, fields...)

--- a/test/testlib/tls.go
+++ b/test/testlib/tls.go
@@ -43,7 +43,7 @@ func createTLSGeneratorPod(t *testing.T, namespaceName string, image string, tim
 	kubectlOptions.Namespace = namespaceName
 
 	k8s.KubectlApplyFromString(t, kubectlOptions, podTemplateString)
-	AddTeardown(TEARDOWN_SECRETS, func() { k8s.KubectlDeleteFromString(t, kubectlOptions, podTemplateString) })
+	AddTeardown(TEARDOWN_SECRETS, func() { k8s.KubectlDeleteFromStringE(t, kubectlOptions, podTemplateString) })
 
 	AwaitPodStatus(t, namespaceName, podName, corev1.PodReady, corev1.ConditionTrue, timeout)
 
@@ -115,7 +115,7 @@ func GenerateTLSConfiguration(t *testing.T, namespaceName string, commands []str
 }
 
 func RotateTLSCertificates(t *testing.T, options *helm.Options,
-	kubectlOptions *k8s.KubectlOptions, adminReleaseName string, databaseReleaseName string, tlsKeysLocation string) {
+	kubectlOptions *k8s.KubectlOptions, adminReleaseName string, databaseReleaseName string, tlsKeysLocation string, helmUpgrade bool) {
 
 	adminReplicaCount, err := strconv.Atoi(options.SetValues["admin.replicas"])
 	assert.NilError(t, err, "Unable to find/convert admin.replicas value")
@@ -127,16 +127,24 @@ func RotateTLSCertificates(t *testing.T, options *helm.Options,
 		"--alias", "ca_prime", "--cert", "/tmp/"+CA_CERT_FILE_NEW, "--timeout", "60")
 	assert.NilError(t, err, "add trusted-certificate failed")
 
-	// Upgrade admin release
-	DeletePod(t, namespaceName, "jobs/job-lb-policy-nearest")
-	helm.Upgrade(t, options, ADMIN_HELM_CHART_PATH, adminReleaseName)
+	if helmUpgrade == true {
+		// Upgrade admin release
+		DeletePod(t, namespaceName, "jobs/job-lb-policy-nearest")
+		helm.Upgrade(t, options, ADMIN_HELM_CHART_PATH, adminReleaseName)
 
-	adminStatefulSet := fmt.Sprintf("%s-nuodb", adminReleaseName)
-	k8s.RunKubectl(t, kubectlOptions, "rollout", "status", "sts/"+adminStatefulSet, "--timeout", "300s")
-	AwaitAdminFullyConnected(t, namespaceName, admin0, adminReplicaCount)
+		adminStatefulSet := fmt.Sprintf("%s-nuodb", adminReleaseName)
+		k8s.RunKubectl(t, kubectlOptions, "rollout", "status", "sts/"+adminStatefulSet, "--timeout", "300s")
+		AwaitAdminFullyConnected(t, namespaceName, admin0, adminReplicaCount)
 
-	// Upgrade database release
-	helm.Upgrade(t, options, DATABASE_HELM_CHART_PATH, databaseReleaseName)
-
+		// Upgrade database release
+		helm.Upgrade(t, options, DATABASE_HELM_CHART_PATH, databaseReleaseName)
+	} else {
+		// Rolling upgrade could take a lot of time due to readiness probes.
+		// Faster approach will be to restart all PODs. A prerequsite for this 
+		// is to have the same secrets update before hand.
+		k8s.RunKubectl(t, kubectlOptions, "delete", "pod", "--selector=domain=nuodb")
+		AwaitPodPhase(t, namespaceName, admin0, corev1.PodRunning, 60*time.Second)
+		AwaitAdminFullyConnected(t, namespaceName, admin0, adminReplicaCount)
+	}
 	AwaitDatabaseUp(t, namespaceName, admin0, "demo", 2)
 }

--- a/test/testlib/tls.go
+++ b/test/testlib/tls.go
@@ -138,5 +138,5 @@ func RotateTLSCertificates(t *testing.T, options *helm.Options,
 	// Upgrade database release
 	helm.Upgrade(t, options, DATABASE_HELM_CHART_PATH, databaseReleaseName)
 
-	AwaitDatabaseUp(t, namespaceName, admin0, "demo")
+	AwaitDatabaseUp(t, namespaceName, admin0, "demo", 2)
 }


### PR DESCRIPTION
remove `admin.persistence.enabled` and make the persistent mode the default. This matches the settings in the database layer (no database.sm.persistence.enabled) exists and it the safe/reasonable default

Add a readiness probe to the engine layer. It makes sure that the process is fully up (seen from the admin layer) before it is marked as READY.

Add small integration tests for the probe.

Add upgrade tests and rolling upgrade tests. These show the readiness probe the best. A deployment/statefulset only restarts one engine before it proceeds with the next.

Refactor a few tests. Move some of the smaller tests back into `short` to rebalance the short vs long runs. Both are now around 30 min.