### PR TITLE
Downgrade to Helm v2.9.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ env:
     - TEST_SUITE=minikube-short REQUIRES_MINIKUBE=true
     - TEST_SUITE=minikube-long REQUIRES_MINIKUBE=true
   global:
-    - HELM_VERSION="v2.14.3"
+    - HELM_VERSION="v2.9.0"
     - DEP_VERSION=0.5.4
     - KUBERNETES_VERSION=1.15.0
     - MINIKUBE_VERSION=1.2.0

--- a/scripts/ci/determine_and_run_tests.sh
+++ b/scripts/ci/determine_and_run_tests.sh
@@ -6,7 +6,7 @@ if [[ $TEST_SUITE = "basic"  ]]; then
   ./test/test_suite.sh
   go test -timeout 10m -v ./test/integration
 elif [[ $TEST_SUITE = "minikube-short"  ]]; then
-  go test -timeout 30m -v ./test/minikube -tags=short
+  go test -timeout 35m -v ./test/minikube -tags=short
 elif [[ $TEST_SUITE = "minikube-long"  ]]; then
-  go test -timeout 30m -v ./test/minikube -tags=long
+  go test -timeout 35m -v ./test/minikube -tags=long
 fi

--- a/scripts/ci/install_deps.sh
+++ b/scripts/ci/install_deps.sh
@@ -23,7 +23,8 @@ sudo chown -R travis: /home/travis/.minikube/
 kubectl cluster-info
 
 # install helm
-helm init
+# Use default K8s service account as a workaround explained in https://github.com/helm/helm/issues/3460
+helm init --service-account default
 
 # get the image to speed up tests
 docker pull nuodb/nuodb-ce:latest

--- a/scripts/ci/install_deps.sh
+++ b/scripts/ci/install_deps.sh
@@ -4,7 +4,7 @@
 curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v"${KUBERNETES_VERSION}"/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
 
 # Download Helm and Tiller
-wget http://storage.googleapis.com/kubernetes-helm/helm-"${HELM_VERSION}"-linux-amd64.tar.gz -O /tmp/helm.tar.gz
+wget https://get.helm.sh/helm-"${HELM_VERSION}"-linux-amd64.tar.gz -O /tmp/helm.tar.gz
 tar xzf /tmp/helm.tar.gz -C /tmp --strip-components=1 && chmod +x /tmp/helm && sudo mv /tmp/helm /usr/local/bin
 
 if [[ -z "$REQUIRES_MINIKUBE" ]]; then

--- a/stable/admin/Chart.yaml
+++ b/stable/admin/Chart.yaml
@@ -13,4 +13,4 @@ maintainers:
 engine: gotpl
 icon: https://www.nuodb.com/sites/all/themes/nuodb/logo.svg
 appVersion: 4.0.0
-tillerVersion: ">=2.10"
+tillerVersion: ">=2.9"

--- a/stable/backup/Chart.yaml
+++ b/stable/backup/Chart.yaml
@@ -14,4 +14,4 @@ maintainers:
 engine: gotpl
 icon: https://www.nuodb.com/sites/all/themes/nuodb/logo.svg
 appVersion: 4.0.0
-tillerVersion: ">=2.10"
+tillerVersion: ">=2.9"

--- a/stable/database/Chart.yaml
+++ b/stable/database/Chart.yaml
@@ -13,4 +13,4 @@ maintainers:
 engine: gotpl
 icon: https://www.nuodb.com/sites/all/themes/nuodb/logo.svg
 appVersion: 4.0.0
-tillerVersion: ">=2.10"
+tillerVersion: ">=2.9"

--- a/stable/demo-ycsb/Chart.yaml
+++ b/stable/demo-ycsb/Chart.yaml
@@ -13,4 +13,4 @@ maintainers:
 engine: gotpl
 icon: https://www.nuodb.com/sites/all/themes/nuodb/logo.svg
 appVersion: 4.0.0
-tillerVersion: ">=2.10"
+tillerVersion: ">=2.9"

--- a/stable/monitoring-influx/Chart.yaml
+++ b/stable/monitoring-influx/Chart.yaml
@@ -13,4 +13,4 @@ maintainers:
 engine: gotpl
 icon: https://www.nuodb.com/sites/all/themes/nuodb/logo.svg
 appVersion: 4.0.0
-tillerVersion: ">=2.10"
+tillerVersion: ">=2.9"

--- a/stable/monitoring-insights/Chart.yaml
+++ b/stable/monitoring-insights/Chart.yaml
@@ -13,4 +13,4 @@ maintainers:
 engine: gotpl
 icon: https://www.nuodb.com/sites/all/themes/nuodb/logo.svg
 appVersion: 4.0.0
-tillerVersion: ">=2.10"
+tillerVersion: ">=2.9"

--- a/stable/restore/Chart.yaml
+++ b/stable/restore/Chart.yaml
@@ -14,4 +14,4 @@ maintainers:
 engine: gotpl
 icon: https://www.nuodb.com/sites/all/themes/nuodb/logo.svg
 appVersion: 4.0.0
-tillerVersion: ">=2.10"
+tillerVersion: ">=2.9"

--- a/stable/storage-class/Chart.yaml
+++ b/stable/storage-class/Chart.yaml
@@ -13,4 +13,4 @@ maintainers:
 engine: gotpl
 icon: https://www.nuodb.com/sites/all/themes/nuodb/logo.svg
 appVersion: 4.0.0
-tillerVersion: ">=2.10"
+tillerVersion: ">=2.9"

--- a/stable/transparent-hugepage/Chart.yaml
+++ b/stable/transparent-hugepage/Chart.yaml
@@ -14,4 +14,4 @@ maintainers:
 engine: gotpl
 icon: https://www.nuodb.com/sites/all/themes/nuodb/logo.svg
 appVersion: 4.0.0
-tillerVersion: ">=2.10"
+tillerVersion: ">=2.9"

--- a/test/files/thp-affinity.yaml
+++ b/test/files/thp-affinity.yaml
@@ -1,6 +1,8 @@
-nodeAffinity:
-  requiredDuringSchedulingIgnoredDuringExecution:
-    nodeSelectorTerms:
-      - matchExpressions:
-          - key: failure-domain.beta.kubernetes.io/zone
-            operator: Exists
+thp:
+  affinity: |
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: failure-domain.beta.kubernetes.io/zone
+                operator: Exists

--- a/test/minikube/minikube_base_thp_test.go
+++ b/test/minikube/minikube_base_thp_test.go
@@ -58,7 +58,7 @@ func scheduleLabel(t *testing.T, helmChartPath string, namespaceName string) {
 	daemonName := fmt.Sprintf("%s-%s", "transparent-hugepage", randomSuffix)
 
 	options := &helm.Options{
-		ValuesFiles: []string{"thp.affinity": "../files/thp-affinity.yaml"},
+		ValuesFiles: []string{"../files/thp-affinity.yaml"},
 		SetValues:   map[string]string{"thp.fullnameOverride": daemonName},
 	}
 
@@ -82,7 +82,7 @@ func scheduleLabelMismatch(t *testing.T, helmChartPath string, namespaceName str
 	daemonName := fmt.Sprintf("%s-%s", "transparent-hugepage", randomSuffix)
 
 	options := &helm.Options{
-		ValuesFiles: []string{"thp.affinity": "../files/thp-affinity.yaml"},
+		ValuesFiles: []string{"../files/thp-affinity.yaml"},
 		SetValues:   map[string]string{"thp.fullnameOverride": daemonName},
 	}
 

--- a/test/minikube/minikube_base_thp_test.go
+++ b/test/minikube/minikube_base_thp_test.go
@@ -58,8 +58,8 @@ func scheduleLabel(t *testing.T, helmChartPath string, namespaceName string) {
 	daemonName := fmt.Sprintf("%s-%s", "transparent-hugepage", randomSuffix)
 
 	options := &helm.Options{
-		SetFiles:  map[string]string{"thp.affinity": "../files/thp-affinity.yaml"},
-		SetValues: map[string]string{"thp.fullnameOverride": daemonName},
+		ValuesFiles: []string{"thp.affinity": "../files/thp-affinity.yaml"},
+		SetValues:   map[string]string{"thp.fullnameOverride": daemonName},
 	}
 
 	kubectlOptions := k8s.NewKubectlOptions("", "")
@@ -82,8 +82,8 @@ func scheduleLabelMismatch(t *testing.T, helmChartPath string, namespaceName str
 	daemonName := fmt.Sprintf("%s-%s", "transparent-hugepage", randomSuffix)
 
 	options := &helm.Options{
-		SetFiles:  map[string]string{"thp.affinity": "../files/thp-affinity.yaml"},
-		SetValues: map[string]string{"thp.fullnameOverride": daemonName},
+		ValuesFiles: []string{"thp.affinity": "../files/thp-affinity.yaml"},
+		SetValues:   map[string]string{"thp.fullnameOverride": daemonName},
 	}
 
 	kubectlOptions := k8s.NewKubectlOptions("", "")


### PR DESCRIPTION
**Changes**
- Downgrade all Helm charts to Helm 2.9
- Update testing framework so that all Minikube tests are performed with Helm 2.9.0 

**Why**
- Main driver for this is [DB-29168] helm version 2.9 compatibility request