### PR TITLE
[DB-29147] Fix admin chart lb-policy job to avoid creating dead jobs at startup.

### DIFF
--- a/stable/admin/files/waitscript
+++ b/stable/admin/files/waitscript
@@ -1,9 +1,3 @@
 #!/usr/bin/env bash
 
-: ${TIMEOUT:=300}
-
-count = 0
-if ! nuocmd --api-server ${NUOCMD_API_SERVER} check servers --check-active --check-connected --check-leader --timeout ${TIMEOUT} ; then
-    echo "ERROR: nuocmd check server failed; admin not up"
-    exit 1
-fi
+nuocmd --api-server ${NUOCMD_API_SERVER} check servers --check-active --check-connected --check-leader --wait-forever


### PR DESCRIPTION
**Changes**

Change the admin lb-policy job to `--wait-forever` instead of polling loop to avoid a hailstorm of dead job objects when Admin is coming up.

Thanks, Dirk Butson, for the great feedback and patch!!!

**Testing Performed**

Test on GKE.
