### PR TITLE
Autoconfigure role and service account

### DIFF
--- a/stable/admin/README.md
+++ b/stable/admin/README.md
@@ -114,6 +114,8 @@ The following tables list the configurable parameters for the `nuodb` option:
 | `image.tag` | NuoDB container image tag | `latest` |
 | `image.pullPolicy` | NuoDB container pull policy |`Always`|
 | `image.pullSecrets` | Specify docker-registry secret names as an array | [] (does not add image pull secrets to deployed pods) |
+| `serviceAccount` | The name of the service account used by NuoDB Pods | `nuodb` |
+| `addRoleBinding` | Whether to add role and role-binding giving `serviceAccount` access to Kubernetes APIs (Pods, PersistentVolumes, PersistentVolumeClaims, StatefulSets) | `true` |
 
 The `registry` option can be used to connect to private image repositories, such as Artifactory.
 

--- a/stable/admin/templates/role.yaml
+++ b/stable/admin/templates/role.yaml
@@ -1,0 +1,18 @@
+{{- if or (not (hasKey .Values.nuodb "addRoleBinding")) .Values.nuodb.addRoleBinding }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: nuodb-kube-inspector
+rules:
+- apiGroups:
+  - ""
+  - apps
+  resources:
+  - persistentvolumeclaims
+  - persistentvolumes
+  - pods
+  - statefulsets
+  verbs:
+  - get
+  - list
+{{- end }}

--- a/stable/admin/templates/rolebinding.yaml
+++ b/stable/admin/templates/rolebinding.yaml
@@ -1,0 +1,13 @@
+{{- if or (not (hasKey .Values.nuodb "addRoleBinding")) .Values.nuodb.addRoleBinding }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: nuodb-kube-inspector
+roleRef:
+  kind: Role
+  name: nuodb-kube-inspector
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: {{ default "nuodb" .Values.nuodb.serviceAccount }}
+{{- end }}

--- a/stable/admin/templates/serviceaccount.yaml
+++ b/stable/admin/templates/serviceaccount.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ default "nuodb" .Values.nuodb.serviceAccount }}

--- a/stable/admin/templates/statefulset.yaml
+++ b/stable/admin/templates/statefulset.yaml
@@ -27,6 +27,7 @@ spec:
         domain: {{ .Values.admin.domain }}
         group: nuodb
     spec:
+      serviceAccountName: {{ default "nuodb" .Values.nuodb.serviceAccount }}
       {{- with .Values.admin.nodeSelector }}
       nodeSelector:
 {{ toYaml . | trim | indent 8 }}
@@ -71,6 +72,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: POD_UID
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: NAMESPACE
           valueFrom:
             fieldRef:

--- a/stable/admin/values.yaml
+++ b/stable/admin/values.yaml
@@ -52,6 +52,14 @@ nuodb:
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
     ##
 
+  # the name of the ServiceAccount to use for all NuoDB Pods
+  serviceAccount: nuodb
+
+  # unless set to false, a Role and RoleBinding named "nuodb-kube-inspector"
+  # that grants access to Pods, PersistentVolumeClaims, PersistentVolumes, and
+  # StatefulSets is added to nuodb.serviceAccount
+  addRoleBinding: true
+
 admin:
   # nameOverride: east
   # fullnameOverride: admin-east

--- a/stable/database/README.md
+++ b/stable/database/README.md
@@ -114,6 +114,8 @@ The following tables list the configurable parameters for the `nuodb` option:
 | `image.tag` | NuoDB container image tag | `latest` |
 | `image.pullPolicy` | NuoDB container pull policy |`Always`|
 | `image.pullSecrets` | Specify docker-registry secret names as an array | [] (does not add image pull secrets to deployed pods) |
+| `serviceAccount` | The name of the service account used by NuoDB Pods | `nuodb` |
+| `addRoleBinding` | Whether to add role and role-binding giving `serviceAccount` access to Kubernetes APIs (Pods, PersistentVolumes, PersistentVolumeClaims, StatefulSets) | `true` |
 
 The `registry` option can be used to connect to private image repositories, such as Artifactory.
 

--- a/stable/database/templates/cronjob.yaml
+++ b/stable/database/templates/cronjob.yaml
@@ -42,6 +42,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
             - name: NAMESPACE
               valueFrom:
                 fieldRef:

--- a/stable/database/templates/daemonset.yaml
+++ b/stable/database/templates/daemonset.yaml
@@ -30,6 +30,7 @@ spec:
         chart: {{ template "database.chart" . }}
         release: {{ .Release.Name | quote }}
     spec:
+      serviceAccountName: {{ default "nuodb" .Values.nuodb.serviceAccount }}
 {{- with .Values.database.sm.nodeSelectorNoHotCopyDS }}
       nodeSelector:
 {{ toYaml . | trim | indent 8 }}
@@ -78,6 +79,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: POD_UID
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: NAMESPACE
           valueFrom:
             fieldRef:
@@ -274,6 +279,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: POD_UID
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: NAMESPACE
           valueFrom:
             fieldRef:

--- a/stable/database/templates/daemonset.yaml
+++ b/stable/database/templates/daemonset.yaml
@@ -236,6 +236,7 @@ spec:
         chart: {{ template "database.chart" . }}
         release: {{ .Release.Name | quote }}
     spec:
+      serviceAccountName: {{ default "nuodb" .Values.nuodb.serviceAccount }}
 {{- with .Values.database.sm.nodeSelectorHotCopyDS }}
       nodeSelector:
 {{ toYaml . | trim | indent 8 }}

--- a/stable/database/templates/deployment.yaml
+++ b/stable/database/templates/deployment.yaml
@@ -29,6 +29,7 @@ spec:
         chart: {{ template "database.chart" . }}
         release: {{ .Release.Name | quote }}
     spec:
+      serviceAccountName: {{ default "nuodb" .Values.nuodb.serviceAccount }}
       {{- with .Values.database.te.nodeSelector }}
       nodeSelector:
 {{ toYaml . | trim | indent 8 }}
@@ -72,6 +73,10 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.name
+          - name: POD_UID
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.uid
           - name: NAMESPACE
             valueFrom:
               fieldRef:

--- a/stable/database/templates/deploymentconfig.yaml
+++ b/stable/database/templates/deploymentconfig.yaml
@@ -28,6 +28,7 @@ spec:
         chart: {{ template "database.chart" . }}
         release: {{ .Release.Name | quote }}
     spec:
+      serviceAccountName: {{ default "nuodb" .Values.nuodb.serviceAccount }}
       {{- with .Values.database.te.nodeSelector }}
       nodeSelector:
 {{ toYaml . | trim | indent 8 }}
@@ -71,6 +72,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: POD_UID
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: NAMESPACE
           valueFrom:
             fieldRef:

--- a/stable/database/templates/job.yaml
+++ b/stable/database/templates/job.yaml
@@ -52,6 +52,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: POD_UID
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: NAMESPACE
           valueFrom:
             fieldRef:

--- a/stable/database/templates/statefulset.yaml
+++ b/stable/database/templates/statefulset.yaml
@@ -33,6 +33,7 @@ spec:
         chart: {{ template "database.chart" . }}
         release: {{ .Release.Name | quote }}
     spec:
+      serviceAccountName: {{ default "nuodb" .Values.nuodb.serviceAccount }}
       terminationGracePeriodSeconds: 15
       {{- if .Values.database.securityContext.enabled }}
       securityContext:
@@ -97,6 +98,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: POD_UID
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: NAMESPACE
           valueFrom:
             fieldRef:
@@ -323,6 +328,7 @@ spec:
         chart: {{ template "database.chart" . }}
         release: {{ .Release.Name | quote }}
     spec:
+      serviceAccountName: {{ default "nuodb" .Values.nuodb.serviceAccount }}
       terminationGracePeriodSeconds: 15
       {{- if .Values.database.securityContext.enabled }}
       securityContext:
@@ -384,6 +390,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: POD_UID
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: NAMESPACE
           valueFrom:
             fieldRef:

--- a/stable/database/values.yaml
+++ b/stable/database/values.yaml
@@ -61,6 +61,14 @@ nuodb:
   # the prefix for the shared latest backup ringbuffer - default value is always valid
   latestKey: ""
 
+  # the name of the ServiceAccount to use for all NuoDB Pods
+  serviceAccount: nuodb
+
+  # unless set to false, a Role and RoleBinding named "nuodb-kube-inspector"
+  # that grants access to Pods, PersistentVolumeClaims, PersistentVolumes, and
+  # StatefulSets is added to nuodb.serviceAccount
+  addRoleBinding: true
+
 admin:
   # domain is the name of the NuoDB administration domain (e.g. the cluster name)
   domain: nuodb

--- a/stable/restore/templates/job.yaml
+++ b/stable/restore/templates/job.yaml
@@ -42,6 +42,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: POD_UID
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.uid
         - name: NAMESPACE
           valueFrom:
             fieldRef:

--- a/test/integration/template_database_test.go
+++ b/test/integration/template_database_test.go
@@ -328,14 +328,14 @@ func TestDatabaseStatefulSetVolumes(t *testing.T) {
 
 			var ss appsv1.StatefulSet
 			helm.UnmarshalK8SYaml(t, part, &ss)
-			
+
 			if strings.Contains(part, "-hotcopy") {
 				assert.Check(t, strings.Contains(ss.Spec.VolumeClaimTemplates[0].ObjectMeta.Name, "archive-volume"))
 				assert.Check(t, strings.Contains(ss.Spec.VolumeClaimTemplates[1].ObjectMeta.Name, "backup-volume"))
 				assert.Check(t, strings.Contains(ss.Spec.VolumeClaimTemplates[2].ObjectMeta.Name, "log-volume"))
 			} else {
 				assert.Check(t, strings.Contains(ss.Spec.VolumeClaimTemplates[0].ObjectMeta.Name, "archive-volume"))
-				assert.Check(t, strings.Contains(ss.Spec.VolumeClaimTemplates[1].ObjectMeta.Name, "log-volume"))	
+				assert.Check(t, strings.Contains(ss.Spec.VolumeClaimTemplates[1].ObjectMeta.Name, "log-volume"))
 			}
 		}
 	}

--- a/test/integration/template_resources_test.go
+++ b/test/integration/template_resources_test.go
@@ -630,3 +630,74 @@ func TestDatabaseNoBackupDisabledDaemonSet(t *testing.T) {
 	// with daemonSet
 	assert.Equal(t, partCounter, 1)
 }
+
+func assertExpectedLines(t *testing.T, optionsMap *map[string]string, helmChartName string, templateNames []string, expectedLines *map[string]int) {
+	options := &helm.Options{
+		SetValues: *optionsMap,
+	}
+
+	output := helm.RenderTemplate(t, options, "../../stable/"+helmChartName, templateNames)
+	actualLines := make(map[string]int)
+	for _, line := range strings.Split(output, "\n") {
+		if count, ok := (*expectedLines)[line]; ok {
+			assert.Check(t, count != 0, "Unexpected line: "+line)
+			actualLines[line]++
+		}
+	}
+
+	for line, cnt := range *expectedLines {
+		assert.Equal(t, cnt, actualLines[line], "Unexpected number of occurrences of "+line)
+	}
+}
+
+func TestAddRoleBindingEnabled(t *testing.T) {
+	optionsMap := map[string]string{}
+	templateNames := []string{
+		"templates/role.yaml",
+		"templates/rolebinding.yaml",
+		"templates/serviceaccount.yaml",
+		"templates/statefulset.yaml",
+	}
+	// expect Role, RoleBinding, and ServiceAccount to be created
+	expectedLines := map[string]int{
+		"kind: Role":                      1,
+		"kind: RoleBinding":               1,
+		"kind: ServiceAccount":            1,
+		"      serviceAccountName: nuodb": 1,
+	}
+	assertExpectedLines(t, &optionsMap, "admin", templateNames, &expectedLines)
+}
+
+func TestAddRoleBindingDisabled(t *testing.T) {
+	// disable creation of role and role binding
+	optionsMap := map[string]string{
+		"nuodb.serviceAccount": "default",
+		"nuodb.addRoleBinding": "false",
+	}
+	templateNames := []string{
+		"templates/role.yaml",
+		"templates/rolebinding.yaml",
+		"templates/serviceaccount.yaml",
+		"templates/statefulset.yaml",
+	}
+	expectedLines := map[string]int{
+		"kind: Role":                        0,
+		"kind: RoleBinding":                 0,
+		"kind: ServiceAccount":              1,
+		"      serviceAccountName: default": 1,
+	}
+	assertExpectedLines(t, &optionsMap, "admin", templateNames, &expectedLines)
+}
+
+func TestDatabaseServiceAccount(t *testing.T) {
+	optionsMap := map[string]string{}
+	templateNames := []string{
+		"templates/deployment.yaml",
+		"templates/statefulset.yaml",
+	}
+	// there should be three serviceAccount declarations: SM, hotcopy SM, and TE
+	expectedLines := map[string]int{
+		"      serviceAccountName: nuodb": 3,
+	}
+	assertExpectedLines(t, &optionsMap, "database", templateNames, &expectedLines)
+}

--- a/test/minikube/minikube_base_database_test.go
+++ b/test/minikube/minikube_base_database_test.go
@@ -36,6 +36,46 @@ func populateCreateDBData(t *testing.T, namespaceName string, adminPod string) {
 	)
 }
 
+func verifyKubernetesAccess(t *testing.T, namespaceName string, podName string) {
+	options := k8s.NewKubectlOptions("", "")
+	options.Namespace = namespaceName
+
+	serviceAccountDir := "/var/run/secrets/kubernetes.io/serviceaccount"
+
+	// check namespace matches service account directory
+	output, err := k8s.RunKubectlAndGetOutputE(t, options, "exec", podName, "--", "cat", serviceAccountDir+"/namespace")
+	assert.NilError(t, err, output)
+	assert.Equal(t, namespaceName, output)
+
+	// get authorization token
+	output, err = k8s.RunKubectlAndGetOutputE(t, options, "exec", podName, "--", "cat", serviceAccountDir+"/token")
+	assert.NilError(t, err, output)
+
+	curlCmdPrefix := fmt.Sprintf("curl -s --cacert %s -H 'Authorization: Bearer %s' https://kubernetes.default.svc", serviceAccountDir+"/ca.crt", output)
+
+	// check that we can access Pods
+	url := "/api/v1/namespaces/" + namespaceName + "/pods"
+	output, err = k8s.RunKubectlAndGetOutputE(t, options, "exec", podName, "--", "bash", "-c", curlCmdPrefix+url)
+	assert.NilError(t, err, output)
+	assert.Check(t, strings.Contains(output, "\"kind\": \"PodList\""), output)
+
+	// check that we can access this Pod
+	url = "/api/v1/namespaces/" + namespaceName + "/pods/" + podName
+	output, err = k8s.RunKubectlAndGetOutputE(t, options, "exec", podName, "--", "bash", "-c", curlCmdPrefix+url)
+	assert.NilError(t, err, output)
+	assert.Check(t, strings.Contains(output, "\"kind\": \"Pod\""), output)
+
+	// check that we can access PersistentVolumeClaims
+	url = "/api/v1/namespaces/" + namespaceName + "/persistentvolumeclaims"
+	output, err = k8s.RunKubectlAndGetOutputE(t, options, "exec", podName, "--", "bash", "-c", curlCmdPrefix+url)
+	assert.Check(t, strings.Contains(output, "\"kind\": \"PersistentVolumeClaimList\""), output)
+
+	// check that we can access StatefulSets
+	url = "/apis/apps/v1/namespaces/" + namespaceName + "/statefulsets"
+	output, err = k8s.RunKubectlAndGetOutputE(t, options, "exec", podName, "--", "bash", "-c", curlCmdPrefix+url)
+	assert.Check(t, strings.Contains(output, "\"kind\": \"StatefulSetList\""), output)
+}
+
 func verifyNuoSQL(t *testing.T, namespaceName string, adminPod string, databaseName string) {
 	options := k8s.NewKubectlOptions("", "")
 	options.Namespace = namespaceName
@@ -283,6 +323,46 @@ func TestKubernetesBasicDatabase(t *testing.T) {
 
 		t.Run("verifyNuoSQL-blue", func(t *testing.T) {
 			verifyNuoSQL(t, namespaceName, admin0, "blue")
+		})
+	})
+}
+
+func TestKubernetesAccessWithinPods(t *testing.T) {
+	testlib.AwaitTillerUp(t)
+
+	options := helm.Options{}
+
+	defer testlib.Teardown(testlib.TEARDOWN_ADMIN)
+
+	helmChartReleaseName, namespaceName := testlib.StartAdmin(t, &options, 1, "")
+
+	admin0 := fmt.Sprintf("%s-nuodb-cluster0-0", helmChartReleaseName)
+
+	t.Run("startDatabaseVerifyKubeAccess", func(t *testing.T) {
+		defer testlib.Teardown(testlib.TEARDOWN_DATABASE)
+
+		databaseOptions := helm.Options{
+			SetValues: map[string]string{
+				"database.sm.resources.requests.cpu":    testlib.MINIMAL_VIABLE_ENGINE_CPU,
+				"database.sm.resources.requests.memory": testlib.MINIMAL_VIABLE_ENGINE_MEMORY,
+				"database.te.resources.requests.cpu":    testlib.MINIMAL_VIABLE_ENGINE_CPU,
+				"database.te.resources.requests.memory": testlib.MINIMAL_VIABLE_ENGINE_MEMORY,
+			},
+		}
+		databaseChartName := testlib.StartDatabase(t, namespaceName, admin0, &databaseOptions)
+
+		t.Run("verifyKubernetesAccess", func(t *testing.T) {
+			// verify that Admin Pod can invoke K8s REST APIs
+			verifyKubernetesAccess(t, namespaceName, admin0)
+
+			// verify that SM and TE Pods can invoke K8s REST APIs
+			opt := testlib.GetExtractedOptions(&databaseOptions)
+			tePodNameTemplate := fmt.Sprintf("te-%s-nuodb-%s-%s", databaseChartName, opt.ClusterName, opt.DbName)
+			smPodNameTemplate := fmt.Sprintf("sm-%s-nuodb-%s-%s", databaseChartName, opt.ClusterName, opt.DbName)
+			tePodName := testlib.GetPodName(t, namespaceName, tePodNameTemplate)
+			smPodName := testlib.GetPodName(t, namespaceName, smPodNameTemplate)
+			verifyKubernetesAccess(t, namespaceName, tePodName)
+			verifyKubernetesAccess(t, namespaceName, smPodName)
 		})
 	})
 }

--- a/test/minikube/minikube_tls_admin_test.go
+++ b/test/minikube/minikube_tls_admin_test.go
@@ -1,4 +1,4 @@
-// +build short
+// +build long
 
 package minikube
 

--- a/test/minikube/minikube_tls_admin_test.go
+++ b/test/minikube/minikube_tls_admin_test.go
@@ -4,9 +4,9 @@ package minikube
 
 import (
 	"fmt"
+	"path/filepath"
 	"strings"
 	"testing"
-	"path/filepath"
 
 	"github.com/nuodb/nuodb-helm-charts/test/testlib"
 	"gotest.tools/assert"
@@ -46,7 +46,7 @@ func TestKubernetesTLS(t *testing.T) {
 	testlib.CreateNamespace(t, namespaceName)
 
 	defer testlib.Teardown(testlib.TEARDOWN_SECRETS)
-	
+
 	// create the certs and secrets...
 	tlsCommands := []string{
 		"export DEFAULT_PASSWORD='" + testlib.SECRET_PASSWORD + "'",


### PR DESCRIPTION
Add nuodb.serviceAccount parameter to values files, and automatically
create a service account, role, and role-binding that allows NuoDB Pods
to inspect Kubernetes state.

This is needed by the Admin so that it can clean up objects in the NuoDB
domain state that are associated with resources that are known to be
defunct in Kubernetes. For example, remove a database process object
(start ID) associated with a non-running Pod or container, remove an
archive object (archive ID) associated with a non-existent PVC.