### PR TITLE
add SFTP autoImport

### DIFF
--- a/stable/database/files/nuosm
+++ b/stable/database/files/nuosm
@@ -272,15 +272,30 @@ if [ -n "$restore_source" -a -z "$restore_requested" -a ! -f $DB_DIR/1.atm ]; th
 
   # if the NUODB_IMPORT_URL has a protocol:/ prefix, then use curl to download the archive
   if [ -n "$( echo $restore_source | grep '^[a-z]\+:/[^ ]\+')" ]; then
-   
-    echo "curl -k --user '**' $restore_source | tar xzf - --strip-components $strip_levels -C $DB_DIR"
-    curl -k --user "$restore_credentials" $restore_source | tar xzf - --strip-components $strip_levels -C $DB_DIR
+
+    # define the download directory depending on the type of source
+    if [ $NUODB_AUTO_IMPORT_TYPE = "backupset" ]; then
+      # It is a restore so switch the download to somewhere temporary available on all SMs (it will be removed later)
+      auto_restore_download_dir="${NUODB_ARCHIVEDIR}/${NUODB_DOMAIN}/$(basename $restore_source .tar.gz)-downloaded"
+      mkdir $auto_restore_download_dir
+    else
+      auto_restore_download_dir=$DB_DIR
+    fi
+    
+    # download the source
+    echo "curl -k --user '**' $restore_source | tar xzf - --strip-components $strip_levels -C $auto_restore_download_dir"
+    curl -k --user "$restore_credentials" $restore_source | tar xzf - --strip-components $strip_levels -C $auto_restore_download_dir
 
     chown -R $(echo "${NUODB_OS_USER:-1000}:${NUODB_OS_GROUP:-0}" | tr -d '"') $DB_DIR
 
     [ -n "$NUODB_DEBUG" ] && ls -l $DB_DIR
-
-    nuodocker --api-server $NUOCMD_API_SERVER restore archive --origin-dir $DB_DIR --restore-dir $DB_DIR --db-name $DB_NAME --clean-metadata
+    
+    # if it was a backupset, proceed as for a restore, otherwise its an archive
+    if [ $NUODB_AUTO_IMPORT_TYPE = "backupset" ]; then
+      set -- --restore-from-dir "$auto_restore_download_dir" "$@"
+    else
+      nuodocker --api-server $NUOCMD_API_SERVER restore archive --origin-dir $DB_DIR --restore-dir $DB_DIR --db-name $DB_NAME --clean-metadata
+    fi
 
     #ls -l $DB_DIR
   elif [ -d "$NUODB_BACKUPDIR/$restore_source" ]; then
@@ -300,4 +315,9 @@ if [ -n "${NUODB_OPTIONS}" ] ; then
     exec nuodocker start sm --archive-dir "${DB_DIR}" --dba-user "${DB_USER}" --dba-password "${DB_PASSWORD}" --db-name "${DB_NAME}" --options "${NUODB_OPTIONS}" "$@"
 else
     exec nuodocker start sm --archive-dir "${DB_DIR}" --dba-user "${DB_USER}" --dba-password "${DB_PASSWORD}" --db-name "${DB_NAME}" "$@"
+fi
+
+# clean up the temporary download directory
+if [ $NUODB_AUTO_IMPORT_TYPE = "backupset" ]; then
+  rm -rf $auto_restore_download_dir
 fi

--- a/stable/database/files/nuosm
+++ b/stable/database/files/nuosm
@@ -276,7 +276,7 @@ if [ -n "$restore_source" -a -z "$restore_requested" -a ! -f $DB_DIR/1.atm ]; th
     # define the download directory depending on the type of source
     if [ $NUODB_AUTO_IMPORT_TYPE = "backupset" ]; then
       # It is a restore so switch the download to somewhere temporary available on all SMs (it will be removed later)
-      auto_restore_download_dir="${NUODB_ARCHIVEDIR}/${NUODB_DOMAIN}/$(basename $restore_source .tar.gz)-downloaded"
+      auto_restore_download_dir="${NUODB_ARCHIVEDIR}/${NUODB_DOMAIN}/$(basename $restore_source ..${restore_source#*.})-downloaded"
       mkdir $auto_restore_download_dir
     else
       auto_restore_download_dir=$DB_DIR

--- a/stable/database/files/nuosm
+++ b/stable/database/files/nuosm
@@ -150,6 +150,7 @@ if [ "$myArchive" != "-1" ]; then
   elif [ -n "$NUODB_AUTO_RESTORE" ]; then
     restore_source="$NUODB_AUTO_RESTORE"
     restore_credentials=${DATABASE_RESTORE_CREDENTIALS:-:}
+    restore_type=${NUODB_AUTO_RESTORE_TYPE}
     strip_levels=${NUODB_RESTORE_STRIP_LEVELS:-1}
   fi
 
@@ -157,6 +158,7 @@ if [ "$myArchive" != "-1" ]; then
 elif [ -n "$NUODB_AUTO_IMPORT" -a ! -f $DB_DIR/1.atm ]; then
   restore_source="$NUODB_AUTO_IMPORT"
   restore_credentials=${DATABASE_IMPORT_CREDENTIALS:-:}
+  restore_type=${NUODB_AUTO_IMPORT_TYPE}
   strip_levels=${NUODB_IMPORT_STRIP_LEVELS:-1}
 fi
 
@@ -274,31 +276,35 @@ if [ -n "$restore_source" -a -z "$restore_requested" -a ! -f $DB_DIR/1.atm ]; th
   if [ -n "$( echo $restore_source | grep '^[a-z]\+:/[^ ]\+')" ]; then
 
     # define the download directory depending on the type of source
-    if [ $NUODB_AUTO_IMPORT_TYPE = "backupset" ]; then
-      # It is a restore so switch the download to somewhere temporary available on all SMs (it will be removed later)
-      auto_restore_download_dir=$(basename $restore_source)
-      auto_restore_download_dir="${NUODB_ARCHIVEDIR}/${NUODB_DOMAIN}/$(basename $auto_restore_download_dir .${auto_restore_download_dir#*.})-downloaded"
-      mkdir $auto_restore_download_dir
+    if [ "$restore_type" = "stream" ]; then
+      auto_download_dir=$DB_DIR
     else
-      auto_restore_download_dir=$DB_DIR
+      # It is a backupset so switch the download to somewhere temporary available on all SMs (it will be removed later)
+      # This will also run if TYPE has a mistake since it works for either type, but will be less efficient.
+      auto_download_dir=$(basename $restore_source)
+      auto_download_dir="${NUODB_ARCHIVEDIR}/${NUODB_DOMAIN}/$(basename $auto_download_dir .${auto_download_dir#*.})-downloaded"
+      mkdir $auto_download_dir
     fi
     
     # download the source
-    echo "curl -k --user '**' $restore_source | tar xzf - --strip-components $strip_levels -C $auto_restore_download_dir"
-    curl -k --user "$restore_credentials" $restore_source | tar xzf - --strip-components $strip_levels -C $auto_restore_download_dir
+    echo "curl -k --user '**' $restore_source | tar xzf - --strip-components $strip_levels -C $auto_download_dir"
+    curl -k --user "$restore_credentials" $restore_source | tar xzf - --strip-components $strip_levels -C $auto_download_dir
 
     chown -R $(echo "${NUODB_OS_USER:-1000}:${NUODB_OS_GROUP:-0}" | tr -d '"') $DB_DIR
 
     [ -n "$NUODB_DEBUG" ] && ls -l $DB_DIR
     
-    # if it was a backupset, proceed as for a restore, otherwise its an archive
-    if [ $NUODB_AUTO_IMPORT_TYPE = "backupset" ]; then
-      set -- --restore-from-dir "$auto_restore_download_dir" "$@"
-    else
-      nuodocker --api-server $NUOCMD_API_SERVER restore archive --origin-dir $DB_DIR --restore-dir $DB_DIR --db-name $DB_NAME --clean-metadata
+    # restore and/or fix the metadata
+    nuodocker --api-server $NUOCMD_API_SERVER restore archive --origin-dir $auto_download_dir --restore-dir $DB_DIR --db-name $DB_NAME --clean-metadata
+    
+    if [ "$auto_download_dir" != "$DB_DIR" ]; then
+      echo "removing $auto_download_dir"
+      rm -rf $auto_download_dir
     fi
 
-    #ls -l $DB_DIR
+    # completely delete my previous archive metadata
+    [ $myArchive -ge 0 ] && $NUOCMD delete archive --archive-id $myArchive --purge
+
   elif [ -d "$NUODB_BACKUPDIR/$restore_source" ]; then
     # NUODB_IMPORT_URL has no protocol - so just append the --restore-from-dir option
     set -- --restore-from-dir "$NUODB_BACKUPDIR/$restore_source" "$@"
@@ -316,9 +322,4 @@ if [ -n "${NUODB_OPTIONS}" ] ; then
     exec nuodocker start sm --archive-dir "${DB_DIR}" --dba-user "${DB_USER}" --dba-password "${DB_PASSWORD}" --db-name "${DB_NAME}" --options "${NUODB_OPTIONS}" "$@"
 else
     exec nuodocker start sm --archive-dir "${DB_DIR}" --dba-user "${DB_USER}" --dba-password "${DB_PASSWORD}" --db-name "${DB_NAME}" "$@"
-fi
-
-# clean up the temporary download directory
-if [ $NUODB_AUTO_IMPORT_TYPE = "backupset" ]; then
-  rm -rf $auto_restore_download_dir
 fi

--- a/stable/database/files/nuosm
+++ b/stable/database/files/nuosm
@@ -276,7 +276,8 @@ if [ -n "$restore_source" -a -z "$restore_requested" -a ! -f $DB_DIR/1.atm ]; th
     # define the download directory depending on the type of source
     if [ $NUODB_AUTO_IMPORT_TYPE = "backupset" ]; then
       # It is a restore so switch the download to somewhere temporary available on all SMs (it will be removed later)
-      auto_restore_download_dir="${NUODB_ARCHIVEDIR}/${NUODB_DOMAIN}/$(basename $restore_source ..${restore_source#*.})-downloaded"
+      auto_restore_download_dir=basename $restore_source
+      auto_restore_download_dir="${NUODB_ARCHIVEDIR}/${NUODB_DOMAIN}/$(basename $auto_restore_download_dir .${auto_restore_download_dir#*.})-downloaded"
       mkdir $auto_restore_download_dir
     else
       auto_restore_download_dir=$DB_DIR

--- a/stable/database/files/nuosm
+++ b/stable/database/files/nuosm
@@ -261,11 +261,13 @@ if [ -n "$restore_requested" -a -n "$restore_source" ]; then
   nuodocker --api-server $NUOCMD_API_SERVER restore archive --origin-dir $DB_DIR --restore-dir $DB_DIR --db-name $DB_NAME --clean-metadata
 
   # completely delete my previous archive metadata
+  # this is required because nuodocker always creates a new archive
   [ $myArchive -ge 0 ] && $NUOCMD delete archive --archive-id $myArchive --purge
 
 fi
 
 # release my archive if it is locked
+# this will likely never execute but has been left in for completeness
 locked_archive=$( $NUOCMD show archives --db-name $DB_NAME --removed --removed-archive-format "archive-id: {id}" | sed -En "/^archive-id: / {N; /$HOSTNAME/ s/^archive-id: ([0-9]+).*$/\1/; T; p}" | head -n 1 )
 [ -n "$locked_archive" ] && $NUOCMD create archive --db-name $DB_NAME --archive-path $DB_DIR --is-external --restored --archive-id $locked_archive
 
@@ -302,13 +304,12 @@ if [ -n "$restore_source" -a -z "$restore_requested" -a ! -f $DB_DIR/1.atm ]; th
       rm -rf $auto_download_dir
     fi
 
-    # completely delete my previous archive metadata
-    [ $myArchive -ge 0 ] && $NUOCMD delete archive --archive-id $myArchive --purge
-
   elif [ -d "$NUODB_BACKUPDIR/$restore_source" ]; then
     # NUODB_IMPORT_URL has no protocol - so just append the --restore-from-dir option
     set -- --restore-from-dir "$NUODB_BACKUPDIR/$restore_source" "$@"
   fi
+  # completely delete my previous archive metadata
+  [ $myArchive -ge 0 ] && $NUOCMD delete archive --archive-id $myArchive --purge
 fi
 
 # release the first-in semaphore

--- a/stable/database/files/nuosm
+++ b/stable/database/files/nuosm
@@ -276,7 +276,7 @@ if [ -n "$restore_source" -a -z "$restore_requested" -a ! -f $DB_DIR/1.atm ]; th
     # define the download directory depending on the type of source
     if [ $NUODB_AUTO_IMPORT_TYPE = "backupset" ]; then
       # It is a restore so switch the download to somewhere temporary available on all SMs (it will be removed later)
-      auto_restore_download_dir=basename $restore_source
+      auto_restore_download_dir=$(basename $restore_source)
       auto_restore_download_dir="${NUODB_ARCHIVEDIR}/${NUODB_DOMAIN}/$(basename $auto_restore_download_dir .${auto_restore_download_dir#*.})-downloaded"
       mkdir $auto_restore_download_dir
     else

--- a/stable/database/templates/configmap.yaml
+++ b/stable/database/templates/configmap.yaml
@@ -67,8 +67,9 @@ data:
   NUODB_RESTORE_REQUEST_PREFIX: {{ default "/nuodb/nuosm/database" .Values.nuodb.requestKey }}
   NUODB_LATEST_BACKUP_PREFIX: {{ default "nuodb-backup/last_created" .Values.nuodb.latestPrefix }}
   NUODB_BACKUP_KEY: {{ default "/nuodb/nuobackup" .Values.nuodb.latestKey }}
-  NUODB_AUTO_IMPORT: {{ .Values.database.autoImport.source }}
-  NUODB_AUTO_RESTORE: {{ .Values.database.autoRestore.source }}
+  NUODB_AUTO_IMPORT: {{ default "" .Values.database.autoImport.source | quote}}
+  NUODB_AUTO_IMPORT_TYPE: {{ default "stream" .Values.database.autoImport.type | quote}}
+  NUODB_AUTO_RESTORE: {{ default "" .Values.database.autoRestore.source | quote}}
   NUODB_OS_USER: {{ include "os.user" . | quote }}
   NUODB_OS_GROUP: {{ include "os.group" . | quote }}
 ---

--- a/stable/database/templates/configmap.yaml
+++ b/stable/database/templates/configmap.yaml
@@ -70,6 +70,7 @@ data:
   NUODB_AUTO_IMPORT: {{ default "" .Values.database.autoImport.source | quote }}
   NUODB_AUTO_IMPORT_TYPE: {{ default "stream" .Values.database.autoImport.type | quote }}
   NUODB_AUTO_RESTORE: {{ default "" .Values.database.autoRestore.source | quote }}
+  NUODB_AUTO_RESTORE_TYPE: {{ default "stream" .Values.database.autoRestore.type | quote }}
   NUODB_OS_USER: {{ include "os.user" . | quote }}
   NUODB_OS_GROUP: {{ include "os.group" . | quote }}
 ---

--- a/stable/database/templates/statefulset.yaml
+++ b/stable/database/templates/statefulset.yaml
@@ -313,7 +313,7 @@ spec:
       initContainers:
       - name: init-disk
         image: {{ template "init.image" . }}
-        imagePullPolicy: {{ default "" .Values.busyboximagepullPolicy | quote }}
+        imagePullPolicy: {{ default "" .Values.busybox.image.pullPolicy | quote }}
         command: ['chmod' , '770', '/var/opt/nuodb/archive', 'var/opt/nuodb/backup', '/var/log/nuodb']
         volumeMounts:
         - name: archive-volume

--- a/stable/database/values.yaml
+++ b/stable/database/values.yaml
@@ -151,7 +151,6 @@ database:
     type: ""
 
   # ensure all values here are strings - so quote any purely numeric values
-  # source should be a tar.gz
   autoRestore:
     source: ""
     credentials: ""

--- a/stable/database/values.yaml
+++ b/stable/database/values.yaml
@@ -142,12 +142,16 @@ database:
     #   verbose error,flush,warn
 
   # ensure all values here are strings - so quote any purely numeric values
+  # source should be a tar.gz or an already local backupset.
+  # type either stream or backupset
   autoImport:
     source: ""
     credentials: ""
     stripLevels: "1"
+    type: ""
 
   # ensure all values here are strings - so quote any purely numeric values
+  # source should be a tar.gz
   autoRestore:
     source: ""
     credentials: ""

--- a/stable/database/values.yaml
+++ b/stable/database/values.yaml
@@ -155,6 +155,7 @@ database:
     source: ""
     credentials: ""
     stripLevels: "1"
+    type: ""
 
   sm:
     # Settings for storage manager (SM) nodes with hotcopy enabled.

--- a/stable/restore/files/nuorestore
+++ b/stable/restore/files/nuorestore
@@ -79,4 +79,4 @@ if [ "$restore_type" = "database" ]; then
    [ "$auto" = "true" ] && nuocmd --api-server $NUOCMD_API_SERVER shutdown database --db-name $db_name
 fi
 
-echo "Restore chart completed"
+echo "Restore job completed"

--- a/stable/restore/files/nuorestore
+++ b/stable/restore/files/nuorestore
@@ -78,3 +78,5 @@ if [ "$restore_type" = "database" ]; then
    # optionally do automatic initiation of the restore
    [ "$auto" = "true" ] && nuocmd --api-server $NUOCMD_API_SERVER shutdown database --db-name $db_name
 fi
+
+echo "Restore chart completed"


### PR DESCRIPTION
- New value for autoImport.type
- Comments in values for valid values, also specifying we expect .tar.gz
- New configmap entry for above type
- Config map is already included automatically in the statefulset via templates and env:
- Added switch between download backupset to different location and download archive to DB location
- Added switch to restore if it was a backupset
- Added delete of temporary download if it was a backupset
- Fix restore chart failing when using autoRestart=false
- Add support for autoRestore.type

Tested with a rancher deployment in all combinations of stream and backupset between autorestore and autoimport