### PR TITLE
Fix nuocmd get values issue caused by DB-28889

### DIFF
--- a/test/minikube/minikube_base_database_test.go
+++ b/test/minikube/minikube_base_database_test.go
@@ -161,11 +161,11 @@ func backupDatabase(t *testing.T, namespaceName string, podName string, database
 	backupName := fmt.Sprintf("%s/%s", testlib.LAST_BACKUP_PREFIX, databaseName)
 	backupset, err := k8s.RunKubectlAndGetOutputE(t, options.KubectlOptions,
 		"exec", podName, "--",
-		"nuocmd", "get", "value",
-		"--key", backupName,
+		"nuodocker", "get", "current-backup",
+		"--db-name", backupName,
 	)
 
-	assert.NilError(t, err, "Error running: nuocmd get value --key ", backupName)
+	assert.NilError(t, err, "Error running: nuodocker get current-backup --db-name ", backupName)
 	assert.Check(t, backupset != "")
 }
 

--- a/test/minikube/minikube_base_database_test.go
+++ b/test/minikube/minikube_base_database_test.go
@@ -162,10 +162,10 @@ func backupDatabase(t *testing.T, namespaceName string, podName string, database
 	backupset, err := k8s.RunKubectlAndGetOutputE(t, options.KubectlOptions,
 		"exec", podName, "--",
 		"nuodocker", "get", "current-backup",
-		"--db-name", backupName,
+		"--db-name", databaseName,
 	)
 
-	assert.NilError(t, err, "Error running: nuodocker get current-backup --db-name ", backupName)
+	assert.NilError(t, err, "Error running: nuodocker get current-backup --db-name ", databaseName)
 	assert.Check(t, backupset != "")
 }
 

--- a/test/minikube/minikube_base_database_test.go
+++ b/test/minikube/minikube_base_database_test.go
@@ -158,7 +158,6 @@ func backupDatabase(t *testing.T, namespaceName string, podName string, database
 	testlib.AwaitPodPhase(t, namespaceName, backupJob, corev1.PodSucceeded, 120*time.Second)
 
 	// verify that the backup has been documented by the Admin layer
-	backupName := fmt.Sprintf("%s/%s", testlib.LAST_BACKUP_PREFIX, databaseName)
 	backupset, err := k8s.RunKubectlAndGetOutputE(t, options.KubectlOptions,
 		"exec", podName, "--",
 		"nuodocker", "get", "current-backup",


### PR DESCRIPTION
DB-28889 changes the kv key for, update test to handle it using nuodocker instead of nuocmd