### PR TITLE
Allow TEs to be defined as a StatefulSet

### DIFF
--- a/stable/database/templates/deployment.yaml
+++ b/stable/database/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.database.te.enableStatefulSet }}
 {{- if or (not .Values.openshift.enabled) (not .Values.openshift.enableDeploymentConfigs) }}
 apiVersion: apps/v1
 kind: Deployment
@@ -173,4 +174,5 @@ spec:
       schedulerName: default-scheduler
       securityContext: {}
       terminationGracePeriodSeconds: 15
+{{- end }}
 {{- end }}

--- a/stable/database/templates/deploymentconfig.yaml
+++ b/stable/database/templates/deploymentconfig.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.database.te.enableStatefulSet }}
 {{- if and (.Values.openshift.enabled) (.Values.openshift.enableDeploymentConfigs) }}
 apiVersion: apps.openshift.io/v1
 kind: DeploymentConfig
@@ -173,4 +174,5 @@ spec:
       schedulerName: default-scheduler
       securityContext: {}
       terminationGracePeriodSeconds: 15
+{{- end }}
 {{- end }}

--- a/stable/database/templates/service-headless.yaml
+++ b/stable/database/templates/service-headless.yaml
@@ -14,6 +14,7 @@ metadata:
     release: {{ .Release.Name | quote }}
   name: {{ .Values.database.name }}
 spec:
+  publishNotReadyAddresses: true
   clusterIP: None
   ports:
   - { name: 48006-tcp,  port: 48006,  protocol: TCP,  targetPort: 48006 }

--- a/stable/database/templates/statefulset.yaml
+++ b/stable/database/templates/statefulset.yaml
@@ -608,3 +608,185 @@ spec:
   {{- end }}
 {{- end }}
 {{- end }}
+
+{{- if .Values.database.te.enableStatefulSet }}
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+    app: {{ template "database.fullname" . }}
+    group: nuodb
+    database: {{ .Values.database.name }}
+    domain: {{ .Values.admin.domain }}
+    chart: {{ template "database.chart" . }}
+    release: {{ .Release.Name | quote }}
+  name: te-{{ template "database.fullname" . }}
+spec:
+  serviceName: {{ .Values.database.name }}
+  replicas: {{ .Values.database.te.replicas }}
+  selector:
+    matchLabels:
+      app: {{ template "database.fullname" . }}
+      component: te
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: {{ template "database.fullname" . }}
+        group: nuodb
+        database: {{ .Values.database.name }}
+        domain: {{ .Values.admin.domain }}
+        component: te
+        chart: {{ template "database.chart" . }}
+        release: {{ .Release.Name | quote }}
+    spec:
+      {{- with .Values.database.te.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | trim | indent 8 }}
+      {{- end }}
+{{- if .Values.database.te.affinity }}
+      affinity:
+{{ tpl .Values.database.te.affinity . | trim | indent 8 }}
+{{- end }}
+      {{- if .Values.database.te.tolerations }}
+      tolerations:
+{{ toYaml .Values.database.te.tolerations | trim | indent 8 }}
+      {{- end }}
+      containers:
+      - name: te-{{ template "database.fullname" . }}
+        image: {{ template "nuodb.image" . }}
+        imagePullPolicy: {{ .Values.nuodb.image.pullPolicy }}
+    {{- include "database.capabilities" . | indent 8 }}
+        args:
+          - "nuote"
+          - "--database-created-timeout"
+          - "300"
+          - "--servers-ready-timeout"
+          - "300"
+          - "--options"
+          - "mem {{ .Values.database.te.memoryOption}} {{- range $opt, $val := .Values.database.te.engineOptions }} {{$opt}} {{$val}} {{- end}}"
+        {{- with .Values.database.te.labels }}
+          - "--labels"
+          - "{{- range $opt, $val := . }} {{$opt}} {{$val}} {{- end}}"
+        {{- end }}
+        {{- range $opt, $val := .Values.database.te.otherOptions }}
+          - "--{{$opt}}"
+          - "{{$val}}"
+        {{- end }}
+        {{- if or (not (hasKey .Values.database.te.dbServices "enabled")) .Values.database.te.dbServices.enabled }}
+          - "--resolve-address"
+        {{- end}}
+    {{- include "database.envFrom" . | indent 8 }}
+        env:
+          - name: NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - { name: DB_NAME,             value: {{ .Values.database.name | quote }} }
+          - { name: NUOCMD_API_SERVER,   value: "{{ template "admin.address" . }}:8888" }
+          - { name: PEER_ADDRESS,        value: "{{ template "admin.address" . }}" }
+          - { name: COMPONENT_NAME,      value: "te" }
+{{- include "database.env" . | indent 10 }}
+      {{- if .Values.admin.tlsKeyStore }}
+        {{- if .Values.admin.tlsKeyStore.password }}
+          - { name: NUODOCKER_KEYSTORE_PASSWORD,    value: {{ .Values.admin.tlsKeyStore.password | quote }} }
+        {{- end }}
+      {{- end }}
+        ports:
+        - containerPort: 48006
+          protocol: TCP
+        resources:
+{{ toYaml .Values.database.te.resources | trim | indent 10 }}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        {{- with .Values.database.configFiles }}
+        {{- range $key, $val := . }}
+        - name: configurations
+          mountPath: {{ $.Values.database.configFilesPath }}{{ $key }}
+          subPath: {{ $key }}
+        {{- end }}
+        {{- end }}
+        - name: logdir
+          mountPath: /var/log/nuodb
+        - name: nuote
+          mountPath: /usr/local/bin/nuote
+          subPath: nuote
+        - name: readinessprobe
+          mountPath: /usr/local/bin/readinessprobe
+          subPath: readinessprobe
+        {{- if .Values.admin.tlsCACert }}
+        - name: tls-ca-cert
+          mountPath: /etc/nuodb/keys/ca.cert
+          subPath: {{ .Values.admin.tlsCACert.key }}
+        {{- end }}
+        {{- if .Values.admin.tlsClientPEM }}
+        - name: tls-client-pem
+          mountPath: /etc/nuodb/keys/nuocmd.pem
+          subPath: {{ .Values.admin.tlsClientPEM.key }}
+        {{- end }}
+        {{- if .Values.admin.tlsKeyStore }}
+        - name: tls-keystore
+          mountPath: /etc/nuodb/keys/nuoadmin.p12
+          subPath: {{ .Values.admin.tlsKeyStore.key }}
+        {{- end }}
+        readinessProbe:
+          initialDelaySeconds: 30
+          periodSeconds: 5
+          exec:
+            command: [ "readinessprobe" ]
+          failureThreshold: 54
+          # the TE becomes unready if it does not start within 5 minutes = 30s + 5s*54
+          successThreshold: 2
+          timeoutSeconds: 1
+{{- include "nuodb.imagePullSecrets" . | indent 6 }}
+      volumes:
+        {{- if .Values.database.configFiles }}
+        - name: configurations
+          configMap:
+            name: {{ template "database.fullname" . }}-configuration
+        {{- end }}
+        - name: logdir
+          emptyDir: {}
+        - name: nuote
+          configMap:
+            name: {{ template "database.fullname" . }}-nuote
+            defaultMode: 0777
+        - name: readinessprobe
+          configMap:
+            name: {{ template "database.fullname" . }}-readinessprobe
+            defaultMode: 0777
+        {{- if .Values.admin.tlsCACert }}
+        - name: tls-ca-cert
+          secret:
+            secretName: {{ .Values.admin.tlsCACert.secret }}
+            defaultMode: 0440
+        {{- end }}
+        {{- if .Values.admin.tlsClientPEM }}
+        - name: tls-client-pem
+          secret:
+            secretName: {{ .Values.admin.tlsClientPEM.secret }}
+            defaultMode: 0440
+        {{- end }}
+        {{- if .Values.admin.tlsKeyStore }}
+        - name: tls-keystore
+          secret:
+            secretName: {{ .Values.admin.tlsKeyStore.secret }}
+            defaultMode: 0440
+        {{- end }}
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 15
+{{- end }}

--- a/stable/database/values.yaml
+++ b/stable/database/values.yaml
@@ -286,6 +286,11 @@ database:
     dbServices: {}
       # enabled: false
 
+    # Define TEs as a StatefulSet so that DNS entries are created for TEs
+    # (assuming that dbServices.enabled is not false), allowing TLS hostname
+    # verification to be enabled by SQL clients
+    enableStatefulSet: false
+
     # Number of transaction engines (TE) nodes.  Limit is 3 in CE version of NuoDB 
     replicas: 1
 

--- a/test/testlib/nuodb_admin_utilities.go
+++ b/test/testlib/nuodb_admin_utilities.go
@@ -23,11 +23,19 @@ func getFunctionCallerName() string {
 }
 
 func StartAdmin(t *testing.T, options *helm.Options, replicaCount int, namespace string) (helmChartReleaseName string, namespaceName string) {
-	randomSuffix := strings.ToLower(random.UniqueId())
+	return StartAdminWithReleaseName(t, options, replicaCount, namespace, "")
+}
 
+func StartAdminWithReleaseName(t *testing.T, options *helm.Options, replicaCount int, namespace string, helmChartRelease string) (helmChartReleaseName string, namespaceName string) {
 	// Path to the helm chart we will test
 	helmChartPath := ADMIN_HELM_CHART_PATH
-	helmChartReleaseName = fmt.Sprintf("admin-%s", randomSuffix)
+
+	randomSuffix := strings.ToLower(random.UniqueId())
+	if helmChartRelease == "" {
+		helmChartReleaseName = fmt.Sprintf("admin-%s", randomSuffix)
+	} else {
+		helmChartReleaseName = helmChartRelease
+	}
 
 	adminNames := make([]string, replicaCount)
 


### PR DESCRIPTION
Add databases.te.enableStatefulSet option that allows TEs to be defined
as a StatefulSet. Assuming the databases.te.dbServices.enabled is not
false, TEs will acquire FQDNs, which are advertised by the Admin and
also appear in the CN attribute of the TE certificate, allowing hostname
verification to be enabled in SQL clients.

Also update README.md to include instructions on running tests.