### PR TITLE
Add a couple more simple backup tests

### DIFF
--- a/scripts/ci/determine_and_run_tests.sh
+++ b/scripts/ci/determine_and_run_tests.sh
@@ -6,7 +6,7 @@ if [[ $TEST_SUITE = "basic"  ]]; then
   ./test/test_suite.sh
   go test -timeout 10m -v ./test/integration
 elif [[ $TEST_SUITE = "minikube-short"  ]]; then
-  go test -timeout 35m -v ./test/minikube -tags=short
+  go test -timeout 45m -v ./test/minikube -tags=short
 elif [[ $TEST_SUITE = "minikube-long"  ]]; then
-  go test -timeout 35m -v ./test/minikube -tags=long
+  go test -timeout 45m -v ./test/minikube -tags=long
 fi

--- a/test/minikube/minikube_base_admin_test.go
+++ b/test/minikube/minikube_base_admin_test.go
@@ -40,8 +40,8 @@ func TestKubernetesBasicAdminSingleReplica(t *testing.T) {
 	t.Run("verifyAdminHeadlessService", func(t *testing.T) { verifyAdminService(t, namespaceName, admin0, headlessServiceName, true) })
 	t.Run("verifyAdminClusterService", func(t *testing.T) { verifyAdminService(t, namespaceName, admin0, clusterServiceName, false) })
 	t.Run("verifyLBPolicy", func(t *testing.T) { verifyLBPolicy(t, namespaceName, admin0) })
-	t.Run("verifyPodKill", func(t *testing.T) { verifyPodKill(t, namespaceName, admin0, helmChartReleaseName, 1) })
-	t.Run("verifyProcessKill", func(t *testing.T) { verifyKillProcess(t, namespaceName, admin0, helmChartReleaseName, 1) })
+	t.Run("verifyAdminPodKill", func(t *testing.T) { verifyAdminPodKill(t, namespaceName, admin0, helmChartReleaseName, 1) })
+	t.Run("verifyAdminProcessKill", func(t *testing.T) { verifyKillProcess(t, namespaceName, admin0, helmChartReleaseName, 1) })
 }
 
 func TestKubernetesInvalidLicense(t *testing.T) {

--- a/test/minikube/minikube_long_admin_test.go
+++ b/test/minikube/minikube_long_admin_test.go
@@ -35,6 +35,6 @@ func TestKubernetesBasicAdminThreeReplicas(t *testing.T) {
 	t.Run("verifyAdminHeadlessService", func(t *testing.T) { verifyAdminService(t, namespaceName, admin0, headlessServiceName, true) })
 	t.Run("verifyAdminClusterService", func(t *testing.T) { verifyAdminService(t, namespaceName, admin0, clusterServiceName, false) })
 	t.Run("verifyLBPolicy", func(t *testing.T) { verifyLBPolicy(t, namespaceName, admin0) })
-	t.Run("verifyPodKill", func(t *testing.T) { verifyPodKill(t, namespaceName, admin0, helmChartReleaseName, 3) })
+	t.Run("verifyAdminPodKill", func(t *testing.T) { verifyAdminPodKill(t, namespaceName, admin0, helmChartReleaseName, 3) })
 	t.Run("verifyProcessKill", func(t *testing.T) { verifyKillProcess(t, namespaceName, admin0, helmChartReleaseName, 3) })
 }

--- a/test/minikube/minikube_rolling_upgrade_test.go
+++ b/test/minikube/minikube_rolling_upgrade_test.go
@@ -39,7 +39,7 @@ func TestKubernetesUpgradeAdminMinorVersion(t *testing.T) {
 			"nuodb.image.registry": "docker.io",
 			"nuodb.image.repository": "nuodb/nuodb-ce",
 			"nuodb.image.tag": OLD_RELEASE,
-			},
+		},
 	}
 
 	defer testlib.Teardown(testlib.TEARDOWN_ADMIN)

--- a/test/minikube/verify_utility.go
+++ b/test/minikube/verify_utility.go
@@ -22,7 +22,7 @@ func verifyLBPolicy(t *testing.T, namespaceName string, podName string) {
 	testlib.VerifyPolicyInstalled(t, namespaceName, podName)
 }
 
-func verifyPodKill(t *testing.T, namespaceName string, podName string, helmChartReleaseName string, nrReplicasExpected int) {
+func verifyAdminPodKill(t *testing.T, namespaceName string, podName string, helmChartReleaseName string, nrReplicasExpected int) {
 	testlib.KillAdminPod(t, namespaceName, podName)
 	testlib.AwaitNrReplicasScheduled(t, namespaceName, helmChartReleaseName, nrReplicasExpected)
 	testlib.AwaitPodUp(t, namespaceName, podName, 100*time.Second)

--- a/test/testlib/minikube_utilities.go
+++ b/test/testlib/minikube_utilities.go
@@ -432,7 +432,6 @@ func AwaitDatabaseRestart(t *testing.T, namespace string, podName string, databa
 	AwaitDatabaseUp(t, namespace, podName, databaseName, opts.NrTePods+opts.NrSmPods)
 }
 
-
 func AwaitPodRestartCountGreaterThan(t *testing.T, namespace string, podName string, expectedRestartCount int32) {
 	options := k8s.NewKubectlOptions("", "")
 	options.Namespace = namespace


### PR DESCRIPTION
Added a few negative backup tests to the minikube test suite (mainly by messing with the SMs in various ways). The test coverage is by no means complete and needs additional work to design and implement more negative and edge-case tests.
The indentation is a bit of a mess but I can't figure out how to fix it - perhaps the original code was indented with tabs, but my editor is replacing it with whitespace. Will try to fix in an upcoming commit.