### PR TITLE
[DB-29171] Feature request for user provided environment variables for database chart

### DIFF
--- a/stable/database/README.md
+++ b/stable/database/README.md
@@ -229,7 +229,8 @@ The following tables list the configurable parameters of the `database` chart an
 | `securityContext.runAsUser` | User ID for the container | `1000` |
 | `securityContext.fsGroup` | Group ID for the container | `1000` |
 | `securityContext.capabilities` | Enable capabilities for the container - disregards `securityContext.enabled` | `[]` |
-| `env.from` | Import ENV vars from configMap(s) | `[]` |
+| `env` | Import ENV vars inside containers | `[]` |
+| `envFrom` | Import ENV vars from configMap(s) | `[]` |
 | `persistence.accessModes` | Volume access modes enabled (must match capabilities of the storage class) | `ReadWriteOnce` |
 | `persistence.size` | Amount of disk space allocated for database archive storage | `20Gi` |
 | `persistence.storageClass` | Storage class for volume backing database archive storage | `-` |

--- a/stable/database/templates/_helpers.tpl
+++ b/stable/database/templates/_helpers.tpl
@@ -143,3 +143,13 @@ envFrom:
 {{ toYaml . -}}
 {{- end -}}
 {{- end -}}
+
+
+{{/*
+Import user defined ENV vars
+*/}}
+{{- define "database.env" }}
+{{- if not (empty .Values.database.env) }}
+{{ toYaml .Values.database.env }}
+{{- end }}
+{{- end -}}

--- a/stable/database/templates/_helpers.tpl
+++ b/stable/database/templates/_helpers.tpl
@@ -150,6 +150,6 @@ Import user defined ENV vars
 */}}
 {{- define "database.env" }}
 {{- if not (empty .Values.database.env) }}
-{{ toYaml .Values.database.env }}
+{{ toYaml .Values.database.env | trim }}
 {{- end }}
 {{- end -}}

--- a/stable/database/templates/daemonset.yaml
+++ b/stable/database/templates/daemonset.yaml
@@ -104,6 +104,7 @@ spec:
         - { name: NUOCMD_API_SERVER,   value: "{{ template "admin.address" . }}:8888" }
         - { name: PEER_ADDRESS,        value: "{{ template "admin.address" . }}" }
         - { name: NUDOB_ARCHIVEDIR,    value: "/var/opt/nuodb/archive/${NODE_NAME}" }
+{{- include "database.env" . | indent 8 }}
     {{- if .Values.admin.tlsKeyStore }}
       {{- if .Values.admin.tlsKeyStore.password }}
         - { name: NUODOCKER_KEYSTORE_PASSWORD,    value: {{ .Values.admin.tlsKeyStore.password | quote }} }
@@ -297,6 +298,7 @@ spec:
         - { name: PEER_ADDRESS,        value: "{{ template "admin.address" . }}" }
         - { name: NUDOB_ARCHIVEDIR,    value: "/var/opt/nuodb/archive/${NODE_NAME}" }
         - { name: NUODB_IMPORT_STRIP_LEVELS, value: "{{ default "1" .Values.database.import.stripLevels }}"}
+{{- include "database.env" . | indent 8 }}
     {{- if .Values.admin.tlsKeyStore }}
       {{- if .Values.admin.tlsKeyStore.password }}
         - { name: NUODOCKER_KEYSTORE_PASSWORD,    value: {{ .Values.admin.tlsKeyStore.password | quote }} }

--- a/stable/database/templates/deployment.yaml
+++ b/stable/database/templates/deployment.yaml
@@ -77,6 +77,7 @@ spec:
           - { name: DB_NAME,             value: {{ .Values.database.name | quote }} }
           - { name: NUOCMD_API_SERVER,   value: "{{ template "admin.address" . }}:8888" }
           - { name: PEER_ADDRESS,        value: "{{ template "admin.address" . }}" }
+{{- include "database.env" . | indent 10 }}
       {{- if .Values.admin.tlsKeyStore }}
         {{- if .Values.admin.tlsKeyStore.password }}
           - { name: NUODOCKER_KEYSTORE_PASSWORD,    value: {{ .Values.admin.tlsKeyStore.password | quote }} }

--- a/stable/database/templates/deploymentconfig.yaml
+++ b/stable/database/templates/deploymentconfig.yaml
@@ -76,6 +76,7 @@ spec:
         - { name: DB_NAME,             value: {{ .Values.database.name | quote }} }
         - { name: NUOCMD_API_SERVER,   value: "{{ template "admin.address" . }}:8888" }
         - { name: PEER_ADDRESS,        value: "{{ template "admin.address" . }}" }
+{{- include "database.env" . | indent 8 }}
     {{- if .Values.admin.tlsKeyStore }}
       {{- if .Values.admin.tlsKeyStore.password }}
         - { name: NUODOCKER_KEYSTORE_PASSWORD,    value: {{ .Values.admin.tlsKeyStore.password | quote }} }

--- a/stable/database/templates/statefulset.yaml
+++ b/stable/database/templates/statefulset.yaml
@@ -122,6 +122,7 @@ spec:
         - { name: NUODB_DOMAIN,        value: "{{ .Values.admin.domain }}" }
         - { name: NUOCMD_API_SERVER,   value: "{{ template "admin.address" . }}:8888" }
         - { name: PEER_ADDRESS,        value: "{{ template "admin.address" . }}" }
+{{- include "database.env" . | indent 8 }}
     {{- if .Values.admin.tlsKeyStore }}
       {{- if .Values.admin.tlsKeyStore.password }}
         - { name: NUODOCKER_KEYSTORE_PASSWORD,    value: {{ .Values.admin.tlsKeyStore.password | quote }} }
@@ -369,6 +370,7 @@ spec:
         - { name: NUODB_DOMAIN,        value: "{{ .Values.admin.domain }}" }
         - { name: NUOCMD_API_SERVER,   value: "{{ template "admin.address" . }}:8888" }
         - { name: PEER_ADDRESS,        value: "{{ template "admin.address" . }}" }
+{{- include "database.env" . | indent 8 }}
     {{- if .Values.admin.tlsKeyStore }}
       {{- if .Values.admin.tlsKeyStore.password }}
         - { name: NUODOCKER_KEYSTORE_PASSWORD,    value: {{ .Values.admin.tlsKeyStore.password | quote }} }

--- a/stable/database/values.yaml
+++ b/stable/database/values.yaml
@@ -103,6 +103,12 @@ database:
     runAsUser: 1000
     fsGroup: 1000
 
+  ## Import Environment Variables inside containers
+  # List of EnvVar v1 core definitions
+  # ref: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#envvar-v1-core
+  ##
+  env: []
+
   ## Import Environment Variables from one or more configMaps
   # Ex: from: [ configMapRef: { name: myConfigMap }, configMapRef: { name: myOtherConfigMap } ]
   ##

--- a/test/files/database-env.yaml
+++ b/test/files/database-env.yaml
@@ -1,0 +1,7 @@
+database:
+  env:
+    - name: NUODB_ALT_ADDRESS
+      valueFrom:
+        fieldRef:
+            fieldPath: status.podIP
+    - { name: CUSTOM_ENV_VAR, value: "CUSTOM_ENV_VAR_VALUE" }

--- a/test/testlib/minikube_utilities.go
+++ b/test/testlib/minikube_utilities.go
@@ -1,6 +1,7 @@
 package testlib
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -76,12 +77,12 @@ func standardizeSpaces(s string) string {
 
 func RemoveEmptyLines(s string) string {
 	regex, err := regexp.Compile("(\r|\r\n|\n){2,}")
-    if err != nil {
-        return s
-    }
-    s = regex.ReplaceAllString(s, "\n")
+	if err != nil {
+		return s
+	}
+	s = regex.ReplaceAllString(s, "\n")
 	s = strings.TrimRight(s, "\n")
-	
+
 	return s
 }
 
@@ -219,7 +220,6 @@ func AwaitPodPhase(t *testing.T, namespace string, podName string, phase corev1.
 func AwaitAdminPodUp(t *testing.T, namespace string, adminPodName string, timeout time.Duration) {
 	AwaitPodStatus(t, namespace, adminPodName, corev1.PodReady, corev1.ConditionTrue, timeout)
 }
-
 
 func AwaitPodTemplateHasVersion(t *testing.T, namespace string, podNameTemplate string, expectedVersion string, timeout time.Duration) {
 	options := k8s.NewKubectlOptions("", "")
@@ -534,4 +534,16 @@ func ExecuteCommandsInPod(t *testing.T, podName string, namespaceName string, co
 	assert.NilError(t, err, "executeCommandsInPod: Script returned error.")
 }
 
+func UnmarshalJSONObject(t *testing.T, stringJSON string) map[string]interface{} {
+	var results map[string]interface{}
+	err := json.Unmarshal([]byte(stringJSON), &results)
+	assert.NilError(t, err)
+	return results
+}
 
+func UnmarshalJSONArray(t *testing.T, stringJSON string) []interface{} {
+	var results []interface{}
+	err := json.Unmarshal([]byte(stringJSON), &results)
+	assert.NilError(t, err)
+	return results
+}

--- a/test/testlib/template_utilities.go
+++ b/test/testlib/template_utilities.go
@@ -1,0 +1,15 @@
+package testlib
+
+import (
+	"strings"
+
+	appsv1 "k8s.io/api/apps/v1"
+)
+
+func IsStatefulSetHotCopyEnabled(ss *appsv1.StatefulSet) bool {
+	return strings.Contains(ss.Name, "hotcopy")
+}
+
+func IsDaemonSetHotCopyEnabled(ss *appsv1.DaemonSet) bool {
+	return strings.Contains(ss.Name, "hotcopy")
+}


### PR DESCRIPTION
**Changes**
- Implement feature which will allow users to pass custom environment variables definition to NuoDB database engines.

**General usage**
User can provide any list of `EnvVar` objects from v1 core definitions (Ref: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#envvar-v1-core)
Example values.yml:
```
database:
  env:
    - name: NODE_NAME
       valueFrom:
         fieldRef:
           fieldPath: spec.nodeName
    - { name: USER_VAR_2,  value: "USER_VAR_2_VALUE" }
...
```
As a result the variables will be exposed in database engine containers for internal use.

**Use case**
The feature is not limited to the 
Export POD IP address as an environment variable and use it to configure `--alt-address` engine option.
```
database:
  env:
    - name: NUODB_ALT_ADDRESS
      valueFrom:
        fieldRef:
          fieldPath: status.podIP
...
  sm:
    engineOptions:
      alt-address: $(NUODB_ALT_ADDRESS)
...
  te:
    engineOptions:
      alt-address: $(NUODB_ALT_ADDRESS)
...
```
As a result, all database engines will be configured with --alt-address option which corresponds to the POD IP address.

**Testing Performed**
- database chart integration tests
- database chart functional tests for general feature usage
- database chart functional tests for the above use case

**Notes**
`nuosm` and `nuote` scripts don't read  `NUODB_ALT_ADDRESS` environment variable, hence, we still need to pass the `alt-address` option via `engineOptions`.