### PR TITLE
Ac/backup restore fixes

### DIFF
--- a/stable/database/templates/configmap.yaml
+++ b/stable/database/templates/configmap.yaml
@@ -67,8 +67,8 @@ data:
   NUODB_RESTORE_REQUEST_PREFIX: {{ default "/nuodb/nuosm/database" .Values.nuodb.requestKey }}
   NUODB_LATEST_BACKUP_PREFIX: {{ default "nuodb-backup/last_created" .Values.nuodb.latestPrefix }}
   NUODB_BACKUP_KEY: {{ default "/nuodb/nuobackup" .Values.nuodb.latestKey }}
-  NUODB_AUTO_IMPORT: {{ .Values.database.autoImport.source }}
-  NUODB_AUTO_RESTORE: {{ .Values.database.autoRestore.source }}
+  NUODB_AUTO_IMPORT: {{ default "" .Values.database.autoImport.source | quote}}
+  NUODB_AUTO_RESTORE: {{ default "" .Values.database.autoRestore.source | quote}}
   NUODB_OS_USER: {{ include "os.user" . | quote }}
   NUODB_OS_GROUP: {{ include "os.group" . | quote }}
 ---

--- a/stable/database/templates/statefulset.yaml
+++ b/stable/database/templates/statefulset.yaml
@@ -313,7 +313,7 @@ spec:
       initContainers:
       - name: init-disk
         image: {{ template "init.image" . }}
-        imagePullPolicy: {{ default "" .Values.busyboximagepullPolicy | quote }}
+        imagePullPolicy: {{ default "" .Values.busybox.image.pullPolicy | quote }}
         command: ['chmod' , '770', '/var/opt/nuodb/archive', 'var/opt/nuodb/backup', '/var/log/nuodb']
         volumeMounts:
         - name: archive-volume


### PR DESCRIPTION
- Fix unquoted strings produced by autoRestore and autoImport sources,  which cause helm template / kubectl apply (and ArgoCD Sync) to fail.

For some reason helm install is unaffected.