### PR TITLE
Add optional persistent volumes for logs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ env:
     - CHANGE_MINIKUBE_NONE_USER=true
     - KUBECONFIG=$HOME/.kube/config
     - NUODB_PRINT_TO_STDOUT=true
-    - NUODB_VERSION=4.0.4
+    - NUODB_VERSION=4.0.3
 
 cache:
   directories:

--- a/incubator/backup/values.yaml
+++ b/incubator/backup/values.yaml
@@ -21,7 +21,7 @@ nuodb:
   image:
     registry: docker.io
     repository: nuodb/nuodb-ce
-    tag: 4.0.4
+    tag: 4.0.3
     pullPolicy: Always
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/incubator/monitoring-influx/values.yaml
+++ b/incubator/monitoring-influx/values.yaml
@@ -35,7 +35,7 @@ nuodb:
   image:
     registry: docker.io
     repository: nuodb/nuodb-ce
-    tag: 4.0.4
+    tag: 4.0.3
     pullPolicy: Always
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/incubator/monitoring-insights/values.yaml
+++ b/incubator/monitoring-insights/values.yaml
@@ -19,7 +19,7 @@ nuodb:
   image:
     registry: docker.io
     repository: nuodb/nuodb-ce
-    tag: 4.0.4
+    tag: 4.0.3
     pullPolicy: Always
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/stable/admin/README.md
+++ b/stable/admin/README.md
@@ -185,6 +185,10 @@ The following tables list the configurable parameters for the `admin` option of 
 | `persistence.accessModes` | Volume access modes enabled (must match capabilities of the storage class) | `ReadWriteMany` |
 | `persistence.size` | Amount of disk space allocated for admin RAFT state | `10Gi` |
 | `persistence.storageClass` | Storage class for volume backing admin RAFT state | `-` |
+| `logPersistence.enabled` | Whether to enable persistent storage for logs | `20Gi` |
+| `logPersistence.accessModes` | Volume access modes enabled (must match capabilities of the storage class) | `ReadWriteOnce` |
+| `logPersistence.size` | Amount of disk space allocated for log storage | `20Gi` |
+| `logPersistence.storageClass` | Storage class for volume backing log storage | `-` |
 | `envFrom` | Import ENV vars from one or more configMaps | `[]` |
 | `options` | Set optons to be passed to nuoadmin as arguments | `{}` |
 | `securityContext.capabilities` | add capabilities to the container | `[]` |

--- a/stable/admin/README.md
+++ b/stable/admin/README.md
@@ -189,7 +189,7 @@ The following tables list the configurable parameters for the `admin` option of 
 | `logPersistence.overwriteBackoff.copies` | How many copies of the crash directory to keep within windowMinutes | `3` |
 | `logPersistence.overwriteBackoff.windowMinutes` | The window within which to keep the number of crash copies | `120` |
 | `logPersistence.accessModes` | Volume access modes enabled (must match capabilities of the storage class) | `ReadWriteOnce` |
-| `logPersistence.size` | Amount of disk space allocated for log storage | `20Gi` |
+| `logPersistence.size` | Amount of disk space allocated for log storage | `60Gi` |
 | `logPersistence.storageClass` | Storage class for volume backing log storage | `-` |
 | `envFrom` | Import ENV vars from one or more configMaps | `[]` |
 | `options` | Set optons to be passed to nuoadmin as arguments | `{}` |

--- a/stable/admin/README.md
+++ b/stable/admin/README.md
@@ -182,7 +182,6 @@ The following tables list the configurable parameters for the `admin` option of 
 | `tolerations` | Tolerations for NuoDB Admin | `[]` |
 | `configFilesPath` | Directory path where `configFiles.*` are found | `/etc/nuodb/` |
 | `configFiles.*` | See below. | `{}` |
-| `persistence.enabled` | Whether or not persistent storage is enabled for admin RAFT state | `false` |
 | `persistence.accessModes` | Volume access modes enabled (must match capabilities of the storage class) | `ReadWriteMany` |
 | `persistence.size` | Amount of disk space allocated for admin RAFT state | `10Gi` |
 | `persistence.storageClass` | Storage class for volume backing admin RAFT state | `-` |
@@ -240,8 +239,7 @@ Verify the Helm chart:
 
 ```bash
 helm install nuodb/admin -n admin \
-    --set persistence.enabled=true \
-    --set persistence.storageClass=nuodb-admin \
+    --set persistence.storageClass=standard-storage \
     --debug --dry-run
 ```
 
@@ -249,8 +247,7 @@ Deploy the administration tier using volumes of the specified storage class:
 
 ```bash
 helm install nuodb/admin -n admin \
-    --set persistence.enabled=true \
-    --set persistence.storageClass=nuodb-admin
+    --set persistence.storageClass=standard-storage
 ```
 
   **Tip**: Be patient, it will take approximately 55 seconds to deploy.

--- a/stable/admin/README.md
+++ b/stable/admin/README.md
@@ -185,7 +185,7 @@ The following tables list the configurable parameters for the `admin` option of 
 | `persistence.accessModes` | Volume access modes enabled (must match capabilities of the storage class) | `ReadWriteMany` |
 | `persistence.size` | Amount of disk space allocated for admin RAFT state | `10Gi` |
 | `persistence.storageClass` | Storage class for volume backing admin RAFT state | `-` |
-| `logPersistence.enabled` | Whether to enable persistent storage for logs | `20Gi` |
+| `logPersistence.enabled` | Whether to enable persistent storage for logs | `false` |
 | `logPersistence.accessModes` | Volume access modes enabled (must match capabilities of the storage class) | `ReadWriteOnce` |
 | `logPersistence.size` | Amount of disk space allocated for log storage | `20Gi` |
 | `logPersistence.storageClass` | Storage class for volume backing log storage | `-` |

--- a/stable/admin/README.md
+++ b/stable/admin/README.md
@@ -186,6 +186,8 @@ The following tables list the configurable parameters for the `admin` option of 
 | `persistence.size` | Amount of disk space allocated for admin RAFT state | `10Gi` |
 | `persistence.storageClass` | Storage class for volume backing admin RAFT state | `-` |
 | `logPersistence.enabled` | Whether to enable persistent storage for logs | `false` |
+| `logPersistence.overwriteBackoff.copies` | How many copies of the crash directory to keep within windowMinutes | `3` |
+| `logPersistence.overwriteBackoff.windowMinutes` | The window within which to keep the number of crash copies | `120` |
 | `logPersistence.accessModes` | Volume access modes enabled (must match capabilities of the storage class) | `ReadWriteOnce` |
 | `logPersistence.size` | Amount of disk space allocated for log storage | `20Gi` |
 | `logPersistence.storageClass` | Storage class for volume backing log storage | `-` |

--- a/stable/admin/files/nuoadmin
+++ b/stable/admin/files/nuoadmin
@@ -26,8 +26,8 @@ export NUODB_LOGDIR NUODB_CFGDIR NUODB_VARDIR NUODB_BINDIR NUODB_RUNDIR
 
 # attempt to retain the previous crash directory (within the configured window to avoid filling the disk)
 if [ -f $NUODB_CRASHDIR/* ]; then
-  crashcount=$(find $NUODB_LOGDIR/crash-* -type d -cmin -10 ! -path . | wc -l)
-  if [ $crashcount -lt 2 ]; then
+  crashcount=$(find $NUODB_LOGDIR/crash-* -type d -cmin -$OVERWRITE_WINDOW ! -path . | wc -l)
+  if [ $crashcount -lt $OVERWRITE_COPIES ]; then
     crashbackupdir="$NUODB_LOGDIR/crash-$( date +%Y%m%dT%H%M%S )/"
     mkdir $crashbackupdir
     mv $NUODB_CRASHDIR/* $crashbackupdir

--- a/stable/admin/files/nuoadmin
+++ b/stable/admin/files/nuoadmin
@@ -1,0 +1,37 @@
+#!/bin/sh
+
+. ${NUODB_HOME}/etc/nuodb_setup.sh
+
+if [ -e ${NUODB_CFGDIR}/jvm-options -a "$NUODB_JAVA_OPTS" = "" ] ; then
+    . ${NUODB_CFGDIR}/jvm-options
+fi
+
+: ${NUODB_SERVERID:=$(hostname)}
+: ${NUODB_ALT_ADDRESS:=$(hostname --fqdn)}
+: ${NUODB_ADMIN_PORT:="48005"}
+
+if [ "${NUODB_ALTERNATIVE_ENTRYPOINT}" != "" ] ; then
+    if nuodocker --api-server "${NUODB_ALTERNATIVE_ENTRYPOINT}:8888" check servers ; then
+        # Admin server exists at alternative entrypoint. Use it instead
+        NUODB_DOMAIN_ENTRYPOINT="${NUODB_ALTERNATIVE_ENTRYPOINT}"
+    fi
+fi
+
+# if endpoint is not specified, default to bootstrap server
+if [ "${NUODB_DOMAIN_ENTRYPOINT}" = "" ] ; then
+    NUODB_DOMAIN_ENTRYPOINT="${NUODB_BOOTSTRAP_SERVERID}"
+fi
+
+export NUODB_LOGDIR NUODB_CFGDIR NUODB_VARDIR NUODB_BINDIR NUODB_RUNDIR
+
+# attempt to retain the previous crash directory if it exists
+if [ -f $NUODB_CRASHDIR/* ]; then
+  crashbackupdir="$NUODB_LOGDIR/crash-$( date +%Y%m%dT%H%M%S )/"
+  mkdir $crashbackupdir
+  mv $NUODB_CRASHDIR/* $crashbackupdir
+fi
+
+exec nuodocker start admin \
+     --server-id "$NUODB_SERVERID" --alt-address "$NUODB_ALT_ADDRESS" --admin-port "$NUODB_ADMIN_PORT" \
+     --domain-entrypoint "$NUODB_DOMAIN_ENTRYPOINT" --bootstrap-server-id "$NUODB_BOOTSTRAP_SERVERID" \
+     --java-opts "$NUODB_JAVA_OPTS" --args "$*"

--- a/stable/admin/files/nuoadmin
+++ b/stable/admin/files/nuoadmin
@@ -24,11 +24,14 @@ fi
 
 export NUODB_LOGDIR NUODB_CFGDIR NUODB_VARDIR NUODB_BINDIR NUODB_RUNDIR
 
-# attempt to retain the previous crash directory if it exists
+# attempt to retain the previous crash directory (within the configured window to avoid filling the disk)
 if [ -f $NUODB_CRASHDIR/* ]; then
-  crashbackupdir="$NUODB_LOGDIR/crash-$( date +%Y%m%dT%H%M%S )/"
-  mkdir $crashbackupdir
-  mv $NUODB_CRASHDIR/* $crashbackupdir
+  crashcount=$(find $NUODB_LOGDIR/crash-* -type d -cmin -10 ! -path . | wc -l)
+  if [ $crashcount -lt 2 ]; then
+    crashbackupdir="$NUODB_LOGDIR/crash-$( date +%Y%m%dT%H%M%S )/"
+    mkdir $crashbackupdir
+    mv $NUODB_CRASHDIR/* $crashbackupdir
+  fi
 fi
 
 exec nuodocker start admin \

--- a/stable/admin/templates/configmap.yaml
+++ b/stable/admin/templates/configmap.yaml
@@ -28,7 +28,7 @@ data:
   {{ $key }}: |-
 {{ $val | indent 4}}
 {{- end }}
-{{- end -}}
+{{- end }}
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/stable/admin/templates/configmap.yaml
+++ b/stable/admin/templates/configmap.yaml
@@ -29,3 +29,16 @@ data:
 {{ $val | indent 4}}
 {{- end }}
 {{- end -}}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: {{ template "admin.fullname" . }}
+    group: nuodb
+    domain: {{ .Values.admin.domain }}
+    chart: {{ template "admin.chart" . }}
+    release: {{ .Release.Name | quote }}
+  name: {{ template "admin.fullname" . }}-nuoadmin
+data:
+{{ (.Files.Glob "files/nuoadmin").AsConfig | indent 2 }}

--- a/stable/admin/templates/statefulset.yaml
+++ b/stable/admin/templates/statefulset.yaml
@@ -48,7 +48,7 @@ spec:
         volumeMounts:
         - name: raftlog
           mountPath: /var/opt/nuodb
-        - name: log-volume
+        - name: log
           mountPath: /var/log/nuodb
       containers:
       - name: admin
@@ -75,9 +75,15 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        # - name: CONTAINER_START_TIME
+        #   valueFrom:
+        #     fieldRef:
+        #       fieldPath: status.startTime
+        - { name: CONTAINER_START_TIME,    value: $(date +'%Y%m%dT%H%M%S') }
         - { name: NUODB_DOMAIN_ENTRYPOINT, value: "{{ template "admin.fullname" . }}-0.{{ .Values.admin.domain }}" }
         - { name: NUODB_ALT_ADDRESS,       value: "$(POD_NAME).{{ .Values.admin.domain }}.$(NAMESPACE).svc" }
         - { name: NUODB_VARDIR,            value: "/var/opt/nuodb/$(POD_NAME).$(NAMESPACE)" }
+        - { name: NUODB_LOGDIR,            value: "/var/log/nuodb" }
         - { name: COMPONENT_NAME,          value: "admin" }
       {{- if .Values.admin.tlsKeyStore }}
         {{- if .Values.admin.tlsKeyStore.password }}
@@ -110,7 +116,7 @@ spec:
           successThreshold: 2
           timeoutSeconds: 1
         volumeMounts:
-        - name: log-volume
+        - name: log
           mountPath: /var/log/nuodb
         {{- with .Values.admin.configFiles }}
         {{- range $key, $val := . }}
@@ -167,8 +173,10 @@ spec:
           secretName: {{ .Values.admin.tlsClientPEM.secret }}
           defaultMode: 0440
       {{- end }}
-      - name: log-volume
+      {{- if not .Values.admin.logPersistence.enabled }}
+      - name: log
         emptyDir: {}
+      {{- end }}
       {{- if .Values.admin.configFiles }}
       - name: configurations
         configMap:
@@ -198,3 +206,28 @@ spec:
       resources:
         requests:
           storage: {{ .Values.admin.persistence.size }}
+{{- if .Values.admin.logPersistence.enabled }}
+  - metadata:
+      name: log
+      labels:
+        app: {{ template "admin.fullname" . }}
+        group: nuodb
+        domain: {{ .Values.admin.domain }}
+        chart: {{ template "admin.chart" . }}
+        release: {{ .Release.Name | quote }}
+    spec:
+    {{- if .Values.admin.logPersistence.storageClass }}
+      {{- if (eq "-" .Values.admin.logPersistence.storageClass) }}
+      storageClassName: ""
+      {{- else }}
+      storageClassName: {{ .Values.admin.logPersistence.storageClass }}
+      {{- end }}
+    {{- end }}
+      accessModes:
+      {{- range .Values.admin.logPersistence.accessModes }}
+        - {{ . }}
+      {{- end }}
+      resources:
+        requests:
+          storage: {{ .Values.admin.logPersistence.size }}
+{{- end }}

--- a/stable/admin/templates/statefulset.yaml
+++ b/stable/admin/templates/statefulset.yaml
@@ -48,7 +48,7 @@ spec:
         volumeMounts:
         - name: raftlog
           mountPath: /var/opt/nuodb
-        - name: log
+        - name: log-volume
           mountPath: /var/log/nuodb
       containers:
       - name: admin
@@ -75,15 +75,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        # - name: CONTAINER_START_TIME
-        #   valueFrom:
-        #     fieldRef:
-        #       fieldPath: status.startTime
-        - { name: CONTAINER_START_TIME,    value: $(date +'%Y%m%dT%H%M%S') }
         - { name: NUODB_DOMAIN_ENTRYPOINT, value: "{{ template "admin.fullname" . }}-0.{{ .Values.admin.domain }}" }
         - { name: NUODB_ALT_ADDRESS,       value: "$(POD_NAME).{{ .Values.admin.domain }}.$(NAMESPACE).svc" }
         - { name: NUODB_VARDIR,            value: "/var/opt/nuodb/$(POD_NAME).$(NAMESPACE)" }
-        - { name: NUODB_LOGDIR,            value: "/var/log/nuodb" }
         - { name: COMPONENT_NAME,          value: "admin" }
       {{- if .Values.admin.tlsKeyStore }}
         {{- if .Values.admin.tlsKeyStore.password }}
@@ -95,7 +89,7 @@ spec:
         - { name: NUODB_TRUSTSTORE_PASSWORD,  value: {{ .Values.admin.tlsTrustStore.password | quote }} }
         {{- end }}
       {{- end }}
-        args:
+        args: 
           - "nuoadmin"
           - "--"
           - "pendingReconnectTimeout=60000"
@@ -116,7 +110,7 @@ spec:
           successThreshold: 2
           timeoutSeconds: 1
         volumeMounts:
-        - name: log
+        - name: log-volume
           mountPath: /var/log/nuodb
         {{- with .Values.admin.configFiles }}
         {{- range $key, $val := . }}
@@ -127,6 +121,9 @@ spec:
         {{- end }}
         - name: raftlog
           mountPath: /var/opt/nuodb
+        - name: nuoadmin
+          mountPath: /usr/local/bin/nuoadmin
+          subPath: nuoadmin
         {{- if .Values.admin.tlsCACert }}
         - name: tls-ca-cert
           mountPath: /etc/nuodb/keys/ca.cert
@@ -174,7 +171,7 @@ spec:
           defaultMode: 0440
       {{- end }}
       {{- if not .Values.admin.logPersistence.enabled }}
-      - name: log
+      - name: log-volume
         emptyDir: {}
       {{- end }}
       {{- if .Values.admin.configFiles }}
@@ -182,6 +179,10 @@ spec:
         configMap:
           name: {{ template "admin.fullname" . }}-configuration
       {{- end }}
+      - name: nuoadmin
+        configMap:
+          name: {{ template "admin.fullname" . }}-nuoadmin
+          defaultMode: 0777
   volumeClaimTemplates:
   - metadata:
       name: raftlog
@@ -208,7 +209,7 @@ spec:
           storage: {{ .Values.admin.persistence.size }}
 {{- if .Values.admin.logPersistence.enabled }}
   - metadata:
-      name: log
+      name: log-volume
       labels:
         app: {{ template "admin.fullname" . }}
         group: nuodb

--- a/stable/admin/templates/statefulset.yaml
+++ b/stable/admin/templates/statefulset.yaml
@@ -79,6 +79,8 @@ spec:
         - { name: NUODB_ALT_ADDRESS,       value: "$(POD_NAME).{{ .Values.admin.domain }}.$(NAMESPACE).svc" }
         - { name: NUODB_VARDIR,            value: "/var/opt/nuodb/$(POD_NAME).$(NAMESPACE)" }
         - { name: COMPONENT_NAME,          value: "admin" }
+        - { name: OVERWRITE_COPIES,    value: "{{ .Values.admin.logPersistence.overwriteBackoff.copies | default "3" }}" }
+        - { name: OVERWRITE_WINDOW,    value: "{{ .Values.admin.logPersistence.overwriteBackoff.windowMinutes | default "120" }}" }
       {{- if .Values.admin.tlsKeyStore }}
         {{- if .Values.admin.tlsKeyStore.password }}
         - { name: NUODB_KEYSTORE_PASSWORD,    value: {{ .Values.admin.tlsKeyStore.password | quote }} }

--- a/stable/admin/templates/statefulset.yaml
+++ b/stable/admin/templates/statefulset.yaml
@@ -89,7 +89,7 @@ spec:
         - { name: NUODB_TRUSTSTORE_PASSWORD,  value: {{ .Values.admin.tlsTrustStore.password | quote }} }
         {{- end }}
       {{- end }}
-        args: 
+        args:
           - "nuoadmin"
           - "--"
           - "pendingReconnectTimeout=60000"

--- a/stable/admin/values.yaml
+++ b/stable/admin/values.yaml
@@ -19,8 +19,6 @@ cloud:
   # If the NuoDB domain spans 2 or more physical clusters, then each cluster must have a unique clusterName.
   # The default is fine for single-cluster domains.
   clusterName: cluster0
-  clusterDomain: cluster.local
-  entrypointClusterDomain: cluster.local
 
 busybox:
   image:
@@ -84,7 +82,7 @@ admin:
 
   ## Enable persistent log volumes to retain logs when an external logging solution is not used.
   logPersistence:
-    enabled: false
+    enabled: true
     size: 20Gi
     accessModes:
       - ReadWriteOnce

--- a/stable/admin/values.yaml
+++ b/stable/admin/values.yaml
@@ -86,10 +86,10 @@ admin:
     overwriteBackoff:
       # Copies of the crash directory are taken to avoid overwrites of root crash.
       # This controls the window within which no more copies of the crash directory will be taken to avoid the disk filling.
-      # Default will retain 3 copies within the last 120 minutes, after which they will resume.
+      # Default will retain 3 copies within the last 120 minutes, after which copies will continue to be created.
       copies: 3
       windowMinutes: 120
-    size: 20Gi
+    size: 60Gi
     accessModes:
       - ReadWriteOnce
     # storageClass: "-"

--- a/stable/admin/values.yaml
+++ b/stable/admin/values.yaml
@@ -40,7 +40,7 @@ nuodb:
   image:
     registry: docker.io
     repository: nuodb/nuodb-ce
-    tag: 4.0.4
+    tag: 4.0.3
     pullPolicy: Always
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/stable/admin/values.yaml
+++ b/stable/admin/values.yaml
@@ -83,10 +83,16 @@ admin:
   ## Enable persistent log volumes to retain logs when an external logging solution is not used.
   logPersistence:
     enabled: false
+    overwriteBackoff:
+      # Copies of the crash directory are taken to avoid overwrites of root crash.
+      # This controls the window within which no more copies of the crash directory will be taken to avoid the disk filling.
+      # Default will retain 3 copies within the last 120 minutes, after which they will resume.
+      copies: 3
+      windowMinutes: 120
     size: 20Gi
     accessModes:
       - ReadWriteOnce
-    # storageClass: "-"  
+    # storageClass: "-"
 
   ## Use a securityContext to specify additional capabilities
   # For example, if the container needs to configure network setting, then add "NET_ADMIN"

--- a/stable/admin/values.yaml
+++ b/stable/admin/values.yaml
@@ -82,7 +82,7 @@ admin:
 
   ## Enable persistent log volumes to retain logs when an external logging solution is not used.
   logPersistence:
-    enabled: true
+    enabled: false
     size: 20Gi
     accessModes:
       - ReadWriteOnce

--- a/stable/admin/values.yaml
+++ b/stable/admin/values.yaml
@@ -18,7 +18,9 @@ cloud:
   # cluster name is used to make resources unique in multi-cluster configurations.
   # If the NuoDB domain spans 2 or more physical clusters, then each cluster must have a unique clusterName.
   # The default is fine for single-cluster domains.
-  clusteName: cluster0
+  clusterName: cluster0
+  clusterDomain: cluster.local
+  entrypointClusterDomain: cluster.local
 
 busybox:
   image:
@@ -79,6 +81,14 @@ admin:
     accessModes:
       - ReadWriteOnce
     # storageClass: "-"
+
+  ## Enable persistent log volumes to retain logs when an external logging solution is not used.
+  logPersistence:
+    enabled: false
+    size: 20Gi
+    accessModes:
+      - ReadWriteOnce
+    # storageClass: "-"  
 
   ## Use a securityContext to specify additional capabilities
   # For example, if the container needs to configure network setting, then add "NET_ADMIN"

--- a/stable/database/README.md
+++ b/stable/database/README.md
@@ -239,6 +239,8 @@ The following tables list the configurable parameters of the `database` chart an
 | `configFilesPath` | Directory path where `configFiles.*` are found | `/etc/nuodb/` |
 | `configFiles.*` | See below. | `{}` |
 | `sm.logPersistence.enabled` | Whether to enable persistent storage for logs | `false` |
+| `sm.logPersistence.overwriteBackoff.copies` | How many copies of the crash directory to keep within windowMinutes | `3` |
+| `sm.logPersistence.overwriteBackoff.windowMinutes` | The window within which to keep the number of crash copies | `120` |
 | `sm.logPersistence.accessModes` | Volume access modes enabled (must match capabilities of the storage class) | `ReadWriteOnce` |
 | `sm.logPersistence.size` | Amount of disk space allocated for log storage | `20Gi` |
 | `sm.logPersistence.storageClass` | Storage class for volume backing log storage | `-` |

--- a/stable/database/README.md
+++ b/stable/database/README.md
@@ -242,7 +242,7 @@ The following tables list the configurable parameters of the `database` chart an
 | `sm.logPersistence.overwriteBackoff.copies` | How many copies of the crash directory to keep within windowMinutes | `3` |
 | `sm.logPersistence.overwriteBackoff.windowMinutes` | The window within which to keep the number of crash copies | `120` |
 | `sm.logPersistence.accessModes` | Volume access modes enabled (must match capabilities of the storage class) | `ReadWriteOnce` |
-| `sm.logPersistence.size` | Amount of disk space allocated for log storage | `20Gi` |
+| `sm.logPersistence.size` | Amount of disk space allocated for log storage | `60Gi` |
 | `sm.logPersistence.storageClass` | Storage class for volume backing log storage | `-` |
 | `sm.hotCopy.replicas` | SM replicas with hot-copy enabled | `1` |
 | `sm.hotCopy.enablePod` | Create DS/SS for hot-copy enabled SMs | `true` |

--- a/stable/database/README.md
+++ b/stable/database/README.md
@@ -269,10 +269,6 @@ The following tables list the configurable parameters of the `database` chart an
 | `sm.affinity` | Affinity rules for NuoDB SM | `{}` |
 | `sm.nodeSelector` | Node selector rules for NuoDB SM | `{}` |
 | `sm.tolerations` | Tolerations for NuoDB SM | `[]` |
-| `te.logPersistence.enabled` | Whether to enable persistent storage for logs | `20Gi` |
-| `te.logPersistence.accessModes` | Volume access modes enabled (must match capabilities of the storage class) | `ReadWriteOnce` |
-| `te.logPersistence.size` | Amount of disk space allocated for log storage | `20Gi` |
-| `te.logPersistence.storageClass` | Storage class for volume backing log storage | `-` |
 | `te.externalAccess.enabled` | Whether to deploy a Layer 4 cloud load balancer service for the admin layer | `false` |
 | `te.externalAccess.internalIP` | Whether to use an internal (to the cloud) or external (public) IP address for the load balancer | `nil` |
 | `te.dbServices.enabled` | Whether to deploy clusterip and headless services for direct TE connections (defaults true) | `nil` |

--- a/stable/database/README.md
+++ b/stable/database/README.md
@@ -238,6 +238,10 @@ The following tables list the configurable parameters of the `database` chart an
 | `persistence.storageClass` | Storage class for volume backing database archive storage | `-` |
 | `configFilesPath` | Directory path where `configFiles.*` are found | `/etc/nuodb/` |
 | `configFiles.*` | See below. | `{}` |
+| `sm.logPersistence.enabled` | Whether to enable persistent storage for logs | `20Gi` |
+| `sm.logPersistence.accessModes` | Volume access modes enabled (must match capabilities of the storage class) | `ReadWriteOnce` |
+| `sm.logPersistence.size` | Amount of disk space allocated for log storage | `20Gi` |
+| `sm.logPersistence.storageClass` | Storage class for volume backing log storage | `-` |
 | `sm.hotCopy.replicas` | SM replicas with hot-copy enabled | `1` |
 | `sm.hotCopy.enablePod` | Create DS/SS for hot-copy enabled SMs | `true` |
 | `sm.hotcopy.deadline` | Deadline for a hotcopy job to start (seconds) | `1800` |
@@ -265,6 +269,10 @@ The following tables list the configurable parameters of the `database` chart an
 | `sm.affinity` | Affinity rules for NuoDB SM | `{}` |
 | `sm.nodeSelector` | Node selector rules for NuoDB SM | `{}` |
 | `sm.tolerations` | Tolerations for NuoDB SM | `[]` |
+| `te.logPersistence.enabled` | Whether to enable persistent storage for logs | `20Gi` |
+| `te.logPersistence.accessModes` | Volume access modes enabled (must match capabilities of the storage class) | `ReadWriteOnce` |
+| `te.logPersistence.size` | Amount of disk space allocated for log storage | `20Gi` |
+| `te.logPersistence.storageClass` | Storage class for volume backing log storage | `-` |
 | `te.externalAccess.enabled` | Whether to deploy a Layer 4 cloud load balancer service for the admin layer | `false` |
 | `te.externalAccess.internalIP` | Whether to use an internal (to the cloud) or external (public) IP address for the load balancer | `nil` |
 | `te.dbServices.enabled` | Whether to deploy clusterip and headless services for direct TE connections (defaults true) | `nil` |

--- a/stable/database/README.md
+++ b/stable/database/README.md
@@ -315,8 +315,7 @@ Verify the Helm chart:
 
 ```bash
 helm install nuodb/database -n database \
-    --set sm.persistence.enabled=true \
-    --set sm.persistence.storageClass=nuodb-archive \
+    --set sm.persistence.storageClass=standard-storage \
     --debug --dry-run
 ```
 
@@ -324,8 +323,7 @@ Deploy a database without backups:
 
 ```bash
 helm install nuodb/database -n database \
-    --set sm.persistence.enabled=true \
-    --set sm.persistence.storageClass=nuodb-archive
+    --set sm.persistence.storageClass=standard-storage
 ```
 
 The command deploys NuoDB on the Kubernetes cluster in the default configuration. The configuration section lists the parameters that can be configured during installation.

--- a/stable/database/README.md
+++ b/stable/database/README.md
@@ -238,7 +238,7 @@ The following tables list the configurable parameters of the `database` chart an
 | `persistence.storageClass` | Storage class for volume backing database archive storage | `-` |
 | `configFilesPath` | Directory path where `configFiles.*` are found | `/etc/nuodb/` |
 | `configFiles.*` | See below. | `{}` |
-| `sm.logPersistence.enabled` | Whether to enable persistent storage for logs | `20Gi` |
+| `sm.logPersistence.enabled` | Whether to enable persistent storage for logs | `false` |
 | `sm.logPersistence.accessModes` | Volume access modes enabled (must match capabilities of the storage class) | `ReadWriteOnce` |
 | `sm.logPersistence.size` | Amount of disk space allocated for log storage | `20Gi` |
 | `sm.logPersistence.storageClass` | Storage class for volume backing log storage | `-` |

--- a/stable/database/files/nuosm
+++ b/stable/database/files/nuosm
@@ -21,11 +21,14 @@ DB_DIR=${NUODB_ARCHIVEDIR}/${NUODB_DOMAIN}/${DB_NAME}
 NUODB_BINDIR=$NUODB_HOME/bin
 [ -z "$NUOCMD" ] && NUOCMD="$NUODB_BINDIR/nuocmd --api-server $NUOCMD_API_SERVER"
 
-# attempt to retain the previous crash directory
+# attempt to retain the previous crash directory (within the configured window to avoid filling the disk)
 if [ -f $NUODB_CRASHDIR/* ]; then
-  crashbackupdir="$NUODB_LOGDIR/crash-$( date +%Y%m%dT%H%M%S )/"
-  mkdir $crashbackupdir
-  mv $NUODB_CRASHDIR/* $crashbackupdir
+  crashcount=$(find $NUODB_LOGDIR/crash-* -type d -cmin -10 ! -path . | wc -l)
+  if [ $crashcount -lt 2 ]; then
+    crashbackupdir="$NUODB_LOGDIR/crash-$( date +%Y%m%dT%H%M%S )/"
+    mkdir $crashbackupdir
+    mv $NUODB_CRASHDIR/* $crashbackupdir
+  fi
 fi
 
 export NUOCMD DB_NAME

--- a/stable/database/files/nuosm
+++ b/stable/database/files/nuosm
@@ -21,6 +21,13 @@ DB_DIR=${NUODB_ARCHIVEDIR}/${NUODB_DOMAIN}/${DB_NAME}
 NUODB_BINDIR=$NUODB_HOME/bin
 [ -z "$NUOCMD" ] && NUOCMD="$NUODB_BINDIR/nuocmd --api-server $NUOCMD_API_SERVER"
 
+# attempt to retain the previous crash directory
+if [ -f $NUODB_CRASHDIR/* ]; then
+  crashbackupdir="$NUODB_LOGDIR/crash-$( date +%Y%m%dT%H%M%S )/"
+  mkdir $crashbackupdir
+  mv $NUODB_CRASHDIR/* $crashbackupdir
+fi
+
 export NUOCMD DB_NAME
 
 #=======================================

--- a/stable/database/files/nuosm
+++ b/stable/database/files/nuosm
@@ -23,8 +23,8 @@ NUODB_BINDIR=$NUODB_HOME/bin
 
 # attempt to retain the previous crash directory (within the configured window to avoid filling the disk)
 if [ -f $NUODB_CRASHDIR/* ]; then
-  crashcount=$(find $NUODB_LOGDIR/crash-* -type d -cmin -10 ! -path . | wc -l)
-  if [ $crashcount -lt 2 ]; then
+  crashcount=$(find $NUODB_LOGDIR/crash-* -type d -cmin -$OVERWRITE_WINDOW ! -path . | wc -l)
+  if [ $crashcount -lt $OVERWRITE_COPIES ]; then
     crashbackupdir="$NUODB_LOGDIR/crash-$( date +%Y%m%dT%H%M%S )/"
     mkdir $crashbackupdir
     mv $NUODB_CRASHDIR/* $crashbackupdir

--- a/stable/database/templates/statefulset.yaml
+++ b/stable/database/templates/statefulset.yaml
@@ -195,8 +195,10 @@ spec:
         configMap:
           name: {{ template "database.fullname" . }}-configuration
       {{- end }}
+      {{- if not .Values.database.sm.logPersistence.enabled }}
       - name: log-volume
         emptyDir: {}
+      {{- end }}
       - name: nuosm
         configMap:
           name: {{ template "database.fullname" . }}-nuosm
@@ -257,7 +259,34 @@ spec:
       resources:
         requests:
           storage: {{ .Values.database.persistence.size }}
+  {{- if .Values.database.sm.logPersistence.enabled }}
+  - metadata:
+      name: log-volume
+      labels:
+        app: {{ template "database.fullname" . }}
+        group: nuodb
+        database: {{ .Values.database.name }}
+        domain: {{ .Values.admin.domain }}
+        chart: {{ template "database.chart" . }}
+        release: {{ .Release.Name | quote }}
+    spec:
+      accessModes:
+      {{- range .Values.database.sm.logPersistence.accessModes }}
+        - {{ . }}
+      {{- end }}
+    {{- if .Values.database.sm.logPersistence.storageClass }}
+      {{- if (eq "-" .Values.database.sm.logPersistence.storageClass) }}
+      storageClassName: ""
+      {{- else }}
+      storageClassName: {{ .Values.database.sm.logPersistence.storageClass }}
+      {{- end }}
+    {{- end }}
+      resources:
+        requests:
+          storage: {{ .Values.database.sm.logPersistence.size }}
+  {{- end }}
 {{- end }}
+
 {{- if .Values.database.sm.hotCopy.enablePod }}
 ---
 apiVersion: apps/v1
@@ -459,8 +488,10 @@ spec:
         configMap:
           name: {{ template "database.fullname" . }}-configuration
       {{- end }}
+      {{- if not .Values.database.sm.logPersistence.enabled }}
       - name: log-volume
         emptyDir: {}
+      {{- end }}
       - name: nuosm
         configMap:
           name: {{ template "database.fullname" . }}-nuosm
@@ -545,5 +576,31 @@ spec:
       resources:
         requests:
           storage: {{ .Values.database.sm.hotCopy.persistence.size }}
+  {{- if .Values.database.sm.logPersistence.enabled }}
+  - metadata:
+      name: log-volume
+      labels:
+        app: {{ template "database.fullname" . }}
+        group: nuodb
+        database: {{ .Values.database.name }}
+        domain: {{ .Values.admin.domain }}
+        chart: {{ template "database.chart" . }}
+        release: {{ .Release.Name | quote }}
+    spec:
+      accessModes:
+      {{- range .Values.database.sm.logPersistence.accessModes }}
+        - {{ . }}
+      {{- end }}
+    {{- if .Values.database.sm.logPersistence.storageClass }}
+      {{- if (eq "-" .Values.database.sm.logPersistence.storageClass) }}
+      storageClassName: ""
+      {{- else }}
+      storageClassName: {{ .Values.database.sm.logPersistence.storageClass }}
+      {{- end }}
+    {{- end }}
+      resources:
+        requests:
+          storage: {{ .Values.database.sm.logPersistence.size }}
+  {{- end }}
 {{- end }}
 {{- end }}

--- a/stable/database/templates/statefulset.yaml
+++ b/stable/database/templates/statefulset.yaml
@@ -130,6 +130,8 @@ spec:
         - { name: NUOCMD_API_SERVER,   value: "{{ template "admin.address" . }}:8888" }
         - { name: PEER_ADDRESS,        value: "{{ template "admin.address" . }}" }
         - { name: COMPONENT_NAME,      value: "sm" }
+        - { name: OVERWRITE_COPIES,    value: "{{ .Values.database.sm.logPersistence.overwriteBackoff.copies | default "3" }}" }
+        - { name: OVERWRITE_WINDOW,    value: "{{ .Values.database.sm.logPersistence.overwriteBackoff.windowMinutes | default "120" }}" }
 {{- include "database.env" . | indent 8 }}
     {{- if .Values.admin.tlsKeyStore }}
       {{- if .Values.admin.tlsKeyStore.password }}
@@ -421,6 +423,8 @@ spec:
         - { name: PEER_ADDRESS,        value: "{{ template "admin.address" . }}" }
         - { name: NUODB_BACKUP_GROUP,  value: "{{ include "hotcopy.group" . }}" }
         - { name: COMPONENT_NAME,      value: "sm" }
+        - { name: OVERWRITE_COPIES,    value: "{{ .Values.database.sm.logPersistence.overwriteBackoff.copies | default "3" }}" }
+        - { name: OVERWRITE_WINDOW,    value: "{{ .Values.database.sm.logPersistence.overwriteBackoff.windowMinutes | default "120" }}" }
 {{- include "database.env" . | indent 8 }}
     {{- if .Values.admin.tlsKeyStore }}
       {{- if .Values.admin.tlsKeyStore.password }}

--- a/stable/database/values.yaml
+++ b/stable/database/values.yaml
@@ -164,10 +164,10 @@ database:
       overwriteBackoff:
         # Copies of the crash directory are taken to avoid overwrites of root crash.
         # This controls the window within which no more copies of the crash directory will be taken to avoid the disk filling.
-        # Default will retain 3 copies within the last 120 minutes, after which they will resume.
+        # Default will retain 3 copies within the last 120 minutes, after which copies will continue to be created.
         copies: 3
         windowMinutes: 120
-      size: 20Gi
+      size: 60Gi
       accessModes:
         - ReadWriteOnce
       # storageClass: "-"

--- a/stable/database/values.yaml
+++ b/stable/database/values.yaml
@@ -40,7 +40,7 @@ nuodb:
   image:
     registry: docker.io
     repository: nuodb/nuodb-ce
-    tag: 4.0.4
+    tag: 4.0.3
     pullPolicy: Always
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/stable/database/values.yaml
+++ b/stable/database/values.yaml
@@ -160,7 +160,7 @@ database:
   sm:
     ## Enable persistent log volumes to retain logs when an external logging solution is not used.
     logPersistence:
-      enabled: true
+      enabled: false
       size: 20Gi
       accessModes:
         - ReadWriteOnce
@@ -259,14 +259,6 @@ database:
     # tolerationsDS: []
 
   te:
-    ## Enable persistent log volumes to retain logs when an external logging solution is not used.
-    logPersistence:
-      enabled: false
-      size: 20Gi
-      accessModes:
-        - ReadWriteOnce
-      # storageClass: "-"  
-
     ## Enable the Layer 4 Load balancer if required,
     ## and specify if it should provision an internal or external cloud IP address
     externalAccess: {}

--- a/stable/database/values.yaml
+++ b/stable/database/values.yaml
@@ -161,10 +161,16 @@ database:
     ## Enable persistent log volumes to retain logs when an external logging solution is not used.
     logPersistence:
       enabled: false
+      overwriteBackoff:
+        # Copies of the crash directory are taken to avoid overwrites of root crash.
+        # This controls the window within which no more copies of the crash directory will be taken to avoid the disk filling.
+        # Default will retain 3 copies within the last 120 minutes, after which they will resume.
+        copies: 3
+        windowMinutes: 120
       size: 20Gi
       accessModes:
         - ReadWriteOnce
-      # storageClass: "-"  
+      # storageClass: "-"
 
     # Settings for storage manager (SM) nodes with hotcopy enabled.
     # Total SM Limit is 1 in CE version of NuoDB

--- a/stable/database/values.yaml
+++ b/stable/database/values.yaml
@@ -158,6 +158,14 @@ database:
     type: ""
 
   sm:
+    ## Enable persistent log volumes to retain logs when an external logging solution is not used.
+    logPersistence:
+      enabled: true
+      size: 20Gi
+      accessModes:
+        - ReadWriteOnce
+      # storageClass: "-"  
+
     # Settings for storage manager (SM) nodes with hotcopy enabled.
     # Total SM Limit is 1 in CE version of NuoDB
     # These SMs have hotcopy backup enabled. To start SMs without hotcopy use
@@ -251,6 +259,14 @@ database:
     # tolerationsDS: []
 
   te:
+    ## Enable persistent log volumes to retain logs when an external logging solution is not used.
+    logPersistence:
+      enabled: false
+      size: 20Gi
+      accessModes:
+        - ReadWriteOnce
+      # storageClass: "-"  
+
     ## Enable the Layer 4 Load balancer if required,
     ## and specify if it should provision an internal or external cloud IP address
     externalAccess: {}

--- a/stable/restore/values.yaml
+++ b/stable/restore/values.yaml
@@ -26,7 +26,7 @@ nuodb:
   image:
     registry: docker.io
     repository: nuodb/nuodb-ce
-    tag: 4.0.4
+    tag: 4.0.3
     pullPolicy: Always
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/stable/storage-class/templates/storageclass.yaml
+++ b/stable/storage-class/templates/storageclass.yaml
@@ -73,11 +73,11 @@ parameters:
 {{- include "storageClass.allowVolumeExpansion" . }}
 reclaimPolicy: Retain
 volumeBindingMode: Immediate
-{{- else }}
+{{- end }}
+---
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: local-storage
 provisioner: kubernetes.io/no-provisioner
 volumeBindingMode: WaitForFirstConsumer
-{{- end }}

--- a/test/minikube/minikube_rolling_upgrade_test.go
+++ b/test/minikube/minikube_rolling_upgrade_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 const OLD_RELEASE = "4.0"
-const NEW_RELEASE = "4.0.4"
+const NEW_RELEASE = "4.0.3"
 
 func verifyAllProcessesRunning(t *testing.T, namespaceName string, adminPod string, expectedNrProcesses int) {
 	testlib.Await(t, func() bool {


### PR DESCRIPTION
- New values entries to define log storage
- Stateful set changes to provision persistent log volumes
- Add mounting of the nuoadmin script
- Code to retain previous crash outputs to avoid overwriting
- Change to always deploy local-storage class, not only if we are not using a cloud
- Readme updates

Note that this change does not include persistent logging for TEs