### PR TITLE
Add TE/SM Log to the Unit Tests

### DIFF
--- a/test/minikube/minikube_base_admin_test.go
+++ b/test/minikube/minikube_base_admin_test.go
@@ -107,7 +107,7 @@ func TestKubernetesBasicNameOverride(t *testing.T) {
 	// first await could be pulling the image from the repo
 	testlib.AwaitAdminPodUp(t, namespaceName, admin0, 300*time.Second)
 
-	defer testlib.GetAppLog(t, namespaceName, admin0)
+	defer testlib.GetAppLog(t, namespaceName, admin0, "")
 
 	t.Run("verifyAdminState", func(t *testing.T) { testlib.VerifyAdminState(t, namespaceName, admin0) })
 }

--- a/test/minikube/minikube_base_database_test.go
+++ b/test/minikube/minikube_base_database_test.go
@@ -383,55 +383,65 @@ func TestKubernetesRestoreDatabase(t *testing.T) {
 
 	admin0 := fmt.Sprintf("%s-nuodb-cluster0-0", helmChartReleaseName)
 
-	t.Run("startDatabaseStatefulSet", func(t *testing.T) {
-		defer testlib.Teardown(testlib.TEARDOWN_DATABASE)
-		databaseOptions := helm.Options{
-			SetValues: map[string]string{
-				"database.name":                         "demo",
-				"database.sm.resources.requests.cpu":    testlib.MINIMAL_VIABLE_ENGINE_CPU,
-				"database.sm.resources.requests.memory": testlib.MINIMAL_VIABLE_ENGINE_MEMORY,
-				"database.te.resources.requests.cpu":    testlib.MINIMAL_VIABLE_ENGINE_CPU,
-				"database.te.resources.requests.memory": testlib.MINIMAL_VIABLE_ENGINE_MEMORY,
-				"backup.persistence.enabled":            "true",
-				"backup.persistence.size":               "1Gi",
-			},
-		}
+	defer testlib.Teardown(testlib.TEARDOWN_DATABASE)
+	databaseOptions := helm.Options{
+		SetValues: map[string]string{
+			"database.name":                         	"demo",
+			"database.sm.resources.requests.cpu":    	testlib.MINIMAL_VIABLE_ENGINE_CPU,
+			"database.sm.resources.requests.memory": 	testlib.MINIMAL_VIABLE_ENGINE_MEMORY,
+			"database.te.resources.requests.cpu":    	testlib.MINIMAL_VIABLE_ENGINE_CPU,
+			"database.te.resources.requests.memory": 	testlib.MINIMAL_VIABLE_ENGINE_MEMORY,
+			"backup.persistence.enabled":            	"true",
+			"backup.persistence.size":               	"1Gi",
+			"database.te.engineOptions.verbose":		"error\\,flush\\,warn\\,debug\\,index",
+			"database.sm.engineOptions.verbose":		"error\\,flush\\,warn\\,debug\\,index",
+		},
+	}
 
-		testlib.StartDatabase(t, namespaceName, admin0, &databaseOptions)
+	databaseChartName := testlib.StartDatabase(t, namespaceName, admin0, &databaseOptions)
 
-		opts := k8s.NewKubectlOptions("", "")
-		opts.Namespace = namespaceName
-		databaseOptions.KubectlOptions = opts
+	opts := k8s.NewKubectlOptions("", "")
+	opts.Namespace = namespaceName
+	databaseOptions.KubectlOptions = opts
 
-		// wait for the initial backup to complete
-		databaseName := "demo"
-		backupJob := fmt.Sprintf("hotcopy-%s-job-initial-", databaseName)
-		testlib.AwaitPodPhase(t, namespaceName, backupJob, corev1.PodSucceeded, 120*time.Second)
+	// wait for the initial backup to complete
+	databaseName := "demo"
+	backupJob := fmt.Sprintf("hotcopy-%s-job-initial-", databaseName)
+	testlib.AwaitPodPhase(t, namespaceName, backupJob, corev1.PodSucceeded, 120*time.Second)
 
-		// populate some data
-		k8s.RunKubectl(t, opts,
-			"exec", admin0, "--",
-			"/opt/nuodb/bin/nuosql",
-			"--user", "dba",
-			"--password", "secret",
-			"demo",
-			"--file", "/opt/nuodb/samples/quickstart/sql/create-db.sql",
-		)
+	// populate some data
+	k8s.RunKubectl(t, opts,
+		"exec", admin0, "--",
+		"/opt/nuodb/bin/nuosql",
+		"--user", "dba",
+		"--password", "secret",
+		"demo",
+		"--file", "/opt/nuodb/samples/quickstart/sql/create-db.sql",
+	)
 
-		// verify that the database contains the populated data
-		tables, err := testlib.RunSQL(t, namespaceName, admin0, "demo", "show schema User")
-		assert.NilError(t, err, "error running SQL: show schema User")
-		assert.Check(t, strings.Contains(tables, "HOCKEY"), "tables returned: ", tables)
+	// verify that the database contains the populated data
+	tables, err := testlib.RunSQL(t, namespaceName, admin0, "demo", "show schema User")
+	assert.NilError(t, err, "error running SQL: show schema User")
+	assert.Check(t, strings.Contains(tables, "HOCKEY"), "tables returned: ", tables)
 
-		// restore database
-		defer testlib.Teardown(testlib.TEARDOWN_RESTORE)
-		restoreDatabase(t, namespaceName, admin0, &databaseOptions)
+	opt := testlib.GetExtractedOptions(&databaseOptions)
+	tePodNameTemplate := fmt.Sprintf("te-%s-nuodb-%s-%s", databaseChartName, opt.ClusterName, opt.DbName)
+	smPodName := fmt.Sprintf("sm-%s-nuodb-%s-%s", databaseChartName, opt.ClusterName, opt.DbName)
 
-		// verify that the database does NOT contain the data from AFTER the backup
-		tables, err = testlib.RunSQL(t, namespaceName, admin0, "demo", "show schema User")
-		assert.NilError(t, err, "error running SQL: show schema User")
-		assert.Check(t, strings.Contains(tables, "No tables found in schema "), "Show schema returned: ", tables)
-	})
+	tePodName := testlib.GetPodName(t, namespaceName, tePodNameTemplate)
+	testlib.GetAppLog(t, namespaceName, tePodName, "_pre-restart")
+
+	smPodName0 := testlib.GetPodName(t, namespaceName, smPodName)
+	testlib.GetAppLog(t, namespaceName, smPodName0, "_pre-restart")
+
+	// restore database
+	defer testlib.Teardown(testlib.TEARDOWN_RESTORE)
+	restoreDatabase(t, namespaceName, admin0, &databaseOptions)
+
+	// verify that the database does NOT contain the data from AFTER the backup
+	tables, err = testlib.RunSQL(t, namespaceName, admin0, "demo", "show schema User")
+	assert.NilError(t, err, "error running SQL: show schema User")
+	assert.Check(t, strings.Contains(tables, "No tables found in schema "), "Show schema returned: ", tables)
 }
 
 func TestKubernetesImportDatabase(t *testing.T) {

--- a/test/minikube/minikube_base_database_test.go
+++ b/test/minikube/minikube_base_database_test.go
@@ -393,8 +393,6 @@ func TestKubernetesRestoreDatabase(t *testing.T) {
 			"database.te.resources.requests.memory": 	testlib.MINIMAL_VIABLE_ENGINE_MEMORY,
 			"backup.persistence.enabled":            	"true",
 			"backup.persistence.size":               	"1Gi",
-			"database.te.engineOptions.verbose":		"error\\,flush\\,warn\\,debug\\,index",
-			"database.sm.engineOptions.verbose":		"error\\,flush\\,warn\\,debug\\,index",
 		},
 	}
 

--- a/test/minikube/minikube_rolling_upgrade_test.go
+++ b/test/minikube/minikube_rolling_upgrade_test.go
@@ -99,7 +99,7 @@ func TestKubernetesUpgradeFullDatabaseMinorVersion(t *testing.T) {
 	options.SetValues["nuodb.image.tag"] = NEW_RELEASE
 
 	// get the log before the restart
-	testlib.GetAppLog(t, namespaceName, admin0)
+	testlib.GetAppLog(t, namespaceName, admin0, "")
 
 	helm.Upgrade(t, &options, testlib.ADMIN_HELM_CHART_PATH, adminHelmChartReleaseName)
 

--- a/test/minikube/minikube_tls_admin_test.go
+++ b/test/minikube/minikube_tls_admin_test.go
@@ -96,7 +96,7 @@ func TestKubernetesTLS(t *testing.T) {
 
 		tePodNameTemplate := fmt.Sprintf("te-%s", databaseReleaseName)
 		tePodName := testlib.GetPodName(t, namespaceName, tePodNameTemplate)
-		defer testlib.GetAppLog(t, namespaceName, tePodName)
+		defer testlib.GetAppLog(t, namespaceName, tePodName, "")
 
 		// TE certificate is signed by the admin and the DN entry is the pod name
 		// this is the 4th pod name because: #0 and #1 are trusted certs, #2 is CA, #3 is admin, #4 is engine
@@ -121,7 +121,7 @@ func TestKubernetesTLS(t *testing.T) {
 
 		tePodNameTemplate := fmt.Sprintf("te-%s", databaseReleaseName)
 		tePodName := testlib.GetPodName(t, namespaceName, tePodNameTemplate)
-		defer testlib.GetAppLog(t, namespaceName, tePodName)
+		defer testlib.GetAppLog(t, namespaceName, tePodName, "")
 
 		// TE certificate is not signed by the admin and the DN entry is the generic admin name
 		// this is the 3rd pod name because: #0 and #1 are trusted certs, #2 is CA, #3 is admin (and engine)

--- a/test/testlib/minikube_utilities.go
+++ b/test/testlib/minikube_utilities.go
@@ -515,9 +515,9 @@ func GetK8sEventLog(t *testing.T, namespace string) {
 
 }
 
-func GetAppLog(t *testing.T, namespace string, podName string) {
+func GetAppLog(t *testing.T, namespace string, podName string, fileNameSuffix string) {
 	dirPath := filepath.Join(RESULT_DIR, namespace)
-	filePath := filepath.Join(dirPath, podName)
+	filePath := filepath.Join(dirPath, podName+fileNameSuffix)
 
 	_ = os.MkdirAll(dirPath, 0700)
 

--- a/test/testlib/nuodb_admin_utilities.go
+++ b/test/testlib/nuodb_admin_utilities.go
@@ -65,7 +65,7 @@ func StartAdmin(t *testing.T, options *helm.Options, replicaCount int, namespace
 
 		// first await could be pulling the image from the repo
 		AwaitAdminPodUp(t, namespaceName, adminName, 300*time.Second)
-		AddTeardown("admin", func() { GetAppLog(t, namespaceName, adminName) })
+		AddTeardown("admin", func() { GetAppLog(t, namespaceName, adminName, "") })
 	}
 
 	for i := 0; i < replicaCount; i++ {

--- a/test/testlib/nuodb_database_utilities.go
+++ b/test/testlib/nuodb_database_utilities.go
@@ -80,10 +80,15 @@ func StartDatabase(t *testing.T, namespaceName string, adminPod string, options 
 	AwaitNrReplicasScheduled(t, namespaceName, tePodNameTemplate, opt.NrTePods)
 	AwaitNrReplicasScheduled(t, namespaceName, smPodName, opt.NrSmPods)
 
+	// NOTE: the Teardown logic will pick a TE/SM that is running during teardown time. Not the TE/SM that was running originally
+	// this is relevant for any tests that restart TEs/SMs
+
 	tePodName := GetPodName(t, namespaceName, tePodNameTemplate)
+	AddTeardown(TEARDOWN_DATABASE, func() { GetAppLog(t, namespaceName, GetPodName(t, namespaceName, tePodNameTemplate), "")})
 	AwaitPodStatus(t, namespaceName, tePodName, corev1.PodReady, corev1.ConditionTrue, 180*time.Second)
 
 	smPodName0 := GetPodName(t, namespaceName, smPodName)
+	AddTeardown(TEARDOWN_DATABASE, func() { GetAppLog(t, namespaceName, GetPodName(t, namespaceName, smPodName), "") })
 	AwaitPodStatus(t, namespaceName, smPodName0, corev1.PodReady, corev1.ConditionTrue, 240*time.Second)
 
 	AwaitDatabaseUp(t, namespaceName, adminPod, opt.DbName, opt.NrSmPods+opt.NrTePods)


### PR DESCRIPTION
Improve the debuggability of DB-29815/TestKubernetesRestoreDatabase failures.
- add TE/SM log
- add pre-restart logs
- moved goroutine startDatabaseStatefulSet to the main call