### PR TITLE
Add customisation to database service names to correspond to admin services

### DIFF
--- a/stable/admin/README.md
+++ b/stable/admin/README.md
@@ -235,12 +235,12 @@ Any file located in `admin.configFilesPath` can be replaced; the YAML key corres
 
 #### admin.serviceSuffix
 
-The purpose of this section s to allow customisation of the names of the clusterIP and balancer admin services (load-balancers).
+The purpose of this section is to allow customisation of the names of the clusterIP and balancer admin services (load-balancers).
 
 | Key | Description | Default |
 | ----- | ----------- | ------ |
 | `clusterip` | suffix for the clusterIP load-balancer | "clusterip" |
-| `nuoadmin.conf` | suffix for the balancer service | "balancer" |
+| `balancer` | suffix for the balancer service | "balancer" |
 
 
 ### Running

--- a/stable/admin/README.md
+++ b/stable/admin/README.md
@@ -226,14 +226,22 @@ There are two sets of configuration files documented:
 
 Any file located in `admin.configFilesPath` can be replaced; the YAML key corresponds to the file name being created or replaced.
 
-The following tables list the configurable parameters for the `admin` option of the admin chart and their default values.
-
 | Key | Description | Default |
 | ----- | ----------- | ------ |
 | `nuodb.lic` | [NuoDB license file content; defaults to NuoDB CE Edition][3] | `nil` |
 | `nuoadmin.conf` | [NuoDB Admin host properties][4] | `nil` |
 | `nuodb-types.config`| [Type mappings for the NuoDB Migrator tool][5] | `nil` |
 | `nuoadmin.logback.xml` | Logging configuration. NuoDB recommends using the default settings. | `nil` |
+
+#### admin.serviceSuffix
+
+The purpose of this section s to allow customisation of the names of the clusterIP and balancer admin services (load-balancers).
+
+| Key | Description | Default |
+| ----- | ----------- | ------ |
+| `clusterip` | suffix for the clusterIP load-balancer | "clusterip" |
+| `nuoadmin.conf` | suffix for the balancer service | "balancer" |
+
 
 ### Running
 

--- a/stable/database/README.md
+++ b/stable/database/README.md
@@ -188,7 +188,7 @@ admin:
 
 #### admin.configFiles.*
 
-The purpose of this section is to detail how to provide alternate configuration files for NuoDB. NuoDB has several configuration files that may be modified to suit.
+The purpose of this section is to detail how to provide alternative configuration files for NuoDB. NuoDB has several configuration files that may be modified to suit.
 
 There are two sets of configuration files documented:
 
@@ -197,14 +197,21 @@ There are two sets of configuration files documented:
 
 Any file located in `admin.configFilesPath` can be replaced; the YAML key corresponds to the file name being created or replaced.
 
-The following tables list the configurable parameters for the `admin` option of the admin chart and their default values.
-
 | Key | Description | Default |
 | ----- | ----------- | ------ |
 | `nuodb.lic` | [NuoDB license file content; defaults to NuoDB CE Edition][3] | `nil` |
 | `nuoadmin.conf` | [NuoDB Admin host properties][4] | `nil` |
 | `nuodb-types.config`| [Type mappings for the NuoDB Migrator tool][5] | `nil` |
 | `nuoadmin.logback.xml` | Logging configuration. NuoDB recommends using the default settings. | `nil` |
+
+#### admin.serviceSuffix
+
+The purpose of this section s to allow customisation of the names of the clusterIP and balancer admin services (load-balancers).
+
+| Key | Description | Default |
+| ----- | ----------- | ------ |
+| `clusterip` | suffix for the clusterIP load-balancer | "clusterip" |
+| `nuoadmin.conf` | suffix for the balancer service | "balancer" |
 
 #### backup.*
 
@@ -306,6 +313,15 @@ The following tables list the configurable parameters for the `database` option 
 | Key | Description | Default |
 | ----- | ----------- | ------ |
 | `nuodb.config` | [NuoDB database options][6] | `nil` |
+
+#### database.serviceSuffix
+
+The purpose of this section s to allow customisation of the names of the clusterIP and balancer database services (load-balancers).
+
+| Key | Description | Default |
+| ----- | ----------- | ------ |
+| `clusterip` | suffix for the clusterIP load-balancer | .Values.admin.serviceSuffix.clusterip |
+| `nuoadmin.conf` | suffix for the balancer service | .Values.admin.serviceSuffix.balancer |
 
 ### Running
 

--- a/stable/database/README.md
+++ b/stable/database/README.md
@@ -206,12 +206,12 @@ Any file located in `admin.configFilesPath` can be replaced; the YAML key corres
 
 #### admin.serviceSuffix
 
-The purpose of this section s to allow customisation of the names of the clusterIP and balancer admin services (load-balancers).
+The purpose of this section is to allow customisation of the names of the clusterIP and balancer admin services (load-balancers).
 
 | Key | Description | Default |
 | ----- | ----------- | ------ |
 | `clusterip` | suffix for the clusterIP load-balancer | "clusterip" |
-| `nuoadmin.conf` | suffix for the balancer service | "balancer" |
+| `balancer` | suffix for the balancer service | "balancer" |
 
 #### backup.*
 
@@ -308,20 +308,18 @@ There are two sets of configuration files documented:
 
 Any file located in `database.configFilesPath` can be replaced; the YAML key corresponds to the file name being created or replaced.
 
-The following tables list the configurable parameters for the `database` option of the database chart and their default values.
-
 | Key | Description | Default |
 | ----- | ----------- | ------ |
 | `nuodb.config` | [NuoDB database options][6] | `nil` |
 
 #### database.serviceSuffix
 
-The purpose of this section s to allow customisation of the names of the clusterIP and balancer database services (load-balancers).
+The purpose of this section is to allow customisation of the names of the clusterIP and balancer database services (load-balancers).
 
 | Key | Description | Default |
 | ----- | ----------- | ------ |
 | `clusterip` | suffix for the clusterIP load-balancer | .Values.admin.serviceSuffix.clusterip |
-| `nuoadmin.conf` | suffix for the balancer service | .Values.admin.serviceSuffix.balancer |
+| `balancer` | suffix for the balancer service | .Values.admin.serviceSuffix.balancer |
 
 ### Running
 

--- a/stable/database/templates/service-clusterip.yaml
+++ b/stable/database/templates/service-clusterip.yaml
@@ -12,7 +12,7 @@ metadata:
     domain: {{ .Values.admin.domain }}
     chart: {{ template "database.chart" . }}
     release: {{ .Release.Name | quote }}
-  name: {{ .Values.database.name }}-clusterip
+  name: {{ .Values.database.name }}-{{ default .Values.admin.serviceSuffix.clusterip .Values.database.serviceSuffix.clusterip }}
 spec:
   ports:
   - { name: 48006-tcp,  port: 48006,  protocol: TCP,  targetPort: 48006 }

--- a/stable/database/templates/service.yaml
+++ b/stable/database/templates/service.yaml
@@ -20,7 +20,7 @@ metadata:
     domain: {{ .Values.admin.domain }}
     chart: {{ template "database.chart" . }}
     release: {{ .Release.Name | quote }}
-  name: {{ .Values.database.name }}-balancer
+  name: {{ .Values.database.name }}-{{ default .Values.admin.serviceSuffix.balancer .Values.database.serviceSuffix.balancer }}
 spec:
   ports:
   - { name: 48006-tcp,  port: 48006,  protocol: TCP,  targetPort: 48006 }

--- a/stable/database/values.yaml
+++ b/stable/database/values.yaml
@@ -77,6 +77,10 @@ admin:
   #   secret: nuodb-client-pem
   #   key: nuocmd.pem
 
+  serviceSuffix:
+    clusterip: "clusterip"
+    balancer: "balancer"
+
 database:
   ## Provide a name in place of prometheus-operator for `app:` labels
   ##
@@ -156,6 +160,12 @@ database:
     credentials: ""
     stripLevels: "1"
     type: ""
+
+  # The names of the clusterIP and balancer services can be adjusted by customising the suffix
+  # The default is to use the same as specified for the admin clusterIP and balancer load-balancers.
+  serviceSuffix:
+    clusterip: ""
+    balancer: ""
 
   sm:
     ## Enable persistent log volumes to retain logs when an external logging solution is not used.

--- a/test/testlib/minikube_utilities.go
+++ b/test/testlib/minikube_utilities.go
@@ -313,7 +313,7 @@ func AwaitDatabaseUp(t *testing.T, namespace string, podName string, databaseNam
 	k8s.RunKubectl(t, options, "exec", podName, "--", "nuocmd", "check", "database",
 		"--db-name", databaseName, "--check-running", "--check-liveness", "20",
 		"--num-processes", strconv.Itoa(numProcesses),
-		"--timeout", "300")
+		"--timeout", "600")
 }
 
 func GetDiagnoseOnTestFailure(t *testing.T, namespace string, podName string) {


### PR DESCRIPTION
A follow-on to PR #57.

Add suffixes to services (load-balancers) in the database to match the changes in admin from #57.

I chose to implement a separate set of values: `database.serviceSuffix`.
These default to the values in `admin.serviceSuffix` - created in #57.

An alternative was to directly reuse the values in `admin.serviceSuffix` - which would have logically required a rename of the values.

Happy to have discussion in this PR on the structure of the values.