### PR TITLE
Add "watch" verb to NuoDB role

### DIFF
--- a/stable/admin/templates/role.yaml
+++ b/stable/admin/templates/role.yaml
@@ -15,4 +15,5 @@ rules:
   verbs:
   - get
   - list
+  - watch
 {{- end }}


### PR DESCRIPTION
This is needed in order to enable the Admin to register event listeners.