### PR TITLE
Minor improvements to the tests

### DIFF
--- a/test/integration/database_marshall_test.go
+++ b/test/integration/database_marshall_test.go
@@ -1,0 +1,31 @@
+package integration
+
+import (
+	"github.com/nuodb/nuodb-helm-charts/test/testlib"
+	"gotest.tools/assert"
+	"testing"
+)
+
+func TestDatabaseUnmarshal(t *testing.T) {
+	s := (
+		`{
+  "incarnation": {
+    "major": 1, 
+    "minor": 2
+  }, 
+  "name": "demo", 
+  "state": "NOT_RUNNING", 
+  "uri": "https://localhost:8888/api/1/databases/demo"
+}`)
+
+	err, objects := testlib.UnmarshalDatabase(s)
+
+	assert.NilError(t, err)
+	assert.Equal(t, len(objects), 1)
+
+	obj := objects[0]
+
+	assert.Check(t, obj.Name == "demo")
+	assert.Check(t, obj.State == "NOT_RUNNING")
+
+}

--- a/test/integration/database_marshall_test.go
+++ b/test/integration/database_marshall_test.go
@@ -27,5 +27,7 @@ func TestDatabaseUnmarshal(t *testing.T) {
 
 	assert.Check(t, obj.Name == "demo")
 	assert.Check(t, obj.State == "NOT_RUNNING")
+	assert.Check(t, obj.Incarnation.Major == 1)
+	assert.Check(t, obj.Incarnation.Minor == 2)
 
 }

--- a/test/minikube/minikube_test_test.go
+++ b/test/minikube/minikube_test_test.go
@@ -125,15 +125,3 @@ func TestGetExtractedOptions(t *testing.T) {
 	})
 
 }
-
-func TestParseIncarnations(t *testing.T) {
-
-	incarnation := `   incarnation:(3, 0)
-	[SM] sm-database-j7uzoi-nuodb-cluster0-demo-hotcopy-0/172.17.0.11:48006 [start_id = 3] [server_id = admin-uz7aiw-nuodb-cluster0-0] [pid = 152] [node_id = 1] [last_ack =  1.09] MONITORED:RUNNING
-	[TE] te-database-j7uzoi-nuodb-cluster0-demo-7789b6c57f-99xnz/172.17.0.4:48006 [start_id = 4] [server_id = admin-uz7aiw-nuodb-cluster0-0] [pid = 38] [node_id = 2] [last_ack =  0.56] MONITORED:RUNNING`
-
-	result := testlib.ParseDatabaseIncarnation(t, incarnation)
-
-	assert.Check(t, result[0] == 3)
-	assert.Check(t, result[1] == 0)
-}

--- a/test/testlib/NuoDBDatabase.go
+++ b/test/testlib/NuoDBDatabase.go
@@ -1,0 +1,32 @@
+package testlib
+
+import (
+	"encoding/json"
+	"io"
+	"strings"
+)
+
+type NuoDBDatabase struct {
+	Name string `json:"name"`
+	Processes string `json:"processes"`
+	State string `json:"state"`
+}
+
+func UnmarshalDatabase(s string) (err error, databases []NuoDBDatabase) {
+	dec := json.NewDecoder(strings.NewReader(s))
+
+	for {
+		var obj NuoDBDatabase
+		err = dec.Decode(&obj)
+		if err == io.EOF {
+			// all done
+			return nil, databases
+		}
+
+		if err != nil {
+			return
+		}
+
+		databases = append(databases, obj)
+	}
+}

--- a/test/testlib/NuoDBDatabase.go
+++ b/test/testlib/NuoDBDatabase.go
@@ -6,7 +6,13 @@ import (
 	"strings"
 )
 
+type DBVersion struct {
+	Major int `json:"major"`
+	Minor int `json:"minor"`
+}
+
 type NuoDBDatabase struct {
+	Incarnation DBVersion `json:"incarnation"`
 	Name string `json:"name"`
 	Processes string `json:"processes"`
 	State string `json:"state"`

--- a/test/testlib/constants.go
+++ b/test/testlib/constants.go
@@ -1,7 +1,5 @@
 package testlib
 
-import "regexp"
-
 const CA_CERT_FILE = "ca.cert"
 const CA_CERT_FILE_NEW = "ca_new.cert"
 const CA_CERT_SECRET = "nuodb-ca-cert"
@@ -41,4 +39,4 @@ const MINIMAL_VIABLE_ENGINE_MEMORY = "500Mi"
 
 const NOT_RUNNING_ADMIN_DB_STATE = "NOT_RUNNING"
 
-const K8s_EVENT_LOG_FILE = "kubernetes_event.log"
+const K8S_EVENT_LOG_FILE = "kubernetes_event.log"

--- a/test/testlib/constants.go
+++ b/test/testlib/constants.go
@@ -1,17 +1,13 @@
 package testlib
 
-import (
-	"regexp"
-)
+import "regexp"
 
 const CA_CERT_FILE = "ca.cert"
 const CA_CERT_FILE_NEW = "ca_new.cert"
 const CA_CERT_SECRET = "nuodb-ca-cert"
-const CA_CERT_SECRET_NEW = "nuodb-ca-cert-new"
 
 const KEYSTORE_FILE = "nuoadmin.p12"
 const KEYSTORE_SECRET = "nuodb-keystore"
-const KEYSTORE_SECRET_NEW = "nuodb-keystore-new"
 
 const TRUSTSTORE_FILE = "nuoadmin-truststore.p12"
 const TRUSTSTORE_SECRET = "nuodb-truststore"
@@ -38,12 +34,12 @@ const THP_HELM_CHART_PATH = "../../stable/transparent-hugepage"
 
 const RESULT_DIR = "../../results"
 
-const LAST_BACKUP_PREFIX string = "nuodb-backup/last_created"
 const IMPORT_ARCHIVE_URL = "http://download.nuohub.org/ce_releases/restore.bak.tz"
 
 const MINIMAL_VIABLE_ENGINE_CPU = "500m"
 const MINIMAL_VIABLE_ENGINE_MEMORY = "500Mi"
 
+<<<<<<< 5d146e048796eb5d2b04270dd0ddfe8667845408
 const INCARNATION_REGEX = "incarnation: *[(]([0-9]+) *, *([0-9]+)[)]"
 
 var INCARNATION_PATTERN *regexp.Regexp

--- a/test/testlib/constants.go
+++ b/test/testlib/constants.go
@@ -53,3 +53,5 @@ func init() {
 }
 
 const K8s_EVENT_LOG_FILE = "kubernetes_event.log"
+
+const NOT_RUNNING_ADMIN_DB_STATE = "NOT_RUNNING"

--- a/test/testlib/constants.go
+++ b/test/testlib/constants.go
@@ -39,15 +39,6 @@ const IMPORT_ARCHIVE_URL = "http://download.nuohub.org/ce_releases/restore.bak.t
 const MINIMAL_VIABLE_ENGINE_CPU = "500m"
 const MINIMAL_VIABLE_ENGINE_MEMORY = "500Mi"
 
-<<<<<<< 5d146e048796eb5d2b04270dd0ddfe8667845408
-const INCARNATION_REGEX = "incarnation: *[(]([0-9]+) *, *([0-9]+)[)]"
-
-var INCARNATION_PATTERN *regexp.Regexp
-
-func init() {
-	INCARNATION_PATTERN = regexp.MustCompile(INCARNATION_REGEX)
-}
+const NOT_RUNNING_ADMIN_DB_STATE = "NOT_RUNNING"
 
 const K8s_EVENT_LOG_FILE = "kubernetes_event.log"
-
-const NOT_RUNNING_ADMIN_DB_STATE = "NOT_RUNNING"

--- a/test/testlib/constants.go
+++ b/test/testlib/constants.go
@@ -37,6 +37,4 @@ const IMPORT_ARCHIVE_URL = "http://download.nuohub.org/ce_releases/restore.bak.t
 const MINIMAL_VIABLE_ENGINE_CPU = "500m"
 const MINIMAL_VIABLE_ENGINE_MEMORY = "500Mi"
 
-const NOT_RUNNING_ADMIN_DB_STATE = "NOT_RUNNING"
-
 const K8S_EVENT_LOG_FILE = "kubernetes_event.log"

--- a/test/testlib/minikube_utilities.go
+++ b/test/testlib/minikube_utilities.go
@@ -588,7 +588,7 @@ func GetAdminEventLog(t *testing.T, namespace string, podName string) {
 	if t.Failed() && shouldPrintToStdout() {
 		data, err := ioutil.ReadFile(filePath)
 		assert.NilError(t, err)
-		t.Log(data)
+		t.Log(string(data))
 	}
 }
 

--- a/test/testlib/minikube_utilities.go
+++ b/test/testlib/minikube_utilities.go
@@ -566,6 +566,21 @@ func getAppLogStream(t *testing.T, namespace string, podName string) io.ReadClos
 	return reader
 }
 
+func GetAdminEventLog(t *testing.T, namespace string, podName string) {
+	if !t.Failed() {
+		return
+	}
+	
+	options := k8s.NewKubectlOptions("", "")
+	options.Namespace = namespace
+
+	_, err := k8s.RunKubectlAndGetOutputE(t, options,
+		"exec", podName, "--",
+		"cat", "/var/log/nuodb/nuoadmin_event.log",
+	)
+	assert.NilError(t, err, "GetAdminEventLog: exec cat event_log")
+}
+
 func GetSecret(t *testing.T, namespace string, secretName string) *corev1.Secret {
 	options := k8s.NewKubectlOptions("", "")
 	options.Namespace = namespace

--- a/test/testlib/minikube_utilities.go
+++ b/test/testlib/minikube_utilities.go
@@ -586,9 +586,10 @@ func GetAdminEventLog(t *testing.T, namespace string, podName string) {
 	)
 
 	if t.Failed() && shouldPrintToStdout() {
-		data, err := ioutil.ReadFile(filePath)
-		assert.NilError(t, err)
-		t.Log(string(data))
+		k8s.RunKubectl(t, options,
+			"exec", podName, "--",
+			"cat", "/var/log/nuodb/nuoadmin_event.log",
+		)
 	}
 }
 

--- a/test/testlib/minikube_utilities.go
+++ b/test/testlib/minikube_utilities.go
@@ -614,34 +614,6 @@ func GetDaemonSet(t *testing.T, namespace string, daemonSetName string) *v1.Daem
 	return &object
 }
 
-func AwaitDatabaseNotRunning(t *testing.T, namespace string, dbName string, podName string) {
-	options := k8s.NewKubectlOptions("", "")
-	options.Namespace = namespace
-
-	Await(t, func() bool {
-		output, err := k8s.RunKubectlAndGetOutputE(t, options, "exec", podName, "--", "nuocmd", "--show-json", "get", "databases")
-		if err != nil {
-			t.Logf("AwaitDatabaseNotRunning failed with: %s", err)
-			return false;
-		}
-
-		err, databases := UnmarshalDatabase(output)
-		if err != nil {
-			t.Logf("AwaitDatabaseNotRunning failed with: %s", err)
-			return false;
-		}
-
-		for _, db := range databases {
-			if db.Name == dbName {
-				return db.State == NOT_RUNNING_ADMIN_DB_STATE
-			}
-		}
-
-		t.Logf("AwaitDatabaseNotRunning could not find database: %s", dbName)
-		return false
-	}, 30*time.Second )
-}
-
 func DeleteDatabase(t *testing.T, namespace string, dbName string, podName string) {
 	options := k8s.NewKubectlOptions("", "")
 	options.Namespace = namespace

--- a/test/testlib/nuodb_admin_utilities.go
+++ b/test/testlib/nuodb_admin_utilities.go
@@ -65,7 +65,10 @@ func StartAdmin(t *testing.T, options *helm.Options, replicaCount int, namespace
 
 		// first await could be pulling the image from the repo
 		AwaitAdminPodUp(t, namespaceName, adminName, 300*time.Second)
-		AddTeardown("admin", func() { GetAppLog(t, namespaceName, adminName, "") })
+		AddTeardown("admin", func() {
+			GetAppLog(t, namespaceName, adminName, "")
+			GetAdminEventLog(t, namespaceName, adminName)
+		})
 	}
 
 	for i := 0; i < replicaCount; i++ {

--- a/test/testlib/nuodb_database_utilities.go
+++ b/test/testlib/nuodb_database_utilities.go
@@ -72,6 +72,7 @@ func StartDatabase(t *testing.T, namespaceName string, adminPod string, options 
 	AddTeardown(TEARDOWN_DATABASE, func() {
 		helm.Delete(t, options, helmChartReleaseName, true)
 		AwaitNoPods(t, namespaceName, helmChartReleaseName)
+		AwaitDatabaseNotRunning(t, namespaceName, opt.DbName, adminPod) // workaround for DB-29815
 		DeleteDatabase(t, namespaceName, opt.DbName, adminPod)
 	})
 

--- a/test/testlib/nuodb_database_utilities.go
+++ b/test/testlib/nuodb_database_utilities.go
@@ -72,7 +72,6 @@ func StartDatabase(t *testing.T, namespaceName string, adminPod string, options 
 	AddTeardown(TEARDOWN_DATABASE, func() {
 		helm.Delete(t, options, helmChartReleaseName, true)
 		AwaitNoPods(t, namespaceName, helmChartReleaseName)
-		AwaitDatabaseNotRunning(t, namespaceName, opt.DbName, adminPod) // workaround for DB-29815
 		DeleteDatabase(t, namespaceName, opt.DbName, adminPod)
 	})
 


### PR DESCRIPTION
1) Replace incarnation parsing by JSON. We have seen the regex kill the build a few times in the past. The last instance was today https://travis-ci.org/nuodb/nuodb-helm-charts/jobs/643426609?utm_medium=notification&utm_source=github_status

2) remove unused variables and code

3) recover the Admin Event log. This is required for debugging of admin issues and is different from the K8s event log.