### PR TITLE
add k8s event log to tests

### DIFF
--- a/test/testlib/constants.go
+++ b/test/testlib/constants.go
@@ -51,3 +51,5 @@ var INCARNATION_PATTERN *regexp.Regexp
 func init() {
 	INCARNATION_PATTERN = regexp.MustCompile(INCARNATION_REGEX)
 }
+
+const K8s_EVENT_LOG_FILE = "kubernetes_event.log"

--- a/test/testlib/nuodb_admin_utilities.go
+++ b/test/testlib/nuodb_admin_utilities.go
@@ -42,7 +42,10 @@ func StartAdmin(t *testing.T, options *helm.Options, replicaCount int, namespace
 		callerName := getFunctionCallerName()
 		namespaceName = fmt.Sprintf("%s-%s", strings.ToLower(callerName), randomSuffix)
 		k8s.CreateNamespace(t, kubectlOptions, namespaceName)
-		AddTeardown(TEARDOWN_ADMIN, func() { k8s.DeleteNamespace(t, kubectlOptions, namespaceName) })
+		AddTeardown(TEARDOWN_ADMIN, func() {
+			GetK8sEventLog(t, namespaceName)
+			k8s.DeleteNamespace(t, kubectlOptions, namespaceName)
+		})
 	} else {
 		namespaceName = namespace
 	}
@@ -51,7 +54,9 @@ func StartAdmin(t *testing.T, options *helm.Options, replicaCount int, namespace
 
 	helm.Install(t, options, helmChartPath, helmChartReleaseName)
 
-	AddTeardown("admin", func() { helm.Delete(t, options, helmChartReleaseName, true) })
+	AddTeardown("admin", func() {
+		helm.Delete(t, options, helmChartReleaseName, true)
+	})
 
 	AwaitNrReplicasScheduled(t, namespaceName, helmChartReleaseName, replicaCount)
 


### PR DESCRIPTION
Debugging some issues requires the k8s event log. It enables each developer to see what events have happened on the k8s level.

This is a requirement for understanding why we see `'delete database' failed`.

This code uses the K8s client, rather than kubectl to bypass output to the test log.