### PR TITLE
Add privileged:true for OpenShift environments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,14 +11,21 @@ go:
 env:
   jobs:
     - TEST_SUITE=basic
+
     - TEST_SUITE=minikube-short REQUIRES_MINIKUBE=true
     - TEST_SUITE=minikube-long REQUIRES_MINIKUBE=true
+
+    # does not work due to KVM/Virtualbox limitations of Travis
+    # Minishift can not run with --vm-driver=none https://github.com/minishift/minishift/issues/2757
+    #- TEST_SUITE=minikube-short REQUIRES_MINISHIFT=true
+    #- TEST_SUITE=minikube-long REQUIRES_MINISHIFT=true
   global:
     - HELM_VERSION="v2.9.0"
     - DEP_VERSION=0.5.4
     - KUBERNETES_VERSION=1.15.0
+    - OPENSHIFT_VERSION=3.11.0
     - MINIKUBE_VERSION=1.2.0
-    - CHANGE_MINIKUBE_NONE_USER=true
+    - MINISHIFT_VERSION=1.34.2
     - MINIKUBE_WANTUPDATENOTIFICATION=false
     - MINIKUBE_WANTREPORTERRORPROMPT=false
     - MINIKUBE_HOME=$HOME
@@ -26,7 +33,6 @@ env:
     - KUBECONFIG=$HOME/.kube/config
     - NUODB_PRINT_TO_STDOUT=true
     - NUODB_GET_DIAGNOSE=true
-    - NUODB_VERSION=4.0.4
 
 before_install:
   - sudo apt-get update

--- a/scripts/ci/install_deps.sh
+++ b/scripts/ci/install_deps.sh
@@ -60,6 +60,14 @@ elif [[ -n "$REQUIRES_MINISHIFT" ]]; then
   helm version
 
   kubectl version
+
+  # disable THP to match minikube
+  oc adm policy add-scc-to-user privileged system:serviceaccount:tiller:default
+  oc adm policy add-scc-to-user privileged system:serviceaccount:tiller:tiller
+
+  helm install --set openshift.enabled=true stable/transparent-hugepage/
+
+
 else
   echo "Skipping installation steps"
 fi

--- a/scripts/ci/install_deps.sh
+++ b/scripts/ci/install_deps.sh
@@ -27,6 +27,8 @@ if [[ -n "$REQUIRES_MINIKUBE" ]]; then
 
   # print some info
   helm version
+
+  kubectl version
 elif [[ -n "$REQUIRES_MINISHIFT" ]]; then
   wget https://github.com/openshift/origin/releases/download/v3.11.0/openshift-origin-client-tools-v3.11.0-0cbc58b-linux-64bit.tar.gz -O /tmp/oc.tar.gz
   tar xzf /tmp/oc.tar.gz -C /tmp --strip-components=1 && chmod +x /tmp/oc && sudo mv /tmp/oc /usr/local/bin
@@ -59,8 +61,8 @@ elif [[ -n "$REQUIRES_MINISHIFT" ]]; then
   oc rollout status deployment tiller
 
   helm version
+
+  kubectl version
 else
   echo "Skipping installation steps"
 fi
-
-kubectl version

--- a/scripts/ci/install_deps.sh
+++ b/scripts/ci/install_deps.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# exit when any command fails
+set -e
+
 # Download kubectl, which is a requirement for using minikube.
 curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v"${KUBERNETES_VERSION}"/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
 
@@ -7,28 +10,57 @@ curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v"${K
 wget https://get.helm.sh/helm-"${HELM_VERSION}"-linux-amd64.tar.gz -O /tmp/helm.tar.gz
 tar xzf /tmp/helm.tar.gz -C /tmp --strip-components=1 && chmod +x /tmp/helm && sudo mv /tmp/helm /usr/local/bin
 
-if [[ -z "$REQUIRES_MINIKUBE" ]]; then
-    echo "Skipping minikube installation step"
-    exit 0
+if [[ -n "$REQUIRES_MINIKUBE" ]]; then
+    # Download minikube.
+  curl -Lo minikube https://storage.googleapis.com/minikube/releases/v"${MINIKUBE_VERSION}"/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
+  mkdir -p "$HOME"/.kube "$HOME"/.minikube
+  touch "$KUBECONFIG"
+
+  # start minikube
+  sudo minikube start --vm-driver=none --kubernetes-version=v"${KUBERNETES_VERSION}" --memory=8000 --cpus=4
+  sudo chown -R travis: /home/travis/.minikube/
+  kubectl cluster-info
+
+  # install helm
+  # Use default K8s service account as a workaround explained in https://github.com/helm/helm/issues/3460
+  helm init --service-account default
+
+  # print some info
+  helm version
+elif [[ -n "$REQUIRES_MINISHIFT" ]]; then
+  wget https://github.com/openshift/origin/releases/download/v3.11.0/openshift-origin-client-tools-v3.11.0-0cbc58b-linux-64bit.tar.gz -O /tmp/oc.tar.gz
+  tar xzf /tmp/oc.tar.gz -C /tmp --strip-components=1 && chmod +x /tmp/oc && sudo mv /tmp/oc /usr/local/bin
+
+  oc version
+
+  sudo apt install libvirt-bin qemu-kvm
+  sudo usermod -a -G libvirtd "$(whoami)"
+
+  curl -L https://github.com/dhiltgen/docker-machine-kvm/releases/download/v0.10.0/docker-machine-driver-kvm-ubuntu14.04 -o /tmp/docker-machine-driver-kvm
+  chmod +x /tmp/docker-machine-driver-kvm && sudo mv /tmp/docker-machine-driver-kvm /usr/local/bin
+
+  wget https://github.com/minishift/minishift/releases/download/v"${MINISHIFT_VERSION}"/minishift-"${MINISHIFT_VERSION}"-linux-amd64.tgz -O /tmp/minishift.tar.gz
+  tar xzf /tmp/minishift.tar.gz -C /tmp --strip-components=1 && chmod +x /tmp/minishift && sudo mv /tmp/minishift /usr/local/bin
+
+  sudo minishift start --openshift-version=v"${OPENSHIFT_VERSION}" --memory=8000 --cpus=4
+
+  oc login -u system:admin
+  oc status
+
+  kubectl cluster-info
+
+  export TILLER_NAMESPACE=tiller
+
+  oc new-project tiller
+  oc project
+
+  oc process -f https://github.com/openshift/origin/raw/master/examples/helm/tiller-template.yaml -p TILLER_NAMESPACE="${TILLER_NAMESPACE}" -p HELM_VERSION="${HELM_VERSION}" | oc create -f -
+
+  oc rollout status deployment tiller
+
+  helm version
+else
+  echo "Skipping installation steps"
 fi
 
-# Download minikube.
-curl -Lo minikube https://storage.googleapis.com/minikube/releases/v"${MINIKUBE_VERSION}"/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
-mkdir -p "$HOME"/.kube "$HOME"/.minikube
-touch "$KUBECONFIG"
-
-# start minikube
-sudo minikube start --vm-driver=none --kubernetes-version=v"${KUBERNETES_VERSION}" --memory=8000 --cpus=4
-sudo chown -R travis: /home/travis/.minikube/
-kubectl cluster-info
-
-# install helm
-# Use default K8s service account as a workaround explained in https://github.com/helm/helm/issues/3460
-helm init --service-account default
-
-# get the image to speed up tests
-docker pull nuodb/nuodb-ce:"${NUODB_VERSION}"
-docker pull nuodb/nuodb-ce:latest
-
-# print some info
-helm version
+kubectl version

--- a/scripts/ci/install_deps.sh
+++ b/scripts/ci/install_deps.sh
@@ -25,9 +25,6 @@ if [[ -n "$REQUIRES_MINIKUBE" ]]; then
   # Use default K8s service account as a workaround explained in https://github.com/helm/helm/issues/3460
   helm init --service-account default
 
-  # print some info
-  helm version
-
   kubectl version
 elif [[ -n "$REQUIRES_MINISHIFT" ]]; then
   wget https://github.com/openshift/origin/releases/download/v3.11.0/openshift-origin-client-tools-v3.11.0-0cbc58b-linux-64bit.tar.gz -O /tmp/oc.tar.gz

--- a/stable/admin/README.md
+++ b/stable/admin/README.md
@@ -147,17 +147,8 @@ The following tables list the configurable parameters for the `openshift` option
 | Parameter | Description | Default |
 | ----- | ----------- | ------ |
 | `enabled` | Enable OpenShift features | `false` |
-| `enableDeploymentConfigs` | Prefer DeploymentConfig over Deployment |`false`|
-| `enableRoutes` | Enable OpenShift routes | `true` |
 
-For example, to enable an OpenShift integration, and enable routes:
-
-```yaml
-openshift:
-  enabled: true
-  enableDeploymentConfigs: false
-  enableRoutes: true
-```
+Enabling OpenShift will automatically run all Kubernetes objects with elevated `privileges`.
 
 #### admin.*
 

--- a/stable/admin/templates/_helpers.tpl
+++ b/stable/admin/templates/_helpers.tpl
@@ -128,9 +128,8 @@ Add capabilities in a securityContext
 */}}
 {{- define "admin.capabilities" -}}
 {{- with .Values.admin.securityContext.capabilities }}
-securityContext:
-  capabilities:
-    add: {{ . }}
+capabilities:
+  add: {{ . }}
 {{- end }}
 {{- end -}}
 

--- a/stable/admin/templates/statefulset.yaml
+++ b/stable/admin/templates/statefulset.yaml
@@ -44,6 +44,10 @@ spec:
       - name: init-disk
         image: {{ template "init.image" . }}
         imagePullPolicy: {{ default "" .Values.busybox.image.pullPolicy }}
+{{- if .Values.openshift.enabled }}
+        securityContext:
+          privileged: true
+{{- end }}
         command: ['chmod' , '770', '/var/opt/nuodb', '/var/log/nuodb']
         volumeMounts:
         - name: raftlog
@@ -54,7 +58,13 @@ spec:
       - name: admin
         image: {{ template "nuodb.image" . }}
         imagePullPolicy: {{ .Values.nuodb.image.pullPolicy }}
-    {{- include "admin.capabilities" . | indent 8 }}
+{{- if or (.Values.openshift.enabled) (.Values.admin.securityContext.capabilities) }}
+        securityContext:
+{{- if .Values.openshift.enabled }}
+          privileged: true
+{{- end}}
+        {{- include "admin.capabilities" . | indent 10 }}
+{{- end }}
         ports:
         - { containerPort: 8888,  protocol: TCP }
         - { containerPort: 48004, protocol: TCP }

--- a/stable/admin/values.yaml
+++ b/stable/admin/values.yaml
@@ -95,11 +95,15 @@ admin:
     # storageClass: "-"
 
   ## Use a securityContext to specify additional capabilities
+  # Typically set to runAsUser and/or fsGroup to 0 or 1000.
   # For example, if the container needs to configure network setting, then add "NET_ADMIN"
   # Ex: capabilities: [ "NET_ADMIN" ]
   ##
   securityContext:
     capabilities: []
+    enabled: false
+    runAsUser: 1000
+    fsGroup: 0
 
   ## Specify one or more configMaps to import Environment Variables from
   # Ex:  configMapRef: [ myConfigMap, myOtherConfigMap ]
@@ -173,3 +177,7 @@ admin:
   serviceSuffix:
     clusterip: clusterip
     balancer: balancer
+
+openshift:
+  # change this to true if you want to deploy using OpenShift proprietary features
+  enabled: false

--- a/stable/admin/values.yaml
+++ b/stable/admin/values.yaml
@@ -95,15 +95,11 @@ admin:
     # storageClass: "-"
 
   ## Use a securityContext to specify additional capabilities
-  # Typically set to runAsUser and/or fsGroup to 0 or 1000.
   # For example, if the container needs to configure network setting, then add "NET_ADMIN"
   # Ex: capabilities: [ "NET_ADMIN" ]
   ##
   securityContext:
     capabilities: []
-    enabled: false
-    runAsUser: 1000
-    fsGroup: 0
 
   ## Specify one or more configMaps to import Environment Variables from
   # Ex:  configMapRef: [ myConfigMap, myOtherConfigMap ]

--- a/stable/database/README.md
+++ b/stable/database/README.md
@@ -150,6 +150,8 @@ The following tables list the configurable parameters for the `openshift` option
 | `enableDeploymentConfigs` | Prefer DeploymentConfig over Deployment |`false`|
 | `enableRoutes` | Enable OpenShift routes | `true` |
 
+Enabling OpenShift will automatically run all Kubernetes objects with elevated `privileges`.
+
 For example, to enable an OpenShift integration, and enable routes:
 
 ```yaml
@@ -158,6 +160,7 @@ openshift:
   enableDeploymentConfigs: false
   enableRoutes: true
 ```
+
 
 #### admin.*
 

--- a/stable/database/templates/_helpers.tpl
+++ b/stable/database/templates/_helpers.tpl
@@ -151,9 +151,8 @@ Add capabilities in a securityContext
 */}}
 {{- define "database.capabilities" -}}
 {{- with .Values.database.securityContext.capabilities }}
-securityContext:
-  capabilities:
-    add: {{ . }}
+capabilities:
+  add: {{ . }}
 {{- end }}
 {{- end -}}
 

--- a/stable/database/templates/daemonset.yaml
+++ b/stable/database/templates/daemonset.yaml
@@ -46,7 +46,13 @@ spec:
       - name: sm
         image: {{ template "nuodb.image" . }}
         imagePullPolicy: {{ .Values.nuodb.image.pullPolicy }}
-    {{- include "database.capabilities" . | indent 8 }}
+{{- if or (.Values.openshift.enabled) (.Values.database.securityContext.capabilities) }}
+        securityContext:
+{{- if .Values.openshift.enabled }}
+          privileged: true
+{{- end}}
+        {{- include "database.capabilities" . | indent 10 }}
+{{- end }}
         args:
           - "nuosm"
           - "--servers-ready-timeout"
@@ -247,7 +253,13 @@ spec:
       - name: sm
         image: {{ template "nuodb.image" . }}
         imagePullPolicy: {{ .Values.nuodb.image.pullPolicy }}
-    {{- include "database.capabilities" . | indent 8 }}
+{{- if or (.Values.openshift.enabled) (.Values.database.securityContext.capabilities) }}
+        securityContext:
+{{- if .Values.openshift.enabled }}
+          privileged: true
+{{- end}}
+        {{- include "database.capabilities" . | indent 10 }}
+{{- end }}
         args:
           - "nuosm"
           - "--servers-ready-timeout"

--- a/stable/database/templates/deployment.yaml
+++ b/stable/database/templates/deployment.yaml
@@ -45,7 +45,13 @@ spec:
       - name: te-{{ template "database.fullname" . }}
         image: {{ template "nuodb.image" . }}
         imagePullPolicy: {{ .Values.nuodb.image.pullPolicy }}
-    {{- include "database.capabilities" . | indent 8 }}
+{{- if or (.Values.openshift.enabled) (.Values.database.securityContext.capabilities) }}
+        securityContext:
+          {{- if .Values.openshift.enabled }}
+          privileged: true
+{{- end}}
+        {{- include "database.capabilities" . | indent 10 }}
+{{- end }}
         args:
           - "nuote"
           - "--database-created-timeout"

--- a/stable/database/templates/deploymentconfig.yaml
+++ b/stable/database/templates/deploymentconfig.yaml
@@ -44,7 +44,9 @@ spec:
       - name: te-{{ template "database.fullname" . }}
         image: {{ template "nuodb.image" . }}
         imagePullPolicy: {{ .Values.nuodb.image.pullPolicy }}
-    {{- include "database.capabilities" . | indent 8 }}
+        securityContext:
+          privileged: true
+    {{- include "database.capabilities" . | indent 10 }}
         args:
           - "nuote"
           - "--database-created-timeout"

--- a/stable/database/templates/statefulset.yaml
+++ b/stable/database/templates/statefulset.yaml
@@ -55,6 +55,10 @@ spec:
       - name: init-disk
         image: {{ template "init.image" . }}
         imagePullPolicy: {{ default "" .Values.busybox.image.pullPolicy | quote }}
+{{- if .Values.openshift.enabled }}
+        securityContext:
+          privileged: true
+{{- end }}
         command: ['chmod' , '770', '/var/opt/nuodb/archive', '/var/log/nuodb']
         volumeMounts:
         - name: archive-volume
@@ -65,7 +69,13 @@ spec:
       - name: sm
         image: {{ template "nuodb.image" . }}
         imagePullPolicy: {{ .Values.nuodb.image.pullPolicy }}
-    {{- include "database.capabilities" . | indent 8 }}
+{{- if or (.Values.openshift.enabled) (.Values.database.securityContext.capabilities) }}
+        securityContext:
+{{- if .Values.openshift.enabled }}
+          privileged: true
+{{- end}}
+        {{- include "database.capabilities" . | indent 10 }}
+{{- end }}
         args: 
           - "nuosm"
           - "--servers-ready-timeout"
@@ -345,6 +355,10 @@ spec:
       - name: init-disk
         image: {{ template "init.image" . }}
         imagePullPolicy: {{ default "" .Values.busybox.image.pullPolicy | quote }}
+{{- if .Values.openshift.enabled }}
+        securityContext:
+          privileged: true
+{{- end }}
         command: ['chmod' , '770', '/var/opt/nuodb/archive', 'var/opt/nuodb/backup', '/var/log/nuodb']
         volumeMounts:
         - name: archive-volume
@@ -357,7 +371,13 @@ spec:
       - name: sm
         image: {{ template "nuodb.image" . }}
         imagePullPolicy: {{ .Values.nuodb.image.pullPolicy }}
-    {{- include "database.capabilities" . | indent 8 }}
+{{- if or (.Values.openshift.enabled) (.Values.database.securityContext.capabilities) }}
+        securityContext:
+{{- if .Values.openshift.enabled }}
+          privileged: true
+{{- end}}
+        {{- include "database.capabilities" . | indent 10 }}
+{{- end }}
         args:
           - "nuosm"
           - "--servers-ready-timeout"

--- a/stable/transparent-hugepage/README.md
+++ b/stable/transparent-hugepage/README.md
@@ -99,6 +99,19 @@ busybox:
     pullPolicy: Always
 ```
 
+#### openshift.*
+
+The purpose of this section is to specify parameters specific to OpenShift, e.g. enable features only present in OpenShift.
+
+The following tables list the configurable parameters for the `openshift` option:
+
+| Parameter | Description | Default |
+| ----- | ----------- | ------ |
+| `enabled` | Enable OpenShift features | `false` |
+
+Enabling OpenShift will automatically run all Kubernetes objects with elevated `privileges`.
+
+
 #### thp.*
 
 The following tables list the configurable parameters of the transparent-hugepages chart and their default values.

--- a/stable/transparent-hugepage/templates/daemonset.yaml
+++ b/stable/transparent-hugepage/templates/daemonset.yaml
@@ -43,6 +43,10 @@ spec:
       - name: disable-thp
         image: {{ template "thp.image" . }}
         imagePullPolicy: {{ default "" .Values.busybox.image.pullPolicy }}
+{{- if .Values.openshift.enabled }}
+        securityContext:
+          privileged: true
+{{- end }}
         volumeMounts:
         - name: host-sys
           mountPath: /host-sys
@@ -51,6 +55,10 @@ spec:
       - name: busybox
         image: {{ template "thp.image" . }}
         imagePullPolicy: {{ default "" .Values.busybox.image.pullPolicy }}
+{{- if .Values.openshift.enabled }}
+        securityContext:
+          privileged: true
+{{- end }}
         volumeMounts:
         - name: host-sys
           mountPath: /host-sys

--- a/stable/transparent-hugepage/values.yaml
+++ b/stable/transparent-hugepage/values.yaml
@@ -51,3 +51,7 @@ thp:
 
   # nodeSelector: {}
   # tolerations: []
+
+openshift:
+  # change this to true if you want to deploy using OpenShift proprietary features
+  enabled: false

--- a/test/integration/template_thp_test.go
+++ b/test/integration/template_thp_test.go
@@ -1,0 +1,49 @@
+package integration
+
+import (
+	"github.com/gruntwork-io/terratest/modules/helm"
+	"gotest.tools/assert"
+	appsv1 "k8s.io/api/apps/v1"
+	"strings"
+	"testing"
+)
+
+func TestThpOpenShift(t *testing.T) {
+	// Path to the helm chart we will test
+	helmChartPath := "../../stable/transparent-hugepage"
+
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"openshift.enabled": "true",
+		},
+	}
+
+	// Run RenderTemplate to render the template and capture the output.
+	output := helm.RenderTemplate(t, options, helmChartPath, []string{"templates/daemonset.yaml"})
+
+	cnt := 0
+
+	parts := strings.Split(output, "---")
+	for _, part := range parts {
+		if len(part) == 0 {
+			continue
+		}
+
+		if !strings.Contains(part, "kind: DaemonSet") {
+			continue
+		}
+
+		cnt += 1
+
+		var object appsv1.DaemonSet
+		helm.UnmarshalK8SYaml(t, part, &object)
+
+		assert.Assert(t, object.Spec.Template.Spec.InitContainers[0].SecurityContext.Privileged != nil)
+		assert.Assert(t, object.Spec.Template.Spec.Containers[0].SecurityContext.Privileged != nil)
+
+		assert.Check(t, *object.Spec.Template.Spec.InitContainers[0].SecurityContext.Privileged == true)
+		assert.Check(t, *object.Spec.Template.Spec.Containers[0].SecurityContext.Privileged == true)
+	}
+
+	assert.Check(t, cnt == 1)
+}

--- a/test/minikube/minikube_base_admin_test.go
+++ b/test/minikube/minikube_base_admin_test.go
@@ -8,16 +8,17 @@ import (
 	"testing"
 	"time"
 
-	"github.com/nuodb/nuodb-helm-charts/test/testlib"
 	"github.com/gruntwork-io/terratest/modules/helm"
-	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/gruntwork-io/terratest/modules/random"
+	"github.com/nuodb/nuodb-helm-charts/test/testlib"
 )
 
 func TestKubernetesBasicAdminSingleReplica(t *testing.T) {
 	testlib.AwaitTillerUp(t)
 
-	options := helm.Options{}
+	options := helm.Options{
+		SetValues: map[string]string{},
+	}
 
 	defer testlib.Teardown(testlib.TEARDOWN_ADMIN)
 
@@ -87,14 +88,11 @@ func TestKubernetesBasicNameOverride(t *testing.T) {
 			"admin.fullnameOverride": nonDefaultName,
 		},
 	}
-	kubectlOptions := k8s.NewKubectlOptions("", "")
-	options.KubectlOptions = kubectlOptions
 
-	namespaceName := fmt.Sprintf("testadminsinglereplica-%s", randomSuffix)
-	k8s.CreateNamespace(t, kubectlOptions, namespaceName)
+	namespaceName := fmt.Sprintf("testbasicnameoverride-%s", randomSuffix)
+	testlib.CreateNamespace(t, namespaceName)
+
 	options.KubectlOptions.Namespace = namespaceName
-
-	defer k8s.DeleteNamespace(t, kubectlOptions, namespaceName)
 
 	helm.Install(t, options, testlib.ADMIN_HELM_CHART_PATH, helmChartReleaseName)
 

--- a/test/minikube/minikube_base_admin_test.go
+++ b/test/minikube/minikube_base_admin_test.go
@@ -16,6 +16,7 @@ import (
 
 func TestKubernetesBasicAdminSingleReplica(t *testing.T) {
 	testlib.AwaitTillerUp(t)
+	defer testlib.VerifyTeardown(t)
 
 	options := helm.Options{
 		SetValues: map[string]string{},
@@ -46,6 +47,7 @@ func TestKubernetesBasicAdminSingleReplica(t *testing.T) {
 
 func TestKubernetesInvalidLicense(t *testing.T) {
 	testlib.AwaitTillerUp(t)
+	defer testlib.VerifyTeardown(t)
 
 	licenseString := "red-riding-hood"
 	customFile := "customFile"
@@ -76,6 +78,7 @@ func TestKubernetesInvalidLicense(t *testing.T) {
 
 func TestKubernetesBasicNameOverride(t *testing.T) {
 	testlib.AwaitTillerUp(t)
+	defer testlib.VerifyTeardown(t)
 
 	randomSuffix := strings.ToLower(random.UniqueId())
 

--- a/test/minikube/minikube_base_admin_test.go
+++ b/test/minikube/minikube_base_admin_test.go
@@ -93,6 +93,8 @@ func TestKubernetesBasicNameOverride(t *testing.T) {
 		},
 	}
 
+	defer testlib.Teardown(testlib.TEARDOWN_ADMIN)
+
 	kubectlOptions := k8s.NewKubectlOptions("", "")
 	options.KubectlOptions = kubectlOptions
 

--- a/test/minikube/minikube_base_admin_test.go
+++ b/test/minikube/minikube_base_admin_test.go
@@ -17,9 +17,7 @@ import (
 func TestKubernetesBasicAdminSingleReplica(t *testing.T) {
 	testlib.AwaitTillerUp(t)
 
-	options := helm.Options{
-		SetValues: map[string]string{},
-	}
+	options := helm.Options{}
 
 	defer testlib.Teardown(testlib.TEARDOWN_ADMIN)
 

--- a/test/minikube/minikube_base_admin_test.go
+++ b/test/minikube/minikube_base_admin_test.go
@@ -4,6 +4,7 @@ package minikube
 
 import (
 	"fmt"
+	"github.com/gruntwork-io/terratest/modules/k8s"
 	"strings"
 	"testing"
 	"time"
@@ -88,6 +89,9 @@ func TestKubernetesBasicNameOverride(t *testing.T) {
 			"admin.fullnameOverride": nonDefaultName,
 		},
 	}
+
+	kubectlOptions := k8s.NewKubectlOptions("", "")
+	options.KubectlOptions = kubectlOptions
 
 	namespaceName := fmt.Sprintf("testbasicnameoverride-%s", randomSuffix)
 	testlib.CreateNamespace(t, namespaceName)

--- a/test/minikube/minikube_base_database_test.go
+++ b/test/minikube/minikube_base_database_test.go
@@ -187,6 +187,7 @@ func restoreDatabase(t *testing.T, namespaceName string, podName string, databas
 
 func TestKubernetesBasicDatabase(t *testing.T) {
 	testlib.AwaitTillerUp(t)
+	defer testlib.VerifyTeardown(t)
 
 	options := helm.Options{}
 
@@ -288,6 +289,7 @@ func TestKubernetesBasicDatabase(t *testing.T) {
 
 func TestKubernetesAltAddress(t *testing.T) {
 	testlib.AwaitTillerUp(t)
+	defer testlib.VerifyTeardown(t)
 
 	options := helm.Options{}
 
@@ -318,6 +320,7 @@ func TestKubernetesAltAddress(t *testing.T) {
 
 func TestKubernetesBackupDatabase(t *testing.T) {
 	testlib.AwaitTillerUp(t)
+	defer testlib.VerifyTeardown(t)
 
 	adminOptions := helm.Options{}
 
@@ -375,6 +378,7 @@ func TestKubernetesBackupDatabase(t *testing.T) {
 
 func TestKubernetesRestoreDatabase(t *testing.T) {
 	testlib.AwaitTillerUp(t)
+	defer testlib.VerifyTeardown(t)
 
 	adminOptions := helm.Options{}
 
@@ -448,6 +452,7 @@ func TestKubernetesRestoreDatabase(t *testing.T) {
 
 func TestKubernetesImportDatabase(t *testing.T) {
 	testlib.AwaitTillerUp(t)
+	defer testlib.VerifyTeardown(t)
 
 	adminOptions := helm.Options{}
 

--- a/test/minikube/minikube_base_thp_test.go
+++ b/test/minikube/minikube_base_thp_test.go
@@ -88,6 +88,7 @@ func scheduleLabelMismatch(t *testing.T, helmChartPath string, namespaceName str
 
 func TestKubernetesDefaultMinikubeTHP(t *testing.T) {
 	testlib.AwaitTillerUp(t)
+	defer testlib.VerifyTeardown(t)
 
 	randomSuffix := strings.ToLower(random.UniqueId())
 
@@ -97,6 +98,8 @@ func TestKubernetesDefaultMinikubeTHP(t *testing.T) {
 
 	kubectlOptions := k8s.NewKubectlOptions("", "")
 	options.KubectlOptions = kubectlOptions
+
+	defer testlib.Teardown(testlib.TEARDOWN_ADMIN) // some namespace cleanup
 
 	namespaceName := fmt.Sprintf("testthp-%s", randomSuffix)
 	testlib.CreateNamespace(t, namespaceName)

--- a/test/minikube/minikube_base_thp_test.go
+++ b/test/minikube/minikube_base_thp_test.go
@@ -113,10 +113,7 @@ func TestKubernetesDefaultMinikubeTHP(t *testing.T) {
 	options.KubectlOptions = kubectlOptions
 
 	namespaceName := fmt.Sprintf("testthp-%s", randomSuffix)
-	k8s.CreateNamespace(t, kubectlOptions, namespaceName)
-	options.KubectlOptions.Namespace = namespaceName
-
-	defer k8s.DeleteNamespace(t, kubectlOptions, namespaceName)
+	testlib.CreateNamespace(t, namespaceName)
 
 	/*
 		These tests do not verify that THP can be turned off via DaemonSet.

--- a/test/minikube/minikube_base_thp_test.go
+++ b/test/minikube/minikube_base_thp_test.go
@@ -16,20 +16,6 @@ import (
 	"gotest.tools/assert"
 )
 
-func labelMinikubeNode(t *testing.T, namespace string, labelName string, labelValue string) {
-	options := k8s.NewKubectlOptions("", "")
-	options.Namespace = namespace
-
-	var labelString string
-
-	if labelValue != "" {
-		labelString = fmt.Sprintf("%s=%s", labelName, labelValue)
-	} else {
-		labelString = fmt.Sprintf("%s-", labelName)
-	}
-
-	k8s.RunKubectl(t, options, "label", "nodes", "minikube", labelString, "--overwrite")
-}
 
 func scheduleDefault(t *testing.T, helmChartPath string, namespaceName string) {
 	randomSuffix := strings.ToLower(random.UniqueId())
@@ -66,7 +52,7 @@ func scheduleLabel(t *testing.T, helmChartPath string, namespaceName string) {
 	options.KubectlOptions = kubectlOptions
 	options.KubectlOptions.Namespace = namespaceName
 
-	labelMinikubeNode(t, namespaceName, "failure-domain.beta.kubernetes.io/zone", randomSuffix)
+	testlib.LabelNodes(t, namespaceName, "failure-domain.beta.kubernetes.io/zone", randomSuffix)
 
 	helm.Install(t, options, helmChartPath, helmChartReleaseName)
 
@@ -90,7 +76,7 @@ func scheduleLabelMismatch(t *testing.T, helmChartPath string, namespaceName str
 	options.KubectlOptions = kubectlOptions
 	options.KubectlOptions.Namespace = namespaceName
 
-	labelMinikubeNode(t, namespaceName, "failure-domain.beta.kubernetes.io/zone", "")
+	testlib.LabelNodes(t, namespaceName, "failure-domain.beta.kubernetes.io/zone", "")
 
 	helm.Install(t, options, helmChartPath, helmChartReleaseName)
 

--- a/test/minikube/minikube_long_admin_test.go
+++ b/test/minikube/minikube_long_admin_test.go
@@ -14,6 +14,7 @@ func TestKubernetesBasicAdminThreeReplicas(t *testing.T) {
 	t.Skip("Flaky! DB-29422")
 
 	testlib.AwaitTillerUp(t)
+	defer testlib.VerifyTeardown(t)
 
 	options := helm.Options{
 		SetValues: map[string]string{"admin.replicas": "3"},

--- a/test/minikube/minikube_rolling_upgrade_test.go
+++ b/test/minikube/minikube_rolling_upgrade_test.go
@@ -33,6 +33,7 @@ func verifyAllProcessesRunning(t *testing.T, namespaceName string, adminPod stri
 
 func TestKubernetesUpgradeAdminMinorVersion(t *testing.T) {
 	testlib.AwaitTillerUp(t)
+	defer testlib.VerifyTeardown(t)
 
 	options := helm.Options{
 		SetValues: map[string]string{
@@ -67,6 +68,7 @@ func TestKubernetesUpgradeAdminMinorVersion(t *testing.T) {
 
 func TestKubernetesUpgradeFullDatabaseMinorVersion(t *testing.T) {
 	testlib.AwaitTillerUp(t)
+	defer testlib.VerifyTeardown(t)
 
 	options := helm.Options{
 		SetValues: map[string]string{
@@ -148,6 +150,7 @@ func TestKubernetesUpgradeFullDatabaseMinorVersion(t *testing.T) {
 
 func TestKubernetesRollingUpgradeAdminMinorVersion(t *testing.T) {
 	testlib.AwaitTillerUp(t)
+	defer testlib.VerifyTeardown(t)
 
 	options := helm.Options{
 		SetValues: map[string]string{

--- a/test/minikube/minikube_tls_admin_test.go
+++ b/test/minikube/minikube_tls_admin_test.go
@@ -35,6 +35,7 @@ func verifyKeystore(t *testing.T, namespace string, podName string, keystore str
 
 func TestKubernetesTLS(t *testing.T) {
 	testlib.AwaitTillerUp(t)
+	defer testlib.VerifyTeardown(t)
 
 	randomSuffix := strings.ToLower(random.UniqueId())
 	namespaceName := fmt.Sprintf("testkubernetestls-%s", randomSuffix)

--- a/test/minikube/minikube_tls_admin_test.go
+++ b/test/minikube/minikube_tls_admin_test.go
@@ -37,7 +37,7 @@ func TestKubernetesTLS(t *testing.T) {
 	testlib.AwaitTillerUp(t)
 
 	randomSuffix := strings.ToLower(random.UniqueId())
-	namespaceName := fmt.Sprintf("testbasicnameoverride-%s", randomSuffix)
+	namespaceName := fmt.Sprintf("testkubernetestls-%s", randomSuffix)
 	testlib.CreateNamespace(t, namespaceName)
 
 	defer testlib.Teardown(testlib.TEARDOWN_SECRETS)

--- a/test/minikube/minikube_tls_admin_test.go
+++ b/test/minikube/minikube_tls_admin_test.go
@@ -37,12 +37,8 @@ func TestKubernetesTLS(t *testing.T) {
 	testlib.AwaitTillerUp(t)
 
 	randomSuffix := strings.ToLower(random.UniqueId())
-
-	namespaceName := fmt.Sprintf("test-admin-tls-%s", randomSuffix)
-	kubectlOptions := k8s.NewKubectlOptions("", "")
-	k8s.CreateNamespace(t, kubectlOptions, namespaceName)
-
-	defer k8s.DeleteNamespace(t, kubectlOptions, namespaceName)
+	namespaceName := fmt.Sprintf("testbasicnameoverride-%s", randomSuffix)
+	testlib.CreateNamespace(t, namespaceName)
 
 	defer testlib.Teardown(testlib.TEARDOWN_SECRETS)
 	

--- a/test/minikube/minikube_tls_admin_test.go
+++ b/test/minikube/minikube_tls_admin_test.go
@@ -34,6 +34,10 @@ func verifyKeystore(t *testing.T, namespace string, podName string, keystore str
 }
 
 func TestKubernetesTLS(t *testing.T) {
+	if testlib.IsOpenShiftEnvironment(t) {
+		t.Skip("TLS subPath bind does not work as expected")
+	}
+
 	testlib.AwaitTillerUp(t)
 	defer testlib.VerifyTeardown(t)
 

--- a/test/minikube/minikube_tls_admin_test.go
+++ b/test/minikube/minikube_tls_admin_test.go
@@ -68,7 +68,7 @@ func TestKubernetesTLS(t *testing.T) {
 
 	defer testlib.Teardown(testlib.TEARDOWN_ADMIN)
 
-	helmChartReleaseName, namespaceName := testlib.StartAdmin(t, &options, 3, namespaceName)
+	helmChartReleaseName, _ := testlib.StartAdmin(t, &options, 3, namespaceName)
 
 	admin0 := fmt.Sprintf("%s-nuodb-cluster0-0", helmChartReleaseName)
 

--- a/test/minikube/minikube_tls_rotation_test.go
+++ b/test/minikube/minikube_tls_rotation_test.go
@@ -52,6 +52,10 @@ func startDomainWithTLSCertificates(t *testing.T, options *helm.Options, namespa
 func TestKubernetesTLSRotation(t *testing.T) {
 	t.Skip("Flaky! DB-29423")
 
+	if testlib.IsOpenShiftEnvironment(t) {
+		t.Skip("TLS subPath bind does not work as expected")
+	}
+
 	testlib.AwaitTillerUp(t)
 	defer testlib.VerifyTeardown(t)
 	

--- a/test/minikube/minikube_tls_rotation_test.go
+++ b/test/minikube/minikube_tls_rotation_test.go
@@ -54,7 +54,7 @@ func TestKubernetesTLSRotation(t *testing.T) {
 
 	testlib.AwaitTillerUp(t)
 	randomSuffix := strings.ToLower(random.UniqueId())
-	namespaceName := fmt.Sprintf("testbasicnameoverride-%s", randomSuffix)
+	namespaceName := fmt.Sprintf("testtlsrotation-%s", randomSuffix)
 	testlib.CreateNamespace(t, namespaceName)
 
 	initialTLSCommands := []string{

--- a/test/minikube/minikube_tls_rotation_test.go
+++ b/test/minikube/minikube_tls_rotation_test.go
@@ -53,6 +53,8 @@ func TestKubernetesTLSRotation(t *testing.T) {
 	t.Skip("Flaky! DB-29423")
 
 	testlib.AwaitTillerUp(t)
+	defer testlib.VerifyTeardown(t)
+	
 	randomSuffix := strings.ToLower(random.UniqueId())
 	namespaceName := fmt.Sprintf("testtlsrotation-%s", randomSuffix)
 	testlib.CreateNamespace(t, namespaceName)

--- a/test/testlib/minikube_utilities.go
+++ b/test/testlib/minikube_utilities.go
@@ -375,7 +375,7 @@ func AwaitDatabaseUp(t *testing.T, namespace string, podName string, databaseNam
 	k8s.RunKubectl(t, options, "exec", podName, "--", "nuocmd", "check", "database",
 		"--db-name", databaseName, "--check-running", "--check-liveness", "20",
 		"--num-processes", strconv.Itoa(numProcesses),
-		"--timeout", "600")
+		"--timeout", "300")
 }
 
 func GetDiagnoseOnTestFailure(t *testing.T, namespace string, podName string) {

--- a/test/testlib/minikube_utilities.go
+++ b/test/testlib/minikube_utilities.go
@@ -175,6 +175,9 @@ func Await(t *testing.T, lmbd func() bool, timeout time.Duration) {
 }
 
 func AwaitTillerUp(t *testing.T) {
+    return 
+
+
 	Await(t, func() bool {
 		for _, pod := range findAllPodsInSchema(t, "kube-system") {
 			if strings.Contains(pod.Name, "tiller-deploy") {

--- a/test/testlib/minikube_utilities.go
+++ b/test/testlib/minikube_utilities.go
@@ -188,7 +188,7 @@ func AwaitTillerUp(t *testing.T) {
 	}
 
     Await(t, func() bool {
-		if isOpenShiftEnvironment(t) {
+		if IsOpenShiftEnvironment(t) {
 			return tillerCheck("tiller", "tiller")
 		} else {
 			return tillerCheck("kube-system", "tiller-deploy")

--- a/test/testlib/minikube_utilities.go
+++ b/test/testlib/minikube_utilities.go
@@ -175,18 +175,24 @@ func Await(t *testing.T, lmbd func() bool, timeout time.Duration) {
 }
 
 func AwaitTillerUp(t *testing.T) {
-    return 
-
-
-	Await(t, func() bool {
-		for _, pod := range findAllPodsInSchema(t, "kube-system") {
-			if strings.Contains(pod.Name, "tiller-deploy") {
+	tillerCheck := func(namespace string, podName string) bool {
+		for _, pod := range findAllPodsInSchema(t, namespace) {
+			if strings.Contains(pod.Name, podName) {
 				if arePodConditionsMet(&pod, corev1.PodReady, corev1.ConditionTrue) {
 					return true
 				}
 			}
 		}
+
 		return false
+	}
+
+    Await(t, func() bool {
+		if isOpenShiftEnvironment(t) {
+			return tillerCheck("tiller", "tiller")
+		} else {
+			return tillerCheck("kube-system", "tiller-deploy")
+		}
 	}, 30*time.Second)
 }
 

--- a/test/testlib/minikube_utilities.go
+++ b/test/testlib/minikube_utilities.go
@@ -765,7 +765,6 @@ func UnmarshalJSONObject(t *testing.T, stringJSON string) map[string]interface{}
 }
 
 func VerifyAdminKvSetAndGet(t *testing.T, podName string, namespaceName string) {
-
 	options := k8s.NewKubectlOptions("", "")
 	options.Namespace = namespaceName
 
@@ -789,4 +788,26 @@ func VerifyAdminKvSetAndGet(t *testing.T, podName string, namespaceName string) 
 	assert.Check(t, elapsed.Seconds() < 2.0, fmt.Sprintf("KV get took longer than 2s: %s", elapsed))
 
 	assert.Check(t, output == "testVal", fmt.Sprintf("KV get returned the wrong value: %s", output))
+}
+
+func LabelNodes(t *testing.T, namespaceName string, labelName string, labelValue string) {
+	options := k8s.NewKubectlOptions("", "")
+	options.Namespace = namespaceName
+
+	var labelString string
+
+	if labelValue != "" {
+		labelString = fmt.Sprintf("%s=%s", labelName, labelValue)
+	} else {
+		labelString = fmt.Sprintf("%s-", labelName)
+	}
+
+	nodes := k8s.GetNodes(t , options)
+
+	assert.Assert(t, len(nodes) > 0)
+
+	for _, node := range nodes {
+		err := k8s.RunKubectlE(t, options, "label", "node", node.Name, labelString, "--overwrite")
+		assert.NilError(t, err, "Labeling node %s with '%s' failed", node.Name, labelString)
+	}
 }

--- a/test/testlib/nuodb_admin_utilities.go
+++ b/test/testlib/nuodb_admin_utilities.go
@@ -26,7 +26,7 @@ func getFunctionCallerName() string {
 func CreateNamespace(t *testing.T, namespaceName string) {
 	kubectlOptions := k8s.NewKubectlOptions("", "")
 
-	if isOpenShiftEnvironment(t) {
+	if IsOpenShiftEnvironment(t) {
 		createOpenShiftProject(t, namespaceName)
 	} else {
 		k8s.CreateNamespace(t, kubectlOptions, namespaceName)

--- a/test/testlib/nuodb_database_utilities.go
+++ b/test/testlib/nuodb_database_utilities.go
@@ -66,6 +66,7 @@ func StartDatabase(t *testing.T, namespaceName string, adminPod string, options 
 	randomSuffix := strings.ToLower(random.UniqueId())
 
 	InjectTestVersion(t, options)
+	InjectOpenShiftValues(t, options)
 	opt := GetExtractedOptions(options)
 
 	helmChartReleaseName = fmt.Sprintf("database-%s", randomSuffix)

--- a/test/testlib/open_shift_utilities.go
+++ b/test/testlib/open_shift_utilities.go
@@ -1,0 +1,49 @@
+package testlib
+
+import (
+	"fmt"
+	"github.com/gruntwork-io/terratest/modules/helm"
+	"gotest.tools/assert"
+	"os/exec"
+	"testing"
+)
+
+var isOpenShift *bool
+
+func isOpenShiftEnvironment(t *testing.T) bool {
+	if isOpenShift == nil {
+		output, err := exec.Command("oc", "status").Output()
+
+		var isOs = (err == nil)
+		isOpenShift = &isOs
+
+		t.Logf("Running in OpenShift:\n%s", string(output))
+	}
+
+	return *isOpenShift
+}
+
+func createOpenShiftProject(t *testing.T, namespaceName string) {
+	output, err := exec.Command("oc", "new-project", namespaceName).Output()
+	assert.NilError(t, err, output)
+	output, err = exec.Command("oc", "policy", "add-role-to-user", "edit", "system:serviceaccount:tiller:tiller").Output()
+	assert.NilError(t, err, output)
+	output, err = exec.Command("oc", "policy", "add-role-to-user", "hostaccess", "system:serviceaccount:tiller:tiller").Output()
+	assert.NilError(t, err, output)
+	output, err = exec.Command("oc", "policy", "add-role-to-user", "privileged", "system:serviceaccount:tiller:tiller").Output()
+	assert.NilError(t, err, output)
+	output, err = exec.Command("oc", "policy", "add-role-to-user", "anyuid", "system:serviceaccount:tiller:tiller").Output()
+	assert.NilError(t, err, output)
+	output, err = exec.Command("oc", "adm", "policy", "add-scc-to-user", "privileged", fmt.Sprintf("system:serviceaccount:%s:default", namespaceName)).Output()
+	assert.NilError(t, err, output)
+}
+
+func InjectOpenShiftValues(t *testing.T, options *helm.Options) {
+	if options.SetValues == nil {
+		options.SetValues = make(map[string]string)
+	}
+
+	if isOpenShiftEnvironment(t) {
+		options.SetValues["openshift.enabled"] = "true"
+	}
+}

--- a/test/testlib/open_shift_utilities.go
+++ b/test/testlib/open_shift_utilities.go
@@ -17,7 +17,9 @@ func isOpenShiftEnvironment(t *testing.T) bool {
 		var isOs = (err == nil)
 		isOpenShift = &isOs
 
-		t.Logf("Running in OpenShift:\n%s", string(output))
+		if isOs {
+			t.Logf("Running in OpenShift:\n%s", string(output))
+		}
 	}
 
 	return *isOpenShift

--- a/test/testlib/open_shift_utilities.go
+++ b/test/testlib/open_shift_utilities.go
@@ -10,7 +10,7 @@ import (
 
 var isOpenShift *bool
 
-func isOpenShiftEnvironment(t *testing.T) bool {
+func IsOpenShiftEnvironment(t *testing.T) bool {
 	if isOpenShift == nil {
 		output, err := exec.Command("oc", "status").Output()
 
@@ -45,7 +45,7 @@ func InjectOpenShiftValues(t *testing.T, options *helm.Options) {
 		options.SetValues = make(map[string]string)
 	}
 
-	if isOpenShiftEnvironment(t) {
+	if IsOpenShiftEnvironment(t) {
 		options.SetValues["openshift.enabled"] = "true"
 	}
 }

--- a/test/testlib/tls.go
+++ b/test/testlib/tls.go
@@ -140,12 +140,14 @@ func GenerateTLSConfiguration(t *testing.T, namespaceName string, commands []str
 	return podName, keysLocation
 }
 
-func RotateTLSCertificates(t *testing.T, options *helm.Options,
-	kubectlOptions *k8s.KubectlOptions, adminReleaseName string, databaseReleaseName string, tlsKeysLocation string, helmUpgrade bool) {
+func RotateTLSCertificates(t *testing.T, options *helm.Options, namespaceName string,
+	adminReleaseName string, databaseReleaseName string, tlsKeysLocation string, helmUpgrade bool) {
+
+	kubectlOptions := k8s.NewKubectlOptions("", "")
+	kubectlOptions.Namespace = namespaceName
 
 	adminReplicaCount, err := strconv.Atoi(options.SetValues["admin.replicas"])
 	assert.NilError(t, err, "Unable to find/convert admin.replicas value")
-	namespaceName := kubectlOptions.Namespace
 	admin0 := fmt.Sprintf("%s-nuodb-cluster0-0", adminReleaseName)
 
 	k8s.RunKubectl(t, kubectlOptions, "cp", filepath.Join(tlsKeysLocation, CA_CERT_FILE_NEW), admin0+":/tmp")


### PR DESCRIPTION
Add a new flag `openshift.enabled` to all Charts. When enabled, all Kubernetes objects in that chart will be created with security context `privileged`. This is required in OpenShift to mount hostPath and execute some of the operations that a DB requires.

Add a script to start a minishift cluster. This can not be added to Travis as minishift tries to start a VM and does not work with vm-driver=none as compared to minikube. There steps can be followed by anyone who wants to run the exising test suite against minishift.

Refactor tests to support both minikube and minishift. They can also be run against a real cluster.

Add verifyTeardown to all tests. Some tests were not calling all the expected teardowns. Fix all the leaks found this way.

Decreases the DB startup timeout back to 300. Travis has a 10min timeout which kills the whole build.
