### PR TITLE
Home page updates to clarify the requirement for Helm version 2, 2.9 or greater

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,13 @@ Use this repository to submit official Charts for NuoDB. Charts are curated appl
 
 For more information on using Helm, refer to the [Helm's documentation](https://github.com/kubernetes/helm#docs).
 
+## NuoDB Helm Chart Version support
+
+For a list of supported NuoDB Helm Chart releases and where to download, click the `Releases` tab above. 
+
+To enable automated notification of new releases, click the `Watch` button above and subscribe to the `Releases Only` selection. |
+
+
 ## Software Release requirements
 
 | Software   | Release Requirements                           | 
@@ -14,7 +21,6 @@ For more information on using Helm, refer to the [Helm's documentation](https://
 | Kubernetes |  The latest and previous minor versions of Kubernetes. For example, if the latest minor release of Kubernetes is 1.15 then 1.15 and 1.14 are supported. Charts may still work on previous versions of Kubernertes even though they are outside the target support window. To provide that support the API versions of objects should be those that work for both the latest minor release and the previous one.|
 | Helm       |  Version 2 is supported, v2.9 or greater   |
 | NuoDB      |  Version [4.0](https://hub.docker.com/r/nuodb/nuodb-ce/tags) and onwards. |
-| NuoDB Helm Charts      |  For a list of supported NuoDB Helm Chart releases and where to download, click the `Releases` tab above. To enable automated notification of new releases, click the `Watch` button above and subscribe to the `Releases Only` selection. |
 
 ## NuoDB Helm Chart Installation
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ $ helm repo add nuodb https://nuodb-charts.storage.googleapis.com/
 "nuodb" has been added to your repositories
 ```
 
-To list the installed NuoDB charts, run `helm search nuodb/`
+To list the NuoDB charts added to your repository, run `helm search nuodb/`
 
 To install a chart, run `helm install nuodb/<chart>`
 
@@ -40,7 +40,7 @@ $ helm repo add nuodb-incubator https://nuodb-charts-incubator.storage.googleapi
 "nuodb-incubator" has been added to your repositories
 ```
 
-To list the installed NuoDB incubator charts, run `helm search nuodb-incubator/`
+To list the NuoDB incubator charts added to your repository, run `helm search nuodb-incubator/`
 
 ## Repository Structure
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ For more information on using Helm, refer to the [Helm's documentation](https://
 
 ## Software Release requirements
 
-| Software   |      Release Requirements                        | 
-|----------- |:------------------------------------------------:|
+| Software   |      Release Requirements                      | 
+|------------|------------------------------------------------|
 | Kubernetes |  This chart repository supports the latest and previous minor versions of Kubernetes. For example, if the latest minor release of Kubernetes is 1.15 then 1.15 and 1.14 are supported. Charts may still work on previous versions of Kubernertes even though they are outside the target support window.|
 | Helm       |  2.x, 2.9 or greater   |
 | NuoDB      |  Version [4.0](https://hub.docker.com/layers/nuodb/nuodb-ce/4.0/images/sha256-aaa558ef71795f15d5b3a1ef07b6be4890925dbd023c59b1f9a674ca20614763) and onwards. |

--- a/README.md
+++ b/README.md
@@ -12,17 +12,11 @@ For more information on using Helm, refer to the [Helm's documentation](https://
 | Software   | Release Requirements                           | 
 |------------|------------------------------------------------|
 | Kubernetes |  The latest and previous minor versions of Kubernetes. For example, if the latest minor release of Kubernetes is 1.15 then 1.15 and 1.14 are supported. Charts may still work on previous versions of Kubernertes even though they are outside the target support window.|
-| Helm       |  2.x, 2.9 or greater   |
+| Helm       |  Version 2.x, 2.9 or greater   |
 | NuoDB      |  Version [4.0](https://hub.docker.com/r/nuodb/nuodb-ce/tags) and onwards. |
+| NuoDB Helm Charts      |  For a list of supported NuoDB Helm Chart releases and where to download, click the `Releases` tab above. To enable automated notification of new releases, click the `Watch` button above and subscribe to the `Releases Only` selection.. |
 
-
-## How to use this repository?
-
-For a list of supported NuoDB Helm Chart releases and where to download, click the `Releases` tab above.
-
-To enable automated notification of new releases, click the `Watch` button above and subscribe to the `Releases Only` selection.
-
-## How do I install these charts?
+## NuoDB Helm Chart Installation
 
 To install, run `helm install nuodb/<chart>`. This is the default repository for NuoDB which is located at
  https://nuodb-charts.storage.googleapis.com/ and must be enabled to use.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ For more information on using Helm, refer to the [Helm's documentation](https://
 | Kubernetes |  The latest and previous minor versions of Kubernetes. For example, if the latest minor release of Kubernetes is 1.15 then 1.15 and 1.14 are supported. Charts may still work on previous versions of Kubernertes even though they are outside the target support window.|
 | Helm       |  Version 2.x, 2.9 or greater   |
 | NuoDB      |  Version [4.0](https://hub.docker.com/r/nuodb/nuodb-ce/tags) and onwards. |
-| NuoDB Helm Charts      |  For a list of supported NuoDB Helm Chart releases and where to download, click the `Releases` tab above. To enable automated notification of new releases, click the `Watch` button above and subscribe to the `Releases Only` selection.. |
+| NuoDB Helm Charts      |  For a list of supported NuoDB Helm Chart releases and where to download, click the `Releases` tab above. To enable automated notification of new releases, click the `Watch` button above and subscribe to the `Releases Only` selection. |
 
 ## NuoDB Helm Chart Installation
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ For more information on using Helm, refer to the [Helm's documentation](https://
 
 | Software   | Release Requirements                           | 
 |------------|------------------------------------------------|
-| Kubernetes |  The latest and previous minor versions of Kubernetes. For example, if the latest minor release of Kubernetes is 1.15 then 1.15 and 1.14 are supported. Charts may still work on previous versions of Kubernertes even though they are outside the target support window.|
+| Kubernetes |  The latest and previous minor versions of Kubernetes. For example, if the latest minor release of Kubernetes is 1.15 then 1.15 and 1.14 are supported. Charts may still work on previous versions of Kubernertes even though they are outside the target support window. To provide that support the API versions of objects should be those that work for both the latest minor release and the previous one.|
 | Helm       |  Version 2 is supported, v2.9 or greater   |
 | NuoDB      |  Version [4.0](https://hub.docker.com/r/nuodb/nuodb-ce/tags) and onwards. |
 | NuoDB Helm Charts      |  For a list of supported NuoDB Helm Chart releases and where to download, click the `Releases` tab above. To enable automated notification of new releases, click the `Watch` button above and subscribe to the `Releases Only` selection. |
@@ -72,8 +72,6 @@ Stable Charts meet the criteria in the [technical requirements](CONTRIBUTING.md#
 Incubator Charts are those that do not meet these criteria. Having the incubator folder allows charts to be shared and improved on until they are ready to be moved into the stable folder. The charts in the `incubator/` directory can be found in the [`gs://nuodb-charts-incubator` Google Storage Bucket](https://console.cloud.google.com/storage/browser/nuodb-charts-incubator).
 
 In order to get a Chart from incubator to stable, Chart maintainers should open a pull request that moves the chart folder.
-
-To provide that support the API versions of objects should be those that work for both the latest minor release and the previous one.
 
 ## Status of the Project
 

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ For more information on using Helm, refer to the [Helm's documentation](https://
 
 ## Software Release requirements
 
-| Software   |      Release Requirements                      | 
+| Software   | Release Requirements                           | 
 |------------|------------------------------------------------|
-| Kubernetes |  This chart repository supports the latest and previous minor versions of Kubernetes. For example, if the latest minor release of Kubernetes is 1.15 then 1.15 and 1.14 are supported. Charts may still work on previous versions of Kubernertes even though they are outside the target support window.|
+| Kubernetes |  The latest and previous minor versions of Kubernetes. For example, if the latest minor release of Kubernetes is 1.15 then 1.15 and 1.14 are supported. Charts may still work on previous versions of Kubernertes even though they are outside the target support window.|
 | Helm       |  2.x, 2.9 or greater   |
 | NuoDB      |  Version [4.0](https://hub.docker.com/layers/nuodb/nuodb-ce/4.0/images/sha256-aaa558ef71795f15d5b3a1ef07b6be4890925dbd023c59b1f9a674ca20614763) and onwards. |
 

--- a/README.md
+++ b/README.md
@@ -73,11 +73,8 @@ Incubator Charts are those that do not meet these criteria. Having the incubator
 
 In order to get a Chart from incubator to stable, Chart maintainers should open a pull request that moves the chart folder.
 
-
 To provide that support the API versions of objects should be those that work for both the latest minor release and the previous one.
 
-
-These chart repository supports 
 ## Status of the Project
 
 This project is still under active development, so you might run into [issues](https://github.com/nuodb/nuodb-helm-charts/issues). If you do, please don't be shy about letting us know, or better yet, contribute a fix or feature.

--- a/README.md
+++ b/README.md
@@ -22,25 +22,37 @@ The default repository for NuoDB is located at https://nuodb-charts.storage.goog
 
 To add the charts for your local client, run the `helm repo add` command below:
 
-```bash
-$ helm repo add nuodb https://nuodb-charts.storage.googleapis.com/
+```
+helm repo add nuodb https://nuodb-charts.storage.googleapis.com/
 "nuodb" has been added to your repositories
 ```
 
 To list the NuoDB charts added to your repository, run `helm search nuodb/`
 
-To install a chart, run `helm install nuodb/<chart>`
+To install a chart into your Kubernetes cluster, run 
+
+```
+helm init
+helm install nuodb/<chart>
+```
 
 ## NuoDB Helm Chart Incubator Repository
 
 The Incubator repository contains enhancements not yet available in the supported releases. To add the Incubator charts for your local client, run the `helm repo add` command below:
 
-```bash
-$ helm repo add nuodb-incubator https://nuodb-charts-incubator.storage.googleapis.com/
+```
+helm repo add nuodb-incubator https://nuodb-charts-incubator.storage.googleapis.com/
 "nuodb-incubator" has been added to your repositories
 ```
 
 To list the NuoDB incubator charts added to your repository, run `helm search nuodb-incubator/`
+
+To install an incubator chart into your Kubernetes cluster, run 
+
+```
+helm init
+helm install nuodb-incubator/<chart>
+```
 
 ## Repository Structure
 

--- a/README.md
+++ b/README.md
@@ -9,11 +9,12 @@ For more information on using Helm, refer to the [Helm's documentation](https://
 
 ## Software Release requirements
 
-**Kubernetes** - This chart repository supports the latest and previous minor versions of Kubernetes. For example, if the latest minor release of Kubernetes is 1.15 then 1.15 and 1.14 are supported. Charts may still work on previous versions of Kubernertes even though they are outside the target support window.
+| Software   |      Release Requirements                        | 
+|----------- |:------------------------------------------------:|
+| Kubernetes |  This chart repository supports the latest and previous minor versions of Kubernetes. For example, if the latest minor release of Kubernetes is 1.15 then 1.15 and 1.14 are supported. Charts may still work on previous versions of Kubernertes even though they are outside the target support window.|
+| Helm       |  2.x, 2.9 or greater   |
+| NuoDB      |  Version [4.0](https://hub.docker.com/layers/nuodb/nuodb-ce/4.0/images/sha256-aaa558ef71795f15d5b3a1ef07b6be4890925dbd023c59b1f9a674ca20614763) and onwards. |
 
-**Helm** - 2.x, 2.9 or greater
-
-**NuoDB** - Version [4.0](https://hub.docker.com/layers/nuodb/nuodb-ce/4.0/images/sha256-aaa558ef71795f15d5b3a1ef07b6be4890925dbd023c59b1f9a674ca20614763) and onwards.
 
 ## How to use this repository?
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,12 @@ Use this repository to submit official Charts for NuoDB. Charts are curated appl
 
 For more information on using Helm, refer to the [Helm's documentation](https://github.com/kubernetes/helm#docs).
 
+## Software Release requirements
+
+Kubernetes - This chart repository supports the latest and previous minor versions of Kubernetes. For example, if the latest minor release of Kubernetes is 1.15 then 1.15 and 1.14 are supported. Charts may still work on previous versions of Kubernertes even though they are outside the target support window.
+Helm - 2.x, 2.9 or greater
+NuoDB - Version [4.0](https://hub.docker.com/layers/nuodb/nuodb-ce/4.0/images/sha256-aaa558ef71795f15d5b3a1ef07b6be4890925dbd023c59b1f9a674ca20614763) and onwards.
+
 ## How to use this repository?
 
 For a list of supported NuoDB Helm Chart releases and where to download, click the `Releases` tab above.
@@ -57,16 +63,11 @@ Incubator Charts are those that do not meet these criteria. Having the incubator
 
 In order to get a Chart from incubator to stable, Chart maintainers should open a pull request that moves the chart folder.
 
-## Supported Kubernetes Versions
-
-This chart repository supports the latest and previous minor versions of Kubernetes. For example, if the latest minor release of Kubernetes is 1.8 then 1.7 and 1.8 are supported. Charts may still work on previous versions of Kubernertes even though they are outside the target supported window.
 
 To provide that support the API versions of objects should be those that work for both the latest minor release and the previous one.
 
-## Supported NuoDB Versions
 
-These chart repository supports NuoDB version [4.0](https://hub.docker.com/layers/nuodb/nuodb-ce/4.0/images/sha256-aaa558ef71795f15d5b3a1ef07b6be4890925dbd023c59b1f9a674ca20614763) and onwards.
-
+These chart repository supports 
 ## Status of the Project
 
 This project is still under active development, so you might run into [issues](https://github.com/nuodb/nuodb-helm-charts/issues). If you do, please don't be shy about letting us know, or better yet, contribute a fix or feature.

--- a/README.md
+++ b/README.md
@@ -3,14 +3,11 @@
 [![Build Status](https://travis-ci.org/nuodb/nuodb-helm-charts.svg?branch=master)](https://travis-ci.org/nuodb/nuodb-helm-charts)
 
 Use this repository to submit official Charts for NuoDB. Charts are curated application definitions for Helm. For more information about installing and using Helm, see its
-[README.md](https://github.com/helm/helm/tree/master/README.md). To get a quick introduction to Charts see this [chart document](https://github.com/helm/helm/blob/master/docs/charts.md).
-
-For more information on using Helm, refer to the [Helm's documentation](https://github.com/kubernetes/helm#docs).
+[README.md](https://github.com/helm/helm/tree/master/README.md). To get a quick introduction to Charts see this [chart document](https://github.com/helm/helm/blob/master/docs/charts.md). For more information on using Helm, refer to the [Helm's documentation](https://github.com/kubernetes/helm#docs).
 
 ## NuoDB Helm Chart Version support
 
 For a list of supported NuoDB Helm Chart releases and where to download, click the `Releases` tab above. 
-
 To enable automated notification of new releases, click the `Watch` button above and subscribe to the `Releases Only` selection. |
 
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ For more information on using Helm, refer to the [Helm's documentation](https://
 | Software   | Release Requirements                           | 
 |------------|------------------------------------------------|
 | Kubernetes |  The latest and previous minor versions of Kubernetes. For example, if the latest minor release of Kubernetes is 1.15 then 1.15 and 1.14 are supported. Charts may still work on previous versions of Kubernertes even though they are outside the target support window.|
-| Helm       |  Version 2, 2.9 or greater   |
+| Helm       |  Version 2 is supported, v2.9 or greater   |
 | NuoDB      |  Version [4.0](https://hub.docker.com/r/nuodb/nuodb-ce/tags) and onwards. |
 | NuoDB Helm Charts      |  For a list of supported NuoDB Helm Chart releases and where to download, click the `Releases` tab above. To enable automated notification of new releases, click the `Watch` button above and subscribe to the `Releases Only` selection. |
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ For more information on using Helm, refer to the [Helm's documentation](https://
 |------------|------------------------------------------------|
 | Kubernetes |  The latest and previous minor versions of Kubernetes. For example, if the latest minor release of Kubernetes is 1.15 then 1.15 and 1.14 are supported. Charts may still work on previous versions of Kubernertes even though they are outside the target support window.|
 | Helm       |  2.x, 2.9 or greater   |
-| NuoDB      |  Version [4.0](https://hub.docker.com/layers/nuodb/nuodb-ce/4.0/images/sha256-aaa558ef71795f15d5b3a1ef07b6be4890925dbd023c59b1f9a674ca20614763) and onwards. |
+| NuoDB      |  Version [4.0](https://hub.docker.com/r/nuodb/nuodb-ce/tags) and onwards. |
 
 
 ## How to use this repository?

--- a/README.md
+++ b/README.md
@@ -23,16 +23,15 @@ The default repository for NuoDB is located at https://nuodb-charts.storage.goog
 To add the charts for your local client, run the `helm repo add` command below:
 
 ```bash
-$ helm init
 $ helm repo add nuodb https://nuodb-charts.storage.googleapis.com/
 "nuodb" has been added to your repositories
 ```
 
-To list the installed NUoDB charts, run `helm search repo nuodb/`
+To list the installed NuoDB charts, run `helm search nuodb/`
 
-To install, run `helm install nuodb/<chart>`. T
+To install a chart, run `helm install nuodb/<chart>`
 
-## How do I enable the Incubator repository?
+## NuoDB Helm Chart Incubator Repository
 
 The Incubator repository contains enhancements not yet available in the supported releases. To add the Incubator charts for your local client, run the `helm repo add` command below:
 
@@ -41,7 +40,7 @@ $ helm repo add nuodb-incubator https://nuodb-charts-incubator.storage.googleapi
 "nuodb-incubator" has been added to your repositories
 ```
 
-To list the installed NuoDB incubator charts, run `helm search repo nuodb-incubator/`
+To list the installed NuoDB incubator charts, run `helm search nuodb-incubator/`
 
 ## Repository Structure
 

--- a/README.md
+++ b/README.md
@@ -9,9 +9,11 @@ For more information on using Helm, refer to the [Helm's documentation](https://
 
 ## Software Release requirements
 
-Kubernetes - This chart repository supports the latest and previous minor versions of Kubernetes. For example, if the latest minor release of Kubernetes is 1.15 then 1.15 and 1.14 are supported. Charts may still work on previous versions of Kubernertes even though they are outside the target support window.
-Helm - 2.x, 2.9 or greater
-NuoDB - Version [4.0](https://hub.docker.com/layers/nuodb/nuodb-ce/4.0/images/sha256-aaa558ef71795f15d5b3a1ef07b6be4890925dbd023c59b1f9a674ca20614763) and onwards.
+**Kubernetes** - This chart repository supports the latest and previous minor versions of Kubernetes. For example, if the latest minor release of Kubernetes is 1.15 then 1.15 and 1.14 are supported. Charts may still work on previous versions of Kubernertes even though they are outside the target support window.
+
+**Helm** - 2.x, 2.9 or greater
+
+**NuoDB** - Version [4.0](https://hub.docker.com/layers/nuodb/nuodb-ce/4.0/images/sha256-aaa558ef71795f15d5b3a1ef07b6be4890925dbd023c59b1f9a674ca20614763) and onwards.
 
 ## How to use this repository?
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ For more information on using Helm, refer to the [Helm's documentation](https://
 | Software   | Release Requirements                           | 
 |------------|------------------------------------------------|
 | Kubernetes |  The latest and previous minor versions of Kubernetes. For example, if the latest minor release of Kubernetes is 1.15 then 1.15 and 1.14 are supported. Charts may still work on previous versions of Kubernertes even though they are outside the target support window.|
-| Helm       |  Version 2.x, 2.9 or greater   |
+| Helm       |  Version 2, 2.9 or greater   |
 | NuoDB      |  Version [4.0](https://hub.docker.com/r/nuodb/nuodb-ce/tags) and onwards. |
 | NuoDB Helm Charts      |  For a list of supported NuoDB Helm Chart releases and where to download, click the `Releases` tab above. To enable automated notification of new releases, click the `Watch` button above and subscribe to the `Releases Only` selection. |
 

--- a/README.md
+++ b/README.md
@@ -18,17 +18,19 @@ For more information on using Helm, refer to the [Helm's documentation](https://
 
 ## NuoDB Helm Chart Installation
 
-To install, run `helm install nuodb/<chart>`. This is the default repository for NuoDB which is located at
- https://nuodb-charts.storage.googleapis.com/ and must be enabled to use.
+The default repository for NuoDB is located at https://nuodb-charts.storage.googleapis.com/ and must be enabled.
 
 To add the charts for your local client, run the `helm repo add` command below:
 
 ```bash
+$ helm init
 $ helm repo add nuodb https://nuodb-charts.storage.googleapis.com/
 "nuodb" has been added to your repositories
 ```
 
 To list the installed NUoDB charts, run `helm search repo nuodb/`
+
+To install, run `helm install nuodb/<chart>`. T
 
 ## How do I enable the Incubator repository?
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ helm init
 helm install nuodb/<chart>
 ```
 
-## NuoDB Helm Chart Incubator Repository
+## NuoDB Helm Chart Incubator Repository Installation
 
 The Incubator repository contains enhancements not yet available in the supported releases. To add the Incubator charts for your local client, run the `helm repo add` command below:
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Use this repository to submit official Charts for NuoDB. Charts are curated appl
 ## NuoDB Helm Chart Version support
 
 For a list of supported NuoDB Helm Chart releases and where to download, click the `Releases` tab above. 
-To enable automated notification of new releases, click the `Watch` button above and subscribe to the `Releases Only` selection. |
+To enable automated notification of new releases, click the `Watch` button above and subscribe to the `Releases Only` selection.
 
 
 ## Software Release requirements


### PR DESCRIPTION
Readme page corrections:
1. added software version requirements section - previously we did not mention Helm version 2 is required. Some of the commands where documented using Helm v3. The issue has been corrected.
2. Installation instructions previously had the Helm install command first, then Helm add. It should be reversed. The doc has been corrected.