### PR TITLE
increase readiness probe timeout

### DIFF
--- a/stable/database/templates/daemonset.yaml
+++ b/stable/database/templates/daemonset.yaml
@@ -155,7 +155,7 @@ spec:
           failureThreshold: 58
           # the SM becomes unready if it does not start within 15 minutes = 30s + 15s*58
           successThreshold: 2
-          timeoutSeconds: 1
+          timeoutSeconds: 5
 {{- include "nuodb.imagePullSecrets" . | indent 6 }}
       volumes:
       - name: log-volume
@@ -358,7 +358,7 @@ spec:
           failureThreshold: 58
           # the SM becomes unready if it does not start within 15 minutes = 30s + 15s*58
           successThreshold: 2
-          timeoutSeconds: 1
+          timeoutSeconds: 5
 {{- include "nuodb.imagePullSecrets" . | indent 6 }}
       volumes:
       - name: log-volume

--- a/stable/database/templates/deployment.yaml
+++ b/stable/database/templates/deployment.yaml
@@ -132,7 +132,7 @@ spec:
           failureThreshold: 54
           # the TE becomes unready if it does not start within 5 minutes = 30s + 5s*54
           successThreshold: 2
-          timeoutSeconds: 1
+          timeoutSeconds: 5
 {{- include "nuodb.imagePullSecrets" . | indent 6 }}
       volumes:
         {{- if .Values.database.configFiles }}

--- a/stable/database/templates/deploymentconfig.yaml
+++ b/stable/database/templates/deploymentconfig.yaml
@@ -132,7 +132,7 @@ spec:
           failureThreshold: 54
           # the TE becomes unready if it does not start within 5 minutes = 30s + 5s*54
           successThreshold: 2
-          timeoutSeconds: 1
+          timeoutSeconds: 5
 {{- include "nuodb.imagePullSecrets" . | indent 6 }}
       volumes:
         {{- if .Values.database.configFiles }}

--- a/stable/database/templates/statefulset.yaml
+++ b/stable/database/templates/statefulset.yaml
@@ -189,7 +189,7 @@ spec:
           failureThreshold: 58
           # the SM becomes unready if it does not start within 15 minutes = 30s + 15s*58
           successThreshold: 2
-          timeoutSeconds: 1
+          timeoutSeconds: 5
 {{- include "nuodb.imagePullSecrets" . | indent 6 }}
       volumes:
       {{- if .Values.database.configFiles }}
@@ -484,7 +484,7 @@ spec:
           failureThreshold: 58
           # the SM becomes unready if it does not start within 15 minutes = 30s + 15s*58
           successThreshold: 2
-          timeoutSeconds: 1
+          timeoutSeconds: 5
 {{- include "nuodb.imagePullSecrets" . | indent 6 }}
       volumes:
       {{- if .Values.database.configFiles }}


### PR DESCRIPTION
In certain OpenShift deployments, 1-second timeout for the readiness probe is not sufficient. Increase it to 5 seconds.

