### PR TITLE
Fix kill process test

### DIFF
--- a/tmp.yaml
+++ b/tmp.yaml
@@ -1,5 +1,0 @@
-nuodb:
-    image:
-        registry: registry.internal.nuodb.com
-        repository: nightly/master-centos7
-        tag: latest

--- a/tmp.yaml
+++ b/tmp.yaml
@@ -1,0 +1,5 @@
+nuodb:
+    image:
+        registry: registry.internal.nuodb.com
+        repository: nightly/master-centos7
+        tag: latest


### PR DESCRIPTION
The kill process test exited too early, without verifying that the pod gets actually rescheduled.

Spotted by @api-Hypernova 