### PR TITLE
prefix admin job-lb-policy with the value of admin.domain

### DIFF
--- a/stable/admin/templates/job.yaml
+++ b/stable/admin/templates/job.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   labels:
-    app: job-lb-policy-{{ template "admin.fullname" . }}
+    app: {{ .Values.admin.domain }}-job-lb-policy-{{ template "admin.fullname" . }}
     group: nuodb
     domain: {{ .Values.admin.domain }}
     chart: {{ template "admin.chart" . }}
@@ -14,12 +14,12 @@ spec:
   template:
     metadata:
       labels:
-        app: job-lb-policy-{{ template "admin.fullname" . }}
+        app: {{ .Values.admin.domain }}-job-lb-policy-{{ template "admin.fullname" . }}
         group: nuodb
         domain: {{ .Values.admin.domain }}
         chart: {{ template "admin.chart" . }}
         release: {{ .Release.Name | quote }}
-      name: job-lb-policy-{{ .Values.admin.lbPolicy | lower }}
+      name: {{ .Values.admin.domain }}-job-lb-policy-{{ .Values.admin.lbPolicy | lower }}
     spec:
       initContainers:
       - name: wait

--- a/test/minikube/minikube_base_admin_test.go
+++ b/test/minikube/minikube_base_admin_test.go
@@ -8,10 +8,14 @@ import (
 	"testing"
 	"time"
 
-	"github.com/nuodb/nuodb-helm-charts/test/testlib"
 	"github.com/gruntwork-io/terratest/modules/helm"
 	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/gruntwork-io/terratest/modules/random"
+	"github.com/nuodb/nuodb-helm-charts/test/testlib"
+)
+
+const (
+	adminDomainName = "nuodb"
 )
 
 func TestKubernetesBasicAdminSingleReplica(t *testing.T) {
@@ -25,9 +29,9 @@ func TestKubernetesBasicAdminSingleReplica(t *testing.T) {
 
 	helmChartReleaseName, namespaceName := testlib.StartAdmin(t, &options, 1, "")
 
-	admin0 := fmt.Sprintf("%s-nuodb-cluster0-0", helmChartReleaseName)
-	headlessServiceName := fmt.Sprintf("nuodb")
-	clusterServiceName := fmt.Sprintf("nuodb-clusterip")
+	admin0 := fmt.Sprintf("%s-%s-cluster0-0", helmChartReleaseName, adminDomainName)
+	headlessServiceName := adminDomainName
+	clusterServiceName := fmt.Sprintf("%s-clusterip", adminDomainName)
 
 	t.Run("verifyAdminState", func(t *testing.T) { testlib.VerifyAdminState(t, namespaceName, admin0) })
 	t.Run("verifyOrderedLicensing", func(t *testing.T) {
@@ -39,7 +43,7 @@ func TestKubernetesBasicAdminSingleReplica(t *testing.T) {
 	})
 	t.Run("verifyAdminHeadlessService", func(t *testing.T) { verifyAdminService(t, namespaceName, admin0, headlessServiceName, true) })
 	t.Run("verifyAdminClusterService", func(t *testing.T) { verifyAdminService(t, namespaceName, admin0, clusterServiceName, false) })
-	t.Run("verifyLBPolicy", func(t *testing.T) { verifyLBPolicy(t, namespaceName, admin0) })
+	t.Run("verifyLBPolicy", func(t *testing.T) { verifyLBPolicy(t, namespaceName, admin0, adminDomainName) })
 	t.Run("verifyPodKill", func(t *testing.T) { verifyPodKill(t, namespaceName, admin0, helmChartReleaseName, 1) })
 	t.Run("verifyProcessKill", func(t *testing.T) { verifyKillProcess(t, namespaceName, admin0, helmChartReleaseName, 1) })
 }
@@ -60,7 +64,7 @@ func TestKubernetesInvalidLicense(t *testing.T) {
 
 	helmChartReleaseName, namespaceName := testlib.StartAdmin(t, options, 1, "")
 
-	admin0 := fmt.Sprintf("%s-nuodb-cluster0-0", helmChartReleaseName)
+	admin0 := fmt.Sprintf("%s-%s-cluster0-0", helmChartReleaseName, adminDomainName)
 
 	t.Run("verifyOrderedLicensing", func(t *testing.T) {
 		testlib.VerifyLicenseIsCommunity(t, namespaceName, admin0)

--- a/test/minikube/minikube_base_admin_test.go
+++ b/test/minikube/minikube_base_admin_test.go
@@ -14,10 +14,6 @@ import (
 	"github.com/nuodb/nuodb-helm-charts/test/testlib"
 )
 
-const (
-	adminDomainName = "nuodb"
-)
-
 func TestKubernetesBasicAdminSingleReplica(t *testing.T) {
 	testlib.AwaitTillerUp(t)
 

--- a/test/minikube/minikube_long_admin_test.go
+++ b/test/minikube/minikube_long_admin_test.go
@@ -23,9 +23,9 @@ func TestKubernetesBasicAdminThreeReplicas(t *testing.T) {
 
 	helmChartReleaseName, namespaceName := testlib.StartAdmin(t, &options, 3, "")
 
-	admin0 := fmt.Sprintf("%s-nuodb-cluster0-0", helmChartReleaseName)
-	headlessServiceName := fmt.Sprintf("nuodb")
-	clusterServiceName := fmt.Sprintf("nuodb-clusterip")
+	admin0 := fmt.Sprintf("%s-%s-cluster0-0", helmChartReleaseName, adminDomainName)
+	headlessServiceName := adminDomainName
+	clusterServiceName := fmt.Sprintf("%s-clusterip", adminDomainName)
 
 	t.Run("verifyAdminState", func(t *testing.T) { testlib.VerifyAdminState(t, namespaceName, admin0) })
 	t.Run("verifyOrderedLicensing", func(t *testing.T) {
@@ -34,7 +34,7 @@ func TestKubernetesBasicAdminThreeReplicas(t *testing.T) {
 	})
 	t.Run("verifyAdminHeadlessService", func(t *testing.T) { verifyAdminService(t, namespaceName, admin0, headlessServiceName, true) })
 	t.Run("verifyAdminClusterService", func(t *testing.T) { verifyAdminService(t, namespaceName, admin0, clusterServiceName, false) })
-	t.Run("verifyLBPolicy", func(t *testing.T) { verifyLBPolicy(t, namespaceName, admin0) })
+	t.Run("verifyLBPolicy", func(t *testing.T) { verifyLBPolicy(t, namespaceName, admin0, adminDomainName) })
 	t.Run("verifyPodKill", func(t *testing.T) { verifyPodKill(t, namespaceName, admin0, helmChartReleaseName, 3) })
 	t.Run("verifyProcessKill", func(t *testing.T) { verifyKillProcess(t, namespaceName, admin0, helmChartReleaseName, 3) })
 }

--- a/test/minikube/minikube_rolling_upgrade_test.go
+++ b/test/minikube/minikube_rolling_upgrade_test.go
@@ -40,14 +40,15 @@ func TestKubernetesUpgradeAdminMinorVersion(t *testing.T) {
 
 	helmChartReleaseName, namespaceName := testlib.StartAdmin(t, &options, 1, "")
 
-	admin0 := fmt.Sprintf("%s-nuodb-cluster0-0", helmChartReleaseName)
+	admin0 := fmt.Sprintf("%s-%s-cluster0-0", helmChartReleaseName, adminDomainName)
 
-	testlib.AwaitBalancerTerminated(t, namespaceName, "job-lb-policy")
+	jobLBPolicy := fmt.Sprintf("%s-job-lb-policy-nearest", adminDomainName)
+	testlib.AwaitBalancerTerminated(t, namespaceName, jobLBPolicy)
 
 	// all jobs need to be deleted before an upgrade can be performed
 	// so far we have not found an automated way to delete them as part of a pre-upgrade hook
 	// if we find it, this line can be removed and the test should still pass
-	testlib.DeletePod(t, namespaceName, "jobs/job-lb-policy-nearest")
+	testlib.DeletePod(t, namespaceName, "jobs/"+jobLBPolicy)
 
 	options.SetValues["nuodb.image.tag"] = NEW_RELEASE
 
@@ -72,7 +73,9 @@ func TestKubernetesUpgradeFullDatabaseMinorVersion(t *testing.T) {
 
 	adminHelmChartReleaseName, namespaceName := testlib.StartAdmin(t, &options, 1, "")
 
-	admin0 := fmt.Sprintf("%s-nuodb-cluster0-0", adminHelmChartReleaseName)
+	admin0 := fmt.Sprintf("%s-%s-cluster0-0", adminHelmChartReleaseName, adminDomainName)
+
+	jobLBPolicy := fmt.Sprintf("%s-job-lb-policy-nearest", adminDomainName)
 
 	defer testlib.Teardown(testlib.TEARDOWN_DATABASE) // ensure resources allocated in called functions are released when this function exits
 
@@ -88,12 +91,12 @@ func TestKubernetesUpgradeFullDatabaseMinorVersion(t *testing.T) {
 
 	databaseHelmChartReleaseName := testlib.StartDatabase(t, namespaceName, admin0, &databaseOptions)
 
-	testlib.AwaitBalancerTerminated(t, namespaceName, "job-lb-policy")
+	testlib.AwaitBalancerTerminated(t, namespaceName, jobLBPolicy)
 
 	// all jobs need to be deleted before an upgrade can be performed
 	// so far we have not found an automated way to delete them as part of a pre-upgrade hook
 	// if we find it, this line can be removed and the test should still pass
-	testlib.DeletePod(t, namespaceName, "jobs/job-lb-policy-nearest")
+	testlib.DeletePod(t, namespaceName, "jobs/"+jobLBPolicy)
 	testlib.DeletePod(t, namespaceName, "jobs/hotcopy-demo-job-initial")
 
 	options.SetValues["nuodb.image.tag"] = NEW_RELEASE
@@ -150,16 +153,17 @@ func TestKubernetesRollingUpgradeAdminMinorVersion(t *testing.T) {
 
 	helmChartReleaseName, namespaceName := testlib.StartAdmin(t, &options, 3, "")
 
-	admin0 := fmt.Sprintf("%s-nuodb-cluster0-0", helmChartReleaseName)
-	admin1 := fmt.Sprintf("%s-nuodb-cluster0-1", helmChartReleaseName)
-	admin2 := fmt.Sprintf("%s-nuodb-cluster0-2", helmChartReleaseName)
+	admin0 := fmt.Sprintf("%s-%s-cluster0-0", helmChartReleaseName, adminDomainName)
+	admin1 := fmt.Sprintf("%s-%s-cluster0-1", helmChartReleaseName, adminDomainName)
+	admin2 := fmt.Sprintf("%s-%s-cluster0-2", helmChartReleaseName, adminDomainName)
 
-	testlib.AwaitBalancerTerminated(t, namespaceName, "job-lb-policy")
+	jobLBPolicy := fmt.Sprintf("%s-job-lb-policy-nearest", adminDomainName)
+	testlib.AwaitBalancerTerminated(t, namespaceName, jobLBPolicy)
 
 	// all jobs need to be deleted before an upgrade can be performed
 	// so far we have not found an automated way to delete them as part of a pre-upgrade hook
 	// if we find it, this line can be removed and the test should still pass
-	testlib.DeletePod(t, namespaceName, "jobs/job-lb-policy-nearest")
+	testlib.DeletePod(t, namespaceName, "jobs/"+jobLBPolicy)
 
 	options.SetValues["nuodb.image.tag"] = NEW_RELEASE
 

--- a/test/minikube/verify_utility.go
+++ b/test/minikube/verify_utility.go
@@ -1,10 +1,11 @@
 package minikube
 
 import (
+        "fmt"
 	"github.com/nuodb/nuodb-helm-charts/test/testlib"
+	"gotest.tools/assert"
 	"testing"
 	"time"
-	"gotest.tools/assert"
 )
 
 func verifyAdminService(t *testing.T, namespaceName string, podName string, serviceName string, ping bool) {
@@ -17,8 +18,9 @@ func verifyAdminService(t *testing.T, namespaceName string, podName string, serv
 	}
 }
 
-func verifyLBPolicy(t *testing.T, namespaceName string, podName string) {
-	testlib.AwaitBalancerTerminated(t, namespaceName, "job-lb-policy")
+func verifyLBPolicy(t *testing.T, namespaceName string, podName string, domainName string) {
+	jobLBPolicy := fmt.Sprintf("%s-job-lb-policy-nearest", domainName)
+	testlib.AwaitBalancerTerminated(t, namespaceName, jobLBPolicy)
 	testlib.VerifyPolicyInstalled(t, namespaceName, podName)
 }
 

--- a/test/minikube/verify_utility.go
+++ b/test/minikube/verify_utility.go
@@ -1,11 +1,15 @@
 package minikube
 
 import (
-        "fmt"
+	"fmt"
 	"github.com/nuodb/nuodb-helm-charts/test/testlib"
 	"gotest.tools/assert"
 	"testing"
 	"time"
+)
+
+const (
+	adminDomainName = "nuodb"
 )
 
 func verifyAdminService(t *testing.T, namespaceName string, podName string, serviceName string, ping bool) {

--- a/test/scripts/deploy.sh
+++ b/test/scripts/deploy.sh
@@ -10,6 +10,7 @@ set -o pipefail
 : ${PLATFORM:="google"}
 : ${TILLER_NAMESPACE:="nuodb"}
 : ${DOMAIN_NAME:="cashews"}
+: ${CLUSTER_NAME:="cluster0"}
 : ${VALUE_CLASS:="tiny"}
 
 # optionally set to 'nuodb' or nuodb-incubator'
@@ -59,15 +60,15 @@ restart () {
 status () {
   local term="${1?Specify term}"
   local expected="${2?Specify expected}"
-  result=( $(kubectl get pods --all-namespaces | grep ${term} | awk '{ print $4 }') )
-  [ $result == ${expected} ];
+  local result=( $(kubectl get pods --all-namespaces | grep ${term} | awk '{ print $4 }') )
+  [ "${result}" == "${expected}" ];
 }
 
 ready () {
   local term="${1?Specify term}"
   local count="${2?Specify count}"
-  result=( $(kubectl get pods --all-namespaces | grep ${term} | awk '{ print $3 }') )
-  [ $result == $count ];
+  local result=( $(kubectl get pods --all-namespaces | grep ${term} | awk '{ print $3 }') )
+  [ "${result}" == "${count}" ];
 }
 
 check () {
@@ -108,19 +109,19 @@ helm install ${REPO_NAME}/admin --name admin \
 
 sleep 180
 
-check-pod "admin-${DOMAIN_NAME}-0" "1/1"
+check-pod "admin-${DOMAIN_NAME}-${CLUSTER_NAME}-0" "1/1"
 
 # check and delete the lb policy jobs
 
 check-job "${DOMAIN_NAME}-job-lb-policy-nearest" "0/1"
 kubectl delete jobs --all
 
-kubectl scale sts admin-${DOMAIN_NAME} --replicas=3
+kubectl scale sts admin-${DOMAIN_NAME}-${CLUSTER_NAME} --replicas=3
 
 sleep 180
 
-check-pod "admin-${DOMAIN_NAME}-1" "1/1"
-check-pod "admin-${DOMAIN_NAME}-2" "1/1"
+check-pod "admin-${DOMAIN_NAME}-${CLUSTER_NAME}-1" "1/1"
+check-pod "admin-${DOMAIN_NAME}-${CLUSTER_NAME}-2" "1/1"
 
 helm install ${REPO_NAME}/database --name database \
   ${values_option} \

--- a/test/scripts/deploy.sh
+++ b/test/scripts/deploy.sh
@@ -112,7 +112,7 @@ check-pod "admin-${DOMAIN_NAME}-0" "1/1"
 
 # check and delete the lb policy jobs
 
-check-job "job-lb-policy-nearest" "0/1"
+check-job "${DOMAIN_NAME}-job-lb-policy-nearest" "0/1"
 kubectl delete jobs --all
 
 kubectl scale sts admin-${DOMAIN_NAME} --replicas=3


### PR DESCRIPTION
prefix admin job-lb-policy with {{.Values.admin.domain }} to ensure
jobs name with the same policy would not collide if multiple cluster
of nuodb get deployed in kubernetes

Signed-off-by: Abdallah Chatila <abdallah@kaloom.com>