### PR TITLE
allow a user to override admin services suffixes

### DIFF
--- a/stable/admin/README.md
+++ b/stable/admin/README.md
@@ -199,6 +199,8 @@ The following tables list the configurable parameters for the `admin` option of 
 | `tlsTrustStore.password` | TLS truststore secret password | `nil` |
 | `tlsClientPEM.secret` | TLS client PEM secret name | `nil` |
 | `tlsClientPEM.key` | TLS client PEM secret key | `nil` |
+| `serviceSuffix.balancer` | The suffix to use for the LoadBalancer service name | `balancer` |
+| `serviceSuffix.clusterip` | The suffix to use for the ClusterIP service name | `clusterip` |
 
 For example, when using GlusterFS storage class, you would supply the following parameter:
 

--- a/stable/admin/templates/service-clusterip.yaml
+++ b/stable/admin/templates/service-clusterip.yaml
@@ -11,7 +11,7 @@ metadata:
     domain: {{ .Values.admin.domain }}
     chart: {{ template "admin.chart" . }}
     release: {{ .Release.Name | quote }}
-  name: {{ .Values.admin.domain }}-clusterip
+  name: {{ .Values.admin.domain }}-{{ .Values.admin.serviceSuffix.clusterip }}
 spec:
   ports:
   - { name: 8888-tcp,   port: 8888,   protocol: TCP,  targetPort: 8888  }

--- a/stable/admin/templates/service.yaml
+++ b/stable/admin/templates/service.yaml
@@ -19,7 +19,7 @@ metadata:
     domain: {{ .Values.admin.domain }}
     chart: {{ template "admin.chart" . }}
     release: {{ .Release.Name | quote }}
-  name: {{ .Values.admin.domain }}-balancer
+  name: {{ .Values.admin.domain }}-{{ .Values.admin.serviceSuffix.balancer }}
 spec:
   ports:
   - { name: 8888-tcp,   port: 8888,   protocol: TCP,  targetPort: 8888  }

--- a/stable/admin/values.yaml
+++ b/stable/admin/values.yaml
@@ -146,3 +146,7 @@ admin:
   # tlsClientPEM:
   #   secret: nuodb-client-pem
   #   key: nuocmd.pem
+
+  serviceSuffix:
+    clusterip: clusterip
+    balancer: balancer


### PR DESCRIPTION
allow a user to have more controler over the name of the clusterip and
load balancer admin services name by overriding
admin.serviceSuffix.balancer and admin.serviceSuffix.clusterip if
desired, default for these suffixes is blancer and clusterip
respectively

Signed-off-by: Abdallah Chatila <abdallah@kaloom.com>