### PR TITLE
prefix admin job-lb-policy with the value of admin.domain

### DIFF
--- a/stable/admin/templates/job.yaml
+++ b/stable/admin/templates/job.yaml
@@ -7,7 +7,7 @@ metadata:
     domain: {{ .Values.admin.domain }}
     chart: {{ template "admin.chart" . }}
     release: {{ .Release.Name | quote }}
-  name: job-lb-policy-{{ .Values.admin.lbPolicy | lower }}
+  name: {{ .Values.admin.domain }}-job-lb-policy-{{ .Values.admin.lbPolicy | lower }}
 spec:
   parallelism: 1
   completions: 1


### PR DESCRIPTION
prefix admin job-lb-policy with {{.Values.admin.domain }} to avoid
cluttering and to ensure jobs name with the same policy would not
collide if multiple cluster of nuodb get deployed in kubernetes

Signed-off-by: Abdallah Chatila <abdallah@kaloom.com>