### PR TITLE
Ntj/restore improvements

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -244,6 +244,7 @@ github.com/gruntwork-io/gruntwork-cli v0.6.1 h1:sPeSdsn3TU1PJMPUHJRFfrxTBHNF0Y0O
 github.com/gruntwork-io/gruntwork-cli v0.6.1/go.mod h1:jp6Z7NcLF2avpY8v71fBx6hds9eOFPELSuD/VPv7w00=
 github.com/gruntwork-io/terratest v0.28.10 h1:4K3idJK5atavZ7iwY+L+RPCA7lFwPu87dVnoFOaoPzI=
 github.com/gruntwork-io/terratest v0.28.10/go.mod h1:PkVylPuUNmItkfOTwSiFreYA4FkanK8AluBuNeGxQOw=
+github.com/gruntwork-io/terratest v0.30.17 h1:4gTq6rihN5lVkSlHQRYu7Hser7KMT8Ke4Wr90C2520M=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.3/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=

--- a/go.sum
+++ b/go.sum
@@ -336,6 +336,7 @@ github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v0.0.0-20151028094244-d8ed2627bdf0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -716,6 +717,7 @@ gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 h1:tQIYjPdBoyREyB9XMu+nnTclpTYkz2zFM+lzLJFO4gQ=
 gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/stable/admin/files/nuoadmin
+++ b/stable/admin/files/nuoadmin
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 . ${NUODB_HOME}/etc/nuodb_setup.sh
 

--- a/stable/admin/templates/configmap.yaml
+++ b/stable/admin/templates/configmap.yaml
@@ -42,3 +42,16 @@ metadata:
   name: {{ template "admin.fullname" . }}-nuoadmin
 data:
 {{ (.Files.Glob "files/nuoadmin").AsConfig | indent 2 }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: {{ template "admin.fullname" . }}
+    group: nuodb
+    domain: {{ .Values.admin.domain }}
+    chart: {{ template "admin.chart" . }}
+    release: {{ .Release.Name | quote }}
+  name: domain-{{ .Values.admin.domain }}-env
+data:
+  NUOADMIN_AP0: {{ template "admin.fullname" .}}-0

--- a/stable/database/README.md
+++ b/stable/database/README.md
@@ -227,6 +227,12 @@ The following tables list the configurable parameters of the `database` chart an
 | `configFilesPath` | Directory path where `configFiles.*` are found | `/etc/nuodb/` |
 | `configFiles.*` | See below. | `{}` |
 | `podAnnotations` | Annotations to pass through to the SM an TE pods | `nil` |
+| `autoImport.*` | Enable and configure the automatic initialising of the initial database state | `disabled` |
+| `autoImport.source` | The source - typically a URL - of the database copy to import | `""` |
+| `autoImport.credentials` | Authentication for the download of `source` in the form `user`:`password` | '""'|
+| `autoImport.stripLevels` | The number of levels to strip off pathnames when unpacking a TAR file of an archive | `1` |
+| `autoImport.type` | Type of content in `source`. One of `stream` -> exact copy of an archive; or `backupset` -> a NuoDB hotcopy backupset | 'backupset' |
+| `autoRestore.*` | Enable and configure the automatic reinitialising of a single archive in a running database - see the options in `autoImport` | `disabled` |
 | `sm.logPersistence.enabled` | Whether to enable persistent storage for logs | `false` |
 | `sm.logPersistence.overwriteBackoff.copies` | How many copies of the crash directory to keep within windowMinutes | `3` |
 | `sm.logPersistence.overwriteBackoff.windowMinutes` | The window within which to keep the number of crash copies | `120` |
@@ -301,7 +307,20 @@ Any file located in `database.configFilesPath` can be replaced; the YAML key cor
 | ----- | ----------- | ------ |
 | `nuodb.config` | [NuoDB database options][6] | `nil` |
 
-#### database.serviceSuffix
+#### restore.*
+
+The following tables list the configurable parameters of the restore chart and their default values.
+
+| Parameter | Description | Default |
+| ----- | ----------- | ------ |
+| `restore.type` | What type of restore to perform: [ "database" | "archive" ]. A "database" restore restarts the entire database at a previous state. An "archive" restore restores/repairs a SINGLE archive in a RUNNING database. | `"database"` |
+| `restore.target` | Where to restore `TO` | `{{ .Values.database.name }}` |
+| `restore.source` | Where to restore `FROM` [ backupset | url | `:latest` | `:group-latest` ] | `:latest` |
+| `restore.credentials` | Credentials to use for a URL source (user:password) | `""` |
+| `restore.autoRestart` | Whether to automatically restart the database and trigger the restore (true/false). Only valid for a "database" restore | `true` |
+
+
+### Running
 
 The purpose of this section is to allow customisation of the names of the clusterIP and balancer database services (load-balancers).
 

--- a/stable/database/files/nuobackup
+++ b/stable/database/files/nuobackup
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # simple script to automate backup.
 #
@@ -13,7 +13,7 @@
 # A backup can be specific to a backup-group, and the backup-groups can have different schedules.
 #
 # An optional semaphore can be specified - if the semaphore is specified, and not set in the KV store, then
-# NO backupis performed.
+# NO backup is performed.
 # This allows a cronjob to run `nuobackup` on a schedule, and conditionally perform a backup if the semaphore has been set.
 #
 # The information of recent backups in the KV store is organised as a ringbuffer.
@@ -30,10 +30,47 @@
 #   --backup-root - directory tree to create the backupsets inside - eg /var/opt/nuodb/backup
 
 # for debugging...
-[ -n "$NUODB_DEBUG" ] && set -x 
+[ "$NUODB_DEBUG" = "verbose" ] && set -x 
 
 : ${NUODB_MAX_BACKUP_HISTORY:=10}
 : ${NUODB_BACKUP_KEY:=/nuodb/nuobackup}
+
+LOGFILE=${NUODB_LOGDIR:=/var/log/nuodb}/nuobackup.log
+
+#=======================================
+# function - log messages
+#
+function log() {
+  if [ -n "$NUODB_DEBUG" ]; then
+    echo "nuobackup $@" | tee -a $LOGFILE
+   #  curl -k -X POST -E /etc/nuodb/keys/nuocmd.pem -H "Content-type: application/json" $ap_protocol://$NUOADMIN_AP0:8888/api/1/diagnostics/log -d "{\"message\": \"nuosm $@\"}"
+  fi
+}
+
+#=======================================
+# function - trace workflow
+#
+function trace() {
+  wotIdid="$@"
+  [ -n "$1" -a -n "$NUODB_DEBUG" ] && log "trace: $wotIdid"
+}
+
+#=======================================
+# function - wrap a log file around so it doesn't grow infinitely
+#
+function wrapLogfile() {
+  logsize=$( du -sb $LOGFILE | grep -o '^ *[0-9]\+' )
+  maxlog=5000000
+  log "logsize=$logsize"
+  if [ ${logsize:=0} -gt $maxlog ]; then
+    lines=$(wc -l $LOGFILE)
+    tail -n $(( lines / 2 )) $LOGFILE > ${LOGFILE}-new
+    rm -rf $LOGFILE
+    mv $LOGFILE-new $LOGFILE
+  fi
+
+  log "log file wrapped around"
+}
 
 backup_type="full"
 db_name=$DB_NAME

--- a/stable/database/files/nuosm
+++ b/stable/database/files/nuosm
@@ -97,10 +97,13 @@ function wrapLogfile() {
     tail -n $(( lines / 2 )) $LOGFILE > ${LOGFILE}-new
     rm -rf $LOGFILE
     mv $LOGFILE-new $LOGFILE
+    log "(nuosm) log file wrapped around"
   fi
-
-  log "(nuosm) log file wrapped around"
 }
+
+#=======================================
+# function to get a value from the KV store
+#
 
 #=======================================
 # function to perform archive restore

--- a/stable/database/files/nuosm
+++ b/stable/database/files/nuosm
@@ -1,11 +1,9 @@
-#!/bin/sh
+#!/bin/bash
 
-[ -n "$NUOSM_LINT" ] && set -n
+[ "$NUODB_DEBUG" = "verbose" ] && set -x
+[ "$NUOSM_VALIDATE" = "true" ] && set -e
 
 . ${NUODB_HOME}/etc/nuodb_setup.sh
-
-NUODB_DEBUG="false"
-#[ -n "$NUODB_DEBUG" ] && set -x
 
 : ${NUODB_ARCHIVEDIR:=/var/opt/nuodb/archive}
 : ${NUODB_BACKUPDIR:=/var/opt/nuodb/backup}
@@ -14,9 +12,20 @@ NUODB_DEBUG="false"
 
 : ${NUODB_IMPORT_CREDENTIALS:=:}
 
+[ -n "$NUODOCKER_KEYSTORE_PASSWORD" ] && ap_protocol="https" || ap_protocol="http"
+
+ERR_ADMIN_UNAVAILABLE=71
+ERR_BACKUPSET_NOT_FOUND=72
+ERR_NO_SPACE=73
+ERR_INCORRECT_BACKUP=74
+ERR_RESTORE_FAILED=75
+
 startup_key="/nuodb/nuosm/startup"
 
-DB_DIR=${NUODB_ARCHIVEDIR}/${NUODB_DOMAIN}/${DB_NAME}
+DB_PARENTDIR=${NUODB_ARCHIVEDIR}/${NUODB_DOMAIN}
+DB_DIR=${DB_PARENTDIR}/${DB_NAME}
+
+LOGFILE=${NUODB_LOGDIR:=/var/log/nuodb}/nuosm.log
 
 NUODB_BINDIR=$NUODB_HOME/bin
 [ -z "$NUOCMD" ] && NUOCMD="$NUODB_BINDIR/nuocmd --api-server $NUOCMD_API_SERVER"
@@ -38,62 +47,126 @@ export NUOCMD DB_NAME
 # function - report an error and exit
 #
 function die() {
-  # cleanup
-  $NUOCMD set value --key $first_req --value '' --expected-value $HOSTNAME
-
   retval=$1
   shift
+  [ -n "$wotIdid" ] && echo "While $wotIdid"
   echo "$@"
+
+  error="$@"
+  log "While $wotIdid: $error"
+
+  # cleanup
+  $NUOCMD set value --key $first_req --value '' --expected-value $HOSTNAME
+  $NUOCMD set value --key $startup_key/$DB_NAME --value '' --expected-value $HOSTNAME
+
+  # release my archive if it is locked
+  locked_archive=$( $NUOCMD show archives --db-name $DB_NAME --removed --removed-archive-format "archive-id: {id}" | sed -En "/^archive-id: / {N; /$HOSTNAME/ s/^archive-id: ([0-9]+).*$/\1/; T; p}" | head -n 1 )
+  [ -n "$locked_archive" ] && $NUOCMD create archive --db-name $DB_NAME --archive-path $DB_DIR --is-external --restored --archive-id $locked_archive
+
   exit $retval
 }
 
 #=======================================
-# function - perform archive restore
+# function - log messages
+#
+function log() {
+  if [ -n "$NUODB_DEBUG" ]; then
+    local err="$@"
+    echo "$err" | tee -a $LOGFILE
+    #curl -k -X POST -E /etc/nuodb/keys/nuocmd.pem -H "Content-type: application/json" $ap_protocol://$NUOADMIN_AP0:8888/api/1/diagnostics/log -d "{\"message\": \"nuosm $err\"}"
+  fi
+}
+
+#=======================================
+# function - trace workflow
+#
+function trace() {
+  wotIdid="$@"
+  [ -n "$1" -a -n "$NUODB_DEBUG" ] && log "trace: $wotIdid"
+}
+
+#=======================================
+# function - wrap a log file around so it doesn't grow infinitely
+#
+function wrapLogfile() {
+  logsize=$( du -sb $LOGFILE | grep -o '^ *[0-9]\+' )
+  maxlog=5000000
+  log "logsize=$logsize; maxlog=$maxlog"
+  if [ ${logsize:=0} -gt $maxlog ]; then
+    lines=$(wc -l $LOGFILE)
+    tail -n $(( lines / 2 )) $LOGFILE > ${LOGFILE}-new
+    rm -rf $LOGFILE
+    mv $LOGFILE-new $LOGFILE
+  fi
+
+  log "(nuosm) log file wrapped around"
+}
+
+#=======================================
+# function to perform archive restore
+#
+# If the restore is successful:
+# * the archive dir contents will have been copied in;
+# * the archive dir metadata will have been reset;
+# * a new corresponding archive object will have been created in Raft.
+#
+# On error, any copy of the replaced archive is retained.
 #
 function perform_restore() {
 
   retval=0
   error=
 
+  log "Restoring $restore_source; existing archives: $( ls -l $DB_PARENTDIR )"
+
   # bail out early if the restore will obviously fail
-  if [ -z "$( echo $restore_source | grep '^[a-z]\+:/[^ ]\+')" ]; then
-    [ -d "$NUODB_BACKUPDIR/$restore_source" ] || error="Backupset $restore_source cannot be found in $NUODB_BACKUPDIR"
+  if [ -z "$( echo $restore_source | grep '^[a-z]\+:/[^ ]\+')" -a ! -d "$NUODB_BACKUPDIR/$restore_source" ]; then
+      error="Backupset $restore_source cannot be found in $NUODB_BACKUPDIR"
+      retval=$ERR_BACKUPSET_NOT_FOUND
+      return $retval
   fi
 
   # work out available space
   archSize="$(du -s $DB_DIR | grep -o '^ *[0-9]\+')"
   archSpace="$(df --output=avail $DB_DIR | grep -o ' *[0-9]\+')"
 
-  if [ $(( archSize * 2 < archSpace)) ]; then
+  if [ $(( archSpace > archSize * 2)) ]; then
     saveName=$DB_DIR-save-$( date +%Y%m%dT%H%M%S )
+    undo="mv $saveName $DB_DIR"
     mv $DB_DIR $saveName
      
     retval=$?
     if [ $retval -ne 0 ]; then
-      mv $saveName $DB_DIR
+      $undo
       error="Error moving archive in preparation for restore"
+      return $retval
     fi
   else
     tarfile=$DB_DIR-$( date +%Y%m%dT%H%M%S ).tar.gz
-    tar czf $tarfile $DB_DIR
+    tar czf $tarfile -C $DB_PARENTDIR $DB_NAME
 
     retval=$?
     if [ $retval -ne 0 ]; then
       rm -rf $tarfile
       error="Restore: unable to save existing archive to TAR file"
+      return $retval
     fi
 
     archSpace="$(df --output=avail $DB_DIR | grep -o ' *[0-9]\+')"
     if [ $(( archSize + 1024000 > archSpace )) ]; then
       rm -rf $tarfile
-      retval=-1
+      retval=$ERR_NO_SPACE
       error="Insufficient space for restore after archive has been saved to TAR."
+      return $retval
     fi
 
+    undo="tar xf $tarfile -C $DB_PARENTDIR"
     rm -rf $DB_DIR
   fi
 
   mkdir $DB_DIR
+
+  log "(restore) recreated $DB_DIR; atoms=$( ls -l $DB_DIR/*.atm | wc -l)"
 
   # find the backup set and backup id
   # backupset=$(ls -tl $BACKUPDIR | head -n 1)
@@ -102,16 +175,75 @@ function perform_restore() {
 
   # restore request is a URL - so retrieve the backup using curl
   if [ -n "$( echo $restore_source | grep '^[a-z]\+:/[^ ]\+')" ]; then
+
+    # define the download directory depending on the type of source
+    if [ "$restore_type" = "stream" ]; then
+      download_dir=$DB_DIR
+    else
+      # It is a backupset so switch the download to somewhere temporary available on all SMs (it will be removed later)
+      # This will also run if TYPE is unrecognised, since it works for either type, but will be less efficient.
+      download_dir=$(basename $restore_source)
+      download_dir="${DB_PARENTDIR}/$(basename $download_dir .${download_dir#*.})-downloaded"
+      mkdir $download_dir
+    fi
+
     [ -n "$restore_credentials" -a "$restore_credentials" != ":" ] && curl_creds="--user $restore_credentials"
     [ -n "$curl_creds" ] && curl_opts="--user *:*"
 
     echo "curl -k $curl_opts $restore_source | tar xzf - --strip-components $strip_levels -C $DB_DIR"
     curl -k $curl_creds "$restore_source" | tar xzf - --strip-components $strip_levels -C $DB_DIR
 
-    chown -R $(echo "${NUODB_OS_USER:-1000}:${NUODB_OS_GROUP:-0}" | tr -d '"') $DB_DIR
+    retval=$?
+    if [ $retval -ne 0 ]; then
+      $undo
+      error="Restore: unable to download/unpack backup $restore_source"
+      return $retval
+    fi
+
+    chown -R $(echo "${NUODB_OS_USER:-1000}:${NUODB_OS_GROUP:-0}" | tr -d '"') $download_dir
+
+    # restore data and/or fix the metadata
+    log "restoring archive and/or clearing restored archive physical metadata"
+    status="$(nuodocker --api-server $NUOCMD_API_SERVER restore archive --origin-dir $download_dir --restore-dir $DB_DIR --db-name $DB_NAME --clean-metadata)"
+    log "$status"
+
+    if [ "$download_dir" != "$DB_DIR" ]; then
+      log "removing $download_dir"
+      rm -rf $download_dir
+    fi
+
   else
-    $NUODB_BINDIR/nuoarchive restore --restore-dir $DB_DIR $NUODB_BACKUPDIR/$restore_source
+    # log "Calling nuoarchive to restore $restore_source into $DB_DIR"
+    # $NUODB_BINDIR/nuoarchive restore --restore-dir $DB_DIR $NUODB_BACKUPDIR/$restore_source
+    log "Calling nuodocker to restore $restore_source into $DB_DIR"
+    status="$(nuodocker --api-server $NUOCMD_API_SERVER restore archive --origin-dir $NUODB_BACKUPDIR/$restore_source --restore-dir $DB_DIR --db-name $DB_NAME --clean-metadata)"
+    log "$status"
   fi
+
+  # make sure the archive is correct for this database
+  restoredName="$($NUODB_BINDIR/nuodb --show-archive-history --archive $DB_DIR | tr -d '\n' | grep -Eo '[<]Arg[>]--database[<]/Arg[>][^<]*[<]Arg[>]([^<]+)[<]/Arg[>]' | sed -r 's;[<]Arg[>]--database[<]/Arg[>][^<]*[<]Arg[>]([^<]+)[<]/Arg[>];\1;' )"
+  if [ -n "$restoredName" -a "$restoredName" != "$DB_NAME" ]; then
+    $undo
+    error="Restore: incorrect backup specified. Database name is $DB_NAME but archive is for $restoredName"
+    retval=$ERR_INCORRECT_BACKUP
+    return $retval
+  fi
+
+  [ -n "$NUODB_DEBUG" ] && ls -l $DB_DIR
+
+  # additional validation of databaseUUId - not currently supported
+  #
+  # if [ $myArchive -ge 0 ]; then
+    # 
+    # restoredID=$($NUODB_BINDIR/nuodb --show-archive-history --archive $DB_DIR/$DB_NAME | grep -Eo 'DatabaseUUId="[-0-9a-fA-F]+"' | sed -r 's;DatabaseUUId="([-0-9a-fA-F]+)";\1;')
+    # databaseID=$($NUOCMD get database-uuid --db-name $DB_NAME)  # not a valid command - adjust when a commandis implemented
+    # if [ "$restoredID" -ne "$datbaseID" ]; then
+    #   $undo
+    #   error="Restore: incorrect backup specified. Database UUID is $databaseID but archive is for $restoredID"
+    #   retval=$ERR_INCORRECT_BACKUP
+    #   return $retval
+    # fi
+  # fi
 
   # # call nuodocker to fix the archive metadata
   # nuodocker --api-server $NUOCMD_API_SERVER restore archive --origin-dir $DB_DIR --restore-dir $DB_DIR --db-name $DB_NAME --clean-metadata
@@ -126,23 +258,46 @@ function perform_restore() {
 #=============================
 # main routine
 #=============================
+
+log "==========================================="
+
+wrapLogfile
+
 # ensure DB_DIR exists
 if [ ! -e "${DB_DIR}" ] ; then
   mkdir -p "${DB_DIR}"
+  log "Created new dir $DB_DIR: atoms=$( ls -l $DB_DIR/*.atm | wc -l )"
+else
+  log "$DB_DIR exists: $( ls -l $DB_DIR | wc -l )"
 fi
+
+log "existing archives: $( ls -l $DB_PARENTDIR )"
+
+# ensure the admin layer is intact...
+trace "checking Admin layer"
+status="$($NUOCMD check servers --check-leader --timeout 30)"
+retval=$?
+[ $retval -ne 0 ] && die $ERR_ADMIN_UNAVAILABLE "(nuosm) Admin layer is inoperative - exiting: $status"
 
 first_req="$NUODB_RESTORE_REQUEST_PREFIX/$DB_NAME/first"
 
+trace "checking archive raft metadata"
 myArchive=$( $NUOCMD show archives --db-name $DB_NAME --archive-format "archive-id: {id}" | sed -En "/^archive-id: / {N; /$HOSTNAME/ s/^archive-id: ([0-9]+).*$/\1/; T; p}" | head -n 1 )
-[ -z "$myArchive" ] && myArchive=-1
-[ -n "$NUODB_DEBUG" ] && echo "myArchive=$myArchive; DB=$DB_NAME; hostname=$HOSTNAME"
-[ -n "$NUODB_DEBUG" -a "$myArchive" = "-1" ] && echo "$($NUOCMD show archives --db-name $DB_NAME)"
+[ -z "$myArchive" ] && myArchive="-1"
+log "myArchive=$myArchive; DB=$DB_NAME; hostname=$HOSTNAME"
+[ -n "$NUODB_DEBUG" -a "$myArchive" -eq "-1" ] && log "$($NUOCMD show archives --db-name $DB_NAME)"
 
 # if a restore from backup has been requested, then do that now
+trace "retrieving restore request from raft"
 restore_req="$NUODB_RESTORE_REQUEST_PREFIX/$DB_NAME/restore"
 restore_requested="$( $NUOCMD get value --key $restore_req )"
 
+log "restore requested: $restore_requested"
+
+wotIdid=""
+
 if [ -n "$restore_requested" ]; then
+  trace "retrieving restore credentials from raft"
   credential_req="$NUODB_RESTORE_REQUEST_PREFIX/$DB_NAME/restore/credentials"
   restore_credentials="$( $NUOCMD get value --key $credential_req )"
   [ -z "$restore_credentials" ] && restore_credentials=${DATABASE_RESTORE_CREDENTIALS:-:}
@@ -153,14 +308,18 @@ if [ -n "$restore_requested" ]; then
 fi
 
 # if my archive already exists
-if [ "$myArchive" != "-1" ]; then
+if [ "$myArchive" -ne "-1" ]; then
+
+  log "myArchive found; existing archives: $( ls -l $DB_PARENTDIR )"
 
   # if a restore has been requested, then do that
   if [ -n "$restore_requested" ]; then
-    restore_source=$restore_requested
-    [ -n "$NUODB_DEBUG" ] && echo "restore requested: $restore_source"
+    restore_source=$(echo $restore_requested | sed -r 's;^stream:(.+)$;\1;')
+    [ "$restore_source" != "$restore_requested" ] && restore_type="stream"
 
-  # else if the database is configured with a an AUTO_RESTORE, then specify that
+    log "restore requested: $restore_source"
+
+  # else if the database is configured with an AUTO_RESTORE, then specify that
   elif [ -n "$NUODB_AUTO_RESTORE" ]; then
     restore_source="$NUODB_AUTO_RESTORE"
     restore_credentials=${DATABASE_RESTORE_CREDENTIALS:-:}
@@ -168,23 +327,46 @@ if [ "$myArchive" != "-1" ]; then
     strip_levels=${NUODB_RESTORE_STRIP_LEVELS:-1}
   fi
 
-# my archive does not exist - check to see if we should IMPORT it
-elif [ -n "$NUODB_AUTO_IMPORT" -a ! -f $DB_DIR/1.atm ]; then
-  restore_source="$NUODB_AUTO_IMPORT"
-  restore_credentials=${DATABASE_IMPORT_CREDENTIALS:-:}
-  restore_type=${NUODB_AUTO_IMPORT_TYPE}
-  strip_levels=${NUODB_IMPORT_STRIP_LEVELS:-1}
+# my archive on disk does not exist - check to see if we should RESTORE/IMPORT it
+elif [ ! -f $DB_DIR/1.atm ]; then
+
+  lostArchive=$($NUOCMD show archives --db-name $DB_NAME --archive-format "archive-id: {id}" | sed -En "/^archive-id: / {N; /UNKNOWN ADDRESS/ s/^archive-id: ([0-9]+).*$/\1/; T; p}" | head -n 1 )
+  
+  # if there is a lost archive, try to REPAIR/RESTORE the disk archive
+  if [ -n "$lostArchive" ]; then
+
+    # delete this lost archive to enable SM restart
+    myArchive="$lostArchive"
+
+    # if autoRestore is enabled - then configure that also
+    if [ -n "$NUODB_AUTO_RESTORE" ]; then
+      restore_source="$NUODB_AUTO_RESTORE"
+      restore_credentials=${DATABASE_RESTORE_CREDENTIALS:-:}
+      restore_type=${NUODB_AUTO_RESTORE_TYPE}
+      strip_levels=${NUODB_RESTORE_STRIP_LEVELS:-1}
+    fi
+
+  # otherwise, we could IMPORT the initial state
+  elif [ -n "$NUODB_AUTO_IMPORT" ]; then 
+    restore_source="$NUODB_AUTO_IMPORT"
+    restore_credentials=${DATABASE_IMPORT_CREDENTIALS:-:}
+    restore_type=${NUODB_AUTO_IMPORT_TYPE}
+    strip_levels=${NUODB_IMPORT_STRIP_LEVELS:-1}
+  fi
+elif [ -n "$NUODB_DEBUG" ]; then
+  log "myArchive not found, but archive has some contents: $( ls -l $DB_DIR | wc -l )"
 fi
 
 # resolve ":latest"
 if [ "$restore_source" = ":latest" ]; then
 
   # find which backup group performed the latest backup
+  trace "retrieve :latest from nuobackup"
   latest_group=$( nuobackup --type report-latest --db-name $DB_NAME )
 
   # if the latest backup was not by my group, then wait to allow an SM from the latest group to start first
   if [ "$latest_group" != "$NUODB_BACKUP_GROUP" ]; then
-    echo ":latest backup was not made by my group $NUODB_BACKUP_GROUP - waiting to allow an SM from $latest_group to start..."
+    log ":latest backup was not made by my group $NUODB_BACKUP_GROUP - waiting to allow an SM from $latest_group to start..."
 
     # try for 30 seconds, sleeping every 2 seconds
     for retry in {1..30..2}; do
@@ -193,38 +375,50 @@ if [ "$restore_source" = ":latest" ]; then
       sleep 2
     done
 
-    [ -n "$sm" ] && echo "Primary restore SM='${sm}'..." || echo "No Primary restore SM found - attempting restore from $NUODB_BACKUP_GROUP..."
+    [ -n "$sm" ] && log "Primary restore SM='${sm}'..." || log "No Primary restore SM found - attempting restore from $NUODB_BACKUP_GROUP..."
   fi
 fi
 
 # resolve the latest backup for the specified backup group
 if [ "$restore_source" = ":latest" -o "$restore_source" = ":group-latest" ]; then
-  [ -n "$NUODB_DEBUG" ] && echo "Resolving restore '$restore_source'..."
+
+  trace "retrieving :group-latest from nuorestore"
+
+  log "Resolving restore '$restore_source'..."
   restore_source=$( nuobackup --type report-latest --db-name $DB_NAME --group $NUODB_BACKUP_GROUP )
-  [ -n "$NUODB_DEBUG" ] && echo "Latest restore for $NUODB_BACKUP_GROUP resolved to $restore_source"
+  log "Latest restore for $NUODB_BACKUP_GROUP resolved to $restore_source"
 fi
+
+wotIdid=""
 
 if [ -n "$restore_requested" -a -n "$restore_source" ]; then
 
+  log "Restore $restore_requested requested; archive contents: $( ls -l $DB_DIR | wc -l)"
+
   # work out who is the first one in
+  trace "trying to reserve first-in"
   $NUOCMD set value --key $first_req --value $HOSTNAME --expected-value ''
   first_in="$( $NUOCMD get value --key $first_req )"
 
-  echo "First-in = $first_in"
+  wotIdid=""
+
+  log "First-in = $first_in"
 
   # if I got in first - perform the restore
   if [ "$first_in" = "$HOSTNAME" ]; then
 
-    echo "I am first-in: $first_in == $HOSTNAME"
+    log "I am first-in: $first_in == $HOSTNAME"
 
-    # [ -z "$restore_source" ] && die -1 "There is no valid LATEST backup - restore of LATEST failed."
+    # [ -z "$restore_source" ] && die 70 "There is no valid LATEST backup - restore of LATEST failed."
 
     # take ownership of the SM startup semaphore
+    trace "Take ownership of SM startup semaphore"
     $NUOCMD set value --key $startup_key/$DB_NAME --value $HOSTNAME --unconditional
 
     # disable all the archive metadata so that get-archive-history will not look for other SMs
+    trace "Disable all archive metadata except my own"
     archive_ids=$( $NUOCMD get archives --db-name $DB_NAME | grep -o "id=[0-9]\+" | grep -o "[0-9]\+")
-    [ -z "$NUODB_DEBUG" ] && echo "archives: $archive_ids"
+    log "archives: $archive_ids"
 
     # delete all archives but my own
     for archv in $archive_ids; do
@@ -232,35 +426,51 @@ if [ -n "$restore_requested" -a -n "$restore_source" ]; then
     done
 
     # and restore the data
+    trace "performing restore"
     perform_restore
+
+    wotIdid=""
+
+    log "Restored from $restore_source"
 
     # clear/release shared state
     # $NUOCMD set value --key $first_req --value '' --expected-value $HOSTNAME
     # $NUOCMD set value --key $restore_req --value '' --expected-value $restore_requested
+    log "clearing restore credential request from raft"
     $NUOCMD set value --key $credential_req --value '' --unconditional
 
-
     # any error is a fatal error
-    [ "$retval" = "0" ] || die $retval $error
+    [ $retval -ne 0 ] && die $retval $error
 
   else
     # attempt to restore the same backup that the initial SM is restoring - to reduce SYNC time
+
+    trace "attempting to restore same backup as master SM to secondary SM"
+
     if [ -n "$( echo $restore_source | grep '^[a-z]\+:/[^ ]\+')" -o -d $NUODB_BACKUPDIR/$restore_source ]; then
       perform_restore
 
+      log "Restored secondary archive to match primary restore"
+
       # any error in a SEED restore is logged, but not fatal
-      [ -n "$error" ] && echo "WARNING: Error performing SEED restore: $error"
+      [ -n "$error" ] && log "WARNING: Error performing SEED restore: $error"
     fi
   fi
 
   # wait until it's my turn to startup
+  trace "waiting until it's my turn to start up"
+  retry=0
   until owner=$( $NUOCMD get value --key $startup_key/$DB_NAME ); [ "$owner" = "$HOSTNAME" -o "$NUODB_SEQUENCE_SYNC" = "false" ] ; do
+
+    [ "$owner" = "" -a $retry -gt 0 ] && die $ERR_RESTORE_FAILED "Fatal error in database RESTORE - initial SM has exited with error - $HOSTNAME aborting also"
 
     # find the start-id of the SM that owns the semaphore
     owner_id=$( $NUOCMD show database --db-name $DB_NAME --skip-exited --process-format "{engine_type}: {address} start-id: {start_id};" | grep -E "^ *SM: $owner" | grep -Eo "start-id: [[0-9]+" | grep -Eo "[0-9]+")
     if [ -z "$owner_id" ]; then
-      echo "Could not find start-id for starting SM on $owner - retrying..."
+      log "Could not find start-id for starting SM on $owner - retrying..."
       sleep 30
+
+      retry=$((retry + 1))
       continue
     fi
 
@@ -277,68 +487,62 @@ if [ -n "$restore_requested" -a -n "$restore_source" ]; then
   done
 
   # call nuodocker to fix the archive metadata
-  nuodocker --api-server $NUOCMD_API_SERVER restore archive --origin-dir $DB_DIR --restore-dir $DB_DIR --db-name $DB_NAME --clean-metadata
+  # trace "clearing physical archive metadata"
+  # log "$(nuodocker --api-server $NUOCMD_API_SERVER restore archive --origin-dir $DB_DIR --restore-dir $DB_DIR --db-name $DB_NAME --clean-metadata)"
 
   # completely delete my previous archive metadata
-  # this is required because nuodocker always creates a new archive
-  [ $myArchive -ge 0 ] && $NUOCMD delete archive --archive-id $myArchive --purge
+  # - because perform_restore always creates a new archive
+  trace "completely deleting the raft metadata for my archive"
+  [ "$myArchive" -ne "-1" ] && log "$($NUOCMD delete archive --archive-id $myArchive --purge)"
 
 fi
+
+wotIdid=""
 
 # release my archive if it is locked
-# this will likely never execute but has been left in for completeness
+# this will likely never execute but is kept to be sure, to be sure...
+trace "releasing my locked archive metadata"
 locked_archive=$( $NUOCMD show archives --db-name $DB_NAME --removed --removed-archive-format "archive-id: {id}" | sed -En "/^archive-id: / {N; /$HOSTNAME/ s/^archive-id: ([0-9]+).*$/\1/; T; p}" | head -n 1 )
-[ -n "$locked_archive" ] && $NUOCMD create archive --db-name $DB_NAME --archive-path $DB_DIR --is-external --restored --archive-id $locked_archive
-
-# if a RESTORE_SOURCE is defined, and the archive dir is empty, then import/restore from the URL
-if [ -n "$restore_source" -a -z "$restore_requested" -a ! -f $DB_DIR/1.atm ]; then
-
-  # if the NUODB_IMPORT_URL has a protocol:/ prefix, then use curl to download the archive
-  if [ -n "$( echo $restore_source | grep '^[a-z]\+:/[^ ]\+')" ]; then
-
-    # define the download directory depending on the type of source
-    if [ "$restore_type" = "stream" ]; then
-      auto_download_dir=$DB_DIR
-    else
-      # It is a backupset so switch the download to somewhere temporary available on all SMs (it will be removed later)
-      # This will also run if TYPE has a mistake since it works for either type, but will be less efficient.
-      auto_download_dir=$(basename $restore_source)
-      auto_download_dir="${NUODB_ARCHIVEDIR}/${NUODB_DOMAIN}/$(basename $auto_download_dir .${auto_download_dir#*.})-downloaded"
-      mkdir $auto_download_dir
-    fi
-    
-    # download the source
-    [ -n "$restore_credentials" -a "$restore_credentials" != ":" ] && curl_creds="--user $restore_credentials"
-    [ -n "$curl_creds" ] && curl_opts="--user *:*"
-
-    echo "curl -k $curl_opts $restore_source | tar xzf - --strip-components $strip_levels -C $auto_download_dir"
-    curl -k $curl_creds "$restore_source" | tar xzf - --strip-components $strip_levels -C $auto_download_dir
-
-    chown -R $(echo "${NUODB_OS_USER:-1000}:${NUODB_OS_GROUP:-0}" | tr -d '"') $DB_DIR
-
-    [ -n "$NUODB_DEBUG" ] && ls -l $DB_DIR
-    
-    # restore and/or fix the metadata
-    nuodocker --api-server $NUOCMD_API_SERVER restore archive --origin-dir $auto_download_dir --restore-dir $DB_DIR --db-name $DB_NAME --clean-metadata
-    
-    if [ "$auto_download_dir" != "$DB_DIR" ]; then
-      echo "removing $auto_download_dir"
-      rm -rf $auto_download_dir
-    fi
-
-  elif [ -d "$NUODB_BACKUPDIR/$restore_source" ]; then
-    # NUODB_IMPORT_URL has no protocol - so just append the --restore-from-dir option
-    set -- --restore-from-dir "$NUODB_BACKUPDIR/$restore_source" "$@"
-  fi
-  # completely delete my previous archive metadata
-  [ $myArchive -ge 0 ] && $NUOCMD delete archive --archive-id $myArchive --purge
+if [ -n "$locked_archive" ]; then
+  $NUOCMD create archive --db-name $DB_NAME --archive-path $DB_DIR --is-external --restored --archive-id $locked_archive
+  log "Unlocking my locked archive $locked_archive"
 fi
 
+log "restore_source=$restore_source; restore_requested=$restore_requested; path=$DB_DIR; atom files=$( ls -l $DB_DIR/*.atm | wc -l ); catalogs=$( ls -l $DB_DIR/*.cat | wc -l)"
+
+# if a RESTORE_SOURCE is defined, and the archive dir is empty, then import/restore from the URL
+atomCount=$( ls -l $DB_DIR/*.atm | wc -l)
+catalogCount=$( ls -l $DB_DIR/*.cat | wc -l )
+if [ -n "$restore_source" -a -z "$restore_requested" -a $atomCount -lt 20 -a $catalogCount -lt 2 ]; then
+
+  trace "restoring empty/damaged archive"
+  log "Existing archive is empty - restoring and clearing metadata"
+
+  perform_restore
+
+  # any error in a SEED restore is logged, but not fatal
+  [ -n "$error" ] && log "WARNING: Error performing IMPORT/SEED restore: $error"
+
+  # completely delete my previous archive metadata
+  trace "completely deleting raft metadata for my archive $myArchive"
+  if [ "$myArchive" -ne "-1" ]; then
+    trace "deleting my archive metadata: $myArchive"
+    log "$( $NUOCMD delete archive --archive-id "$myArchive" --purge )"
+
+  fi
+fi
+
+log "$( $NUOCMD show archives --db-name $DB_NAME )"
+
 # release the first-in semaphore
+wotIdid="releasing first-in semaphore"
 [ -n "$first_in" ] && $NUOCMD set value --key $first_req --value '' --expected-value $HOSTNAME
 
 # clear the restore_request
+wotIdid="clearing restore request"
 [ -n "$restore_requested" ] && $NUOCMD set value --key $restore_req --value '' --expected-value "$restore_requested"
+
+trace "executing nuodocker to start SM"
 
 # expects NUOCMD_API_SERVER to be set.
 if [ -n "${NUODB_OPTIONS}" ] ; then

--- a/stable/database/files/nuote
+++ b/stable/database/files/nuote
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 export NUODB_LOGDIR=/var/log/nuodb/"${POD_NAME}"
 export NUODB_CRASHDIR="$NUODB_LOGDIR"/crash

--- a/stable/database/files/readinessprobe
+++ b/stable/database/files/readinessprobe
@@ -1,5 +1,6 @@
-#!/bin/sh
+#!/bin/bash
 
+# print error and exit
 function die() {
   retval=$1
   shift
@@ -12,10 +13,10 @@ processes=`nuocmd show domain --process-format "{address} {start_id}" | grep \`h
 
 if [ -z "$processes" ]
 then
-  die -1 "No process found"
+  die 80 "No process found"
 fi
 
 for start_id in $processes
 do
-  nuocmd check process --check-running --start-id $start_id || die -1 "Process reported not ready"
+  nuocmd check process --check-running --start-id $start_id || die 81 "Process reported not ready"
 done

--- a/stable/database/templates/_helpers.tpl
+++ b/stable/database/templates/_helpers.tpl
@@ -165,7 +165,7 @@ Import ENV vars from configMaps
    You Have Been Warned.
 */}}
 {{- define "database.envFrom" }}
-envFrom: [ configMapRef: { name: {{ .Values.database.name }}-restore } {{- range $map := .Values.database.envFrom.configMapRef }}, configMapRef: { name: {{$map}} } {{- end }} ]
+envFrom: [ configMapRef: { name: {{ .Values.database.name }}-restore }, configMapRef: { name: domain-{{ .Values.admin.domain }}-env } {{- range $map := .Values.database.envFrom.configMapRef }}, configMapRef: { name: {{$map}} } {{- end }} ]
 {{- end -}}
 
 {{/*

--- a/stable/restore/README.md
+++ b/stable/restore/README.md
@@ -146,14 +146,15 @@ nuodb:
 
 #### restore.*
 
-The following tables list the configurable parameters of the backup chart and their default values.
+The following tables list the configurable parameters of the restore chart and their default values.
 
 | Parameter | Description | Default |
 | ----- | ----------- | ------ |
+| `restore.type` | What type of restore to perform: [ "database" | "archive" ]. A "database" restore restarts the entire database at a previous state. An "archive" restore restores/repairs a SINGLE archive in a RUNNING database. | `"database"` |
 | `restore.target` | Where to restore `TO` | `{{ .Values.database.name }}` |
 | `restore.source` | Where to restore `FROM` [ backupset | url | `:latest` ] | `:latest` |
 | `restore.credentials` | Credentials to use for a URL source (user:password) | `""` |
-| `restore.autoRestart` | Whether to automatically restart the database and trigger the restore (true/false) | `true` |
+| `restore.autoRestart` | Whether to automatically restart the database and trigger the restore (true/false). Only valid for a "database" restore | `true` |
 
 ## Detailed Steps
 

--- a/stable/restore/files/nuorestore
+++ b/stable/restore/files/nuorestore
@@ -47,9 +47,8 @@ function wrapLogfile() {
     tail -n $(( lines / 2 )) $LOGFILE > ${LOGFILE}-new
     rm -rf $LOGFILE
     mv $LOGFILE-new $LOGFILE
+    log "(nuorestore) log file wrapped around"
   fi
-
-  log "(nuorestore) log file wrapped around"
 }
 
 restore_type="database"
@@ -96,6 +95,7 @@ auto=$(echo $auto | tr '[:upper:]' '[:lower:]')
 
 # set the persistent flag for the backup
 log "restore_type=$restore_type; writing $restore_source to $NUODB_RESTORE_REQUEST_PREFIX/$db_name/restore"
+
 nuocmd --api-server $NUOCMD_API_SERVER set value --key $NUODB_RESTORE_REQUEST_PREFIX/$db_name/restore \
     --value $restore_source \
     --unconditional

--- a/stable/restore/files/nuorestore
+++ b/stable/restore/files/nuorestore
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # simple script to perform a NuoDB restore.
 # Sets a flag to tell newly-starting SM(s) to perform the restore; then optionally causes the SM(s) to restart
@@ -10,8 +10,47 @@
 #   --source    - source to restore from - can be a backupset or a URL
 #   --auto      - automatically start the restore operation ( true | false )
 
+[ "$NUODB_DEBUG" = "verbose" ] && set -X
+
 : ${NUODB_BACKUP_KEY:=/nuodb/nuobackup}
 : ${NUODB_RESTORE_REQUEST_PREFIX:=/nuodb/nuosm}
+
+LOGFILE=${NUODB_LOGDIR:=/var/log/nuodb}/nuorestore.log
+
+#=======================================
+# function - log messages
+#
+function log() {
+  if [ -n "$NUODB_DEBUG" ]; then
+    echo "nuorestore $@" | tee -a $LOGFILE
+   #  curl -k -X POST -E /etc/nuodb/keys/nuocmd.pem -H "Content-type: application/json" $ap_protocol://$NUOADMIN_AP0:8888/api/1/diagnostics/log -d "{\"message\": \"nuorestore $@\"}"
+  fi
+}
+
+#=======================================
+# function - trace workflow
+#
+function trace() {
+  wotIdid="$@"
+  [ -n "$1" -a -n "$NUODB_DEBUG" ] && log "trace: $wotIdid"
+}
+
+#=======================================
+# function - wrap a log file around so it doesn't grow infinitely
+#
+function wrapLogfile() {
+  logsize=$( du -sb $LOGFILE | grep -o '^ *[0-9]\+' )
+  maxlog=5000000
+  log "logsize=$logsize"
+  if [ ${logsize:=0} -gt $maxlog ]; then
+    lines=$(wc -l $LOGFILE)
+    tail -n $(( lines / 2 )) $LOGFILE > ${LOGFILE}-new
+    rm -rf $LOGFILE
+    mv $LOGFILE-new $LOGFILE
+  fi
+
+  log "(nuorestore) log file wrapped around"
+}
 
 restore_type="database"
 db_name=$DB_NAME
@@ -56,6 +95,7 @@ restore_type=$(echo $restore_type | tr '[:upper:]' '[:lower:]')
 auto=$(echo $auto | tr '[:upper:]' '[:lower:]')
 
 # set the persistent flag for the backup
+log "restore_type=$restore_type; writing $restore_source to $NUODB_RESTORE_REQUEST_PREFIX/$db_name/restore"
 nuocmd --api-server $NUOCMD_API_SERVER set value --key $NUODB_RESTORE_REQUEST_PREFIX/$db_name/restore \
     --value $restore_source \
     --unconditional
@@ -66,8 +106,12 @@ if [ -n "$restore_credentials" ]; then
         --unconditional
 fi
 
+log "Setting flag for database $db_name to restore from $restore_source on next database/SM startup"
 
 if [ "$restore_type" = "database" ]; then
+
+   log "Setting flag for database $db_name to initiate a new FULL backup after next restart"
+
    # Set the semaphores to create a new backupset from a full backup
    nuocmd --api-server $NUOCMD_API_SERVER set value --key $semaphore/$db_name --value "true" --unconditional
 
@@ -76,7 +120,15 @@ if [ "$restore_type" = "database" ]; then
    done
 
    # optionally do automatic initiation of the restore
-   [ "$auto" = "true" ] && nuocmd --api-server $NUOCMD_API_SERVER shutdown database --db-name $db_name
+   if [ "$auto" = "true" ]; then
+      log "restore.autoRestart=true - initiating full database restart for database $db_name"
+
+      nuocmd --api-server $NUOCMD_API_SERVER shutdown database --db-name $db_name
+   else
+      log "restore.autoRestart=false. Restore will be performed when the database - or SM(s) - are manually restarted - over to you..."
+   fi
+else
+   log "Flag set for $restore_type restore. Restore will be performed when the chosen SM is manually restarted - over to you..."
 fi
 
-echo "Restore job completed"
+log "Restore job completed"

--- a/stable/restore/templates/_helpers.tpl
+++ b/stable/restore/templates/_helpers.tpl
@@ -18,17 +18,18 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
-{{- define "database.fullname" -}}
+{{- define "restore.fullname" -}}
 {{- $domain := default "domain" .Values.admin.domain -}}
 {{- $cluster := default "cluster0" .Values.cloud.cluster.name -}}
-{{- if .Values.database.fullnameOverride -}}
-{{- .Values.database.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- $target := include "restore.target" . -}}
+{{- if .Values.restore.fullnameOverride -}}
+{{- .Values.restore.fullnameOverride | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
-{{- $name := default .Chart.Name .Values.database.nameOverride -}}
+{{- $name := default .Chart.Name .Values.restore.nameOverride -}}
 {{- if contains $name .Release.Name -}}
-{{- printf "%s-%s-%s-%s" .Release.Name $domain $cluster .Values.database.name | trunc 43 | trimSuffix "-" -}}
+{{- printf "%s-%s-%s-%s" .Release.Name $domain $cluster $target | trunc 43 | trimSuffix "-" -}}
 {{- else -}}
-{{- printf "%s-%s-%s-%s-%s" .Release.Name $domain $cluster .Values.database.name $name | trunc 43 | trimSuffix "-" -}}
+{{- printf "%s-%s-%s-%s-%s" .Release.Name $domain $cluster $target $name | trunc 43 | trimSuffix "-" -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}
@@ -133,14 +134,18 @@ Import ENV vars from configMaps
    You Have Been Warned.
 */}}
 {{- define "restore.envFrom" }}
-envFrom: [ configMapRef: { name: {{ .Values.database.name }}-restore } {{- range $map := .Values.restore.envFrom.configMapRef }}, configMapRef: { name: {{$map}} } {{- end }} ]
+envFrom: [ configMapRef: { name: {{ include "restore.target" . }}-restore } {{- range $map := .Values.restore.envFrom.configMapRef }}, configMapRef: { name: {{$map}} } {{- end }} ]
 {{- end -}}
 
 {{/*
 Return the restore target.
 */}}
 {{- define "restore.target" -}}
+{{- if .Values.database -}}
 {{- default .Values.database.name .Values.restore.target -}}
+{{- else -}}
+{{- .Values.restore.target -}}
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/stable/restore/templates/configmap.yaml
+++ b/stable/restore/templates/configmap.yaml
@@ -2,11 +2,11 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
-    app: {{ template "database.fullname" . }}
+    app: {{ template "restore.fullname" . }}
     group: nuodb
     domain: {{ .Values.admin.domain }}
     chart: {{ template "nuodb.chart" . }}
     release: {{ .Release.Name | quote }}
-  name: {{ template "database.fullname" . }}-nuorestore
+  name: {{ template "restore.fullname" . }}-nuorestore
 data:
 {{ (.Files.Glob "files/nuorestore").AsConfig | indent 2 }}

--- a/stable/restore/templates/job.yaml
+++ b/stable/restore/templates/job.yaml
@@ -1,11 +1,12 @@
+{{- $restoreTarget := include "restore.target" . -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: restore-{{ include "restore.target" . }}
+  name: restore-{{ $restoreTarget }}
   labels:
     group: nuodb
     subgroup: restore
-    database: "{{ .Values.database.name }}"
+    database: "{{ $restoreTarget }}"
 spec:
   parallelism: 1
   completions: 1
@@ -26,8 +27,10 @@ spec:
         ##
         args:
         - "nuorestore"
+        - "--type"
+        - "{{ default "database" .Values.restore.type }}"
         - "--db-name"
-        - "{{ include "restore.target" . }}"
+        - "{{ $restoreTarget }}"
         - "--source"
         - "{{ include "restore.source" . }}"
         - "--auto"
@@ -53,12 +56,12 @@ spec:
         - name: DB_NAME
           valueFrom:
             secretKeyRef:
-              name: {{ include "restore.target" . }}.nuodb.com
+              name: {{ $restoreTarget }}.nuodb.com
               key: database-name
         - name: DATABASE_RESTORE_CREDENTIALS
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.database.name }}.nuodb.com
+              name: {{ $restoreTarget }}.nuodb.com
               key: database-restore-credentials
         - { name: NUOCMD_API_SERVER,   value: "{{ template "admin.address" . }}:8888"}
         - { name: NUODB_RESTORE_URL,   value: "{{ include "restore.source" . }}" }
@@ -85,7 +88,7 @@ spec:
         emptyDir: {}
       - name: nuorestore
         configMap:
-          name: {{ template "database.fullname" . }}-nuorestore
+          name: {{ template "restore.fullname" . }}-nuorestore
           defaultMode: 0777
       {{- if .Values.admin.tlsCACert }}
       - name: tls-ca-cert

--- a/stable/restore/values.yaml
+++ b/stable/restore/values.yaml
@@ -62,20 +62,32 @@ admin:
   #   secret: nuodb-client-pem
   #   key: client.pem
 
-database:
-  # name
-  # NuoDB Database name.  must consist of lowercase alphanumeric
-  # characters '[a-z0-9]+'
-  name:
-
 restore:
+
+  ## Provide a name in place of prometheus-operator for `app:` labels
+  ##
+  #nameOverride: ""
+
+  ## Provide a name to substitute for the full names of resources
+  ##
+  #fullnameOverride: ""
+
+  # restore type: [ database | archive ]
+  # default value is "database"
+  #
+  # A database restore restores ALL archives of the database - ie restarts the database at a previous state
+  # An archive restore restores/repairs a single archive in a RUNNING database
+  type: "database"
+
   # name of the existing database being restored 
-  target: ""
+  target: "demo"
 
   # source
   # Can be one of:
   # * the name of a backupset on a hotcopy-SM's backup disk;
   # * the metaname ':latest'
+  # * the URL of a downloadable TAR file of a hotcopy backupset
+  # * stream:URL of a downloadable TAR file of a exact copy of a NuoDB archive
   source: ""
 
   # credentials for the specified target - if different to the database.autoRestore.credentials

--- a/test/integration/script_lint_test.go
+++ b/test/integration/script_lint_test.go
@@ -1,0 +1,100 @@
+package integration
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"path"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/nuodb/nuodb-helm-charts/test/testlib"
+)
+
+const shebangPattern = "[#][!][ \t]*/[^/]+/(sh|bash)"
+
+func TestLintScripts(t *testing.T) {
+	rootPaths := [...]string{
+		testlib.ADMIN_HELM_CHART_PATH,
+		testlib.DATABASE_HELM_CHART_PATH,
+		testlib.RESTORE_HELM_CHART_PATH,
+		testlib.THP_HELM_CHART_PATH,
+		testlib.YCSB_HELM_CHART_PATH,
+	}
+
+	shebang, err := regexp.Compile(shebangPattern)
+	if err != nil {
+		t.Error("Cannot compile patterh:", shebangPattern)
+	}
+
+	first20 := make([]byte, 20)
+
+	var errorList []string
+
+	defer func() {
+		if len(errorList) > 0 {
+			t.Error(strings.Join(errorList, "\nAND "))
+		}
+	}()
+
+	for _, root := range rootPaths {
+		rootPath := path.Join(root, "files")
+
+		info, err := os.Stat(rootPath)
+		if err != nil {
+			fmt.Println(err)
+			continue
+		}
+
+		if !info.IsDir() {
+			continue
+		}
+
+		// open the path
+		dir, err := os.Open(rootPath)
+		if err != nil {
+			fmt.Println(err)
+			continue
+		}
+		defer dir.Close() // remember to close the File
+
+		// get all files in the dir
+		scripts, err := dir.Readdir(-1)
+		if err != nil {
+			log.Println("Error reading dir", rootPath, ":", err)
+		}
+
+		for _, scriptInfo := range scripts {
+			scriptPath := path.Join(rootPath, scriptInfo.Name())
+
+			script, err := os.Open(scriptPath)
+			if err != nil {
+				fmt.Println(err)
+				continue
+			}
+			defer script.Close()
+
+			_, err = script.Read(first20)
+			if err != nil {
+				fmt.Println(err)
+				continue
+			}
+
+			groups := shebang.FindStringSubmatch(string(first20))
+			if len(groups) == 0 {
+				fmt.Println(scriptPath, " is not a shell script >>", string(first20), "<<")
+				continue
+			}
+
+			fmt.Println("groups=", groups)
+			cmd := exec.Command(groups[1], "-n", scriptPath)
+
+			out, err := cmd.CombinedOutput()
+			if err != nil {
+				errorList = append(errorList, fmt.Sprintln(scriptPath, "LINT failed:", err, "\n", string(out)))
+			}
+		}
+	}
+}

--- a/test/minikube/constants.go
+++ b/test/minikube/constants.go
@@ -1,0 +1,5 @@
+package minikube
+
+const LABEL_CLOUD = "minikube"
+const LABEL_REGION = "local"
+const LABEL_ZONE = "local-b"

--- a/test/minikube/minikube_base_database_test.go
+++ b/test/minikube/minikube_base_database_test.go
@@ -236,6 +236,10 @@ func restoreDatabase(t *testing.T, namespaceName string, podName string, databas
 		defer k8s.RunKubectl(t, kubectlOptions, "delete", "job", "restore-demo")
 
 		testlib.AwaitPodPhase(t, namespaceName, "restore-demo-", corev1.PodSucceeded, 120*time.Second)
+		podName := testlib.GetPodName(t, namespaceName, "restore-demo-")
+		if restoreLog, err := k8s.RunKubectlAndGetOutputE(t, kubectlOptions, "logs", podName); err != nil {
+			t.Log(restoreLog)
+		}
 	}
 
 	testlib.AwaitDatabaseRestart(t, namespaceName, podName, "demo", databaseOptions, restore)

--- a/test/minikube/minikube_sm_test.go
+++ b/test/minikube/minikube_sm_test.go
@@ -1,0 +1,287 @@
+// +build long
+
+/*
+ * Tests to verify operation of SM startup.
+ * Separate so that changes to SM startup in general - and the SM startup scipt(s) in particular
+ * can be tested in isolation.
+ */
+
+package minikube
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nuodb/nuodb-helm-charts/test/testlib"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/gruntwork-io/terratest/modules/helm"
+	"github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/gruntwork-io/terratest/modules/random"
+)
+
+func TestKubernetesStartSM(t *testing.T) {
+	// skip this test until the code to detect and recover from database startup failure is robust
+	t.Skip()
+
+	testlib.AwaitTillerUp(t)
+	defer testlib.VerifyTeardown(t)
+
+	adminOptions := helm.Options{}
+
+	defer testlib.Teardown(testlib.TEARDOWN_ADMIN)
+	helmChartReleaseName, namespaceName := testlib.StartAdmin(t, &adminOptions, 1, "")
+
+	admin0 := fmt.Sprintf("%s-nuodb-cluster0-0", helmChartReleaseName)
+
+	t.Run("startDatabaseStatefulSet", func(t *testing.T) {
+		defer testlib.Teardown(testlib.TEARDOWN_DATABASE)
+		databaseOptions := helm.Options{
+			SetValues: map[string]string{
+				"database.sm.resources.requests.cpu":    testlib.MINIMAL_VIABLE_ENGINE_CPU,
+				"database.sm.resources.requests.memory": testlib.MINIMAL_VIABLE_ENGINE_MEMORY,
+				"database.te.resources.requests.cpu":    testlib.MINIMAL_VIABLE_ENGINE_CPU,
+				"database.te.resources.requests.memory": testlib.MINIMAL_VIABLE_ENGINE_MEMORY,
+				"backup.persistence.enabled":            "true",
+				"backup.persistence.size":               "1Gi",
+				"database.env[0].name":                  "NUODB_DEBUG",
+				"database.env[0].value":                 "debug",
+			},
+		}
+
+		databaseChartName := testlib.StartDatabase(t, namespaceName, admin0, &databaseOptions)
+
+		fmt.Println("startDatabase returned...")
+
+		opt := testlib.GetExtractedOptions(&databaseOptions)
+		smPodTemplate := fmt.Sprintf("sm-%s-nuodb-%s-%s", databaseChartName, opt.ClusterName, opt.DbName)
+		sm0 := testlib.GetPodName(t, namespaceName, smPodTemplate)
+
+		fmt.Println("extracted databaseOptions; sm name is ", sm0)
+
+		kubectlOptions := k8s.NewKubectlOptions("", "", namespaceName)
+
+		testlib.AddDiagnosticTeardown(
+			testlib.TEARDOWN_DATABASE,
+			t,
+			func() { testlib.GetFile(t, namespaceName, sm0, "/var/log/nuodb", "nuosm.log") },
+		)
+
+		defer func() {
+			status, _ := k8s.RunKubectlAndGetOutputE(t, kubectlOptions, "exec", admin0, "--", "nuocmd", "show", "database", "--db-name", opt.DbName)
+			fmt.Println("database status", status)
+		}()
+
+		t.Run("verifyRestore", func(t *testing.T) { verifyRestorePasses(t, namespaceName, sm0, "archive", ":latest") })
+		t.Run("verifyNonexstentRestore", func(t *testing.T) { verifyRestoreFails(t, namespaceName, sm0, "archive", "urgle-furgle") })
+
+		// have to wait for the SM to be running again...
+		t.Run("fixArchive1", func(t *testing.T) { healDatabase(t, namespaceName, sm0, admin0, &databaseOptions) })
+		t.Run("verifynonexistentRestoreURL", func(t *testing.T) { verifyRestoreFails(t, namespaceName, sm0, "archive", "urgle://furgle/gurgle") })
+		t.Run("fixArchive2", func(t *testing.T) { healDatabase(t, namespaceName, sm0, admin0, &databaseOptions) })
+		// t.Run("verifyEmptyRestore", func(t *testing.T) {
+		// 	verifyRestoreFails(t, namespaceName, sm0, "archive", testlib.RESTORE_EMPTYARCHIVE_URL)
+		// })
+		// t.Run("fixArchive3", func(t *testing.T) { verifyRestorePasses(t, namespaceName, sm0, "archive", ":latest") })
+		// t.Run("verifyWrongRestore", func(t *testing.T) { verifyRestoreFails(t, namespaceName, sm0, "archive", testlib.RESTORE_ARCHIVE2_URL) })
+		// t.Run("fixArchive4", func(t *testing.T) { verifyRestorePasses(t, namespaceName, sm0, "archive", ":latest") })
+	})
+
+	// t.Run("startDatabaseDaemonSet", func(t *testing.T) {
+	// 	defer testlib.Teardown(testlib.TEARDOWN_DATABASE)
+	// 	databaseOptions := helm.Options{
+	// 		SetValues: map[string]string{
+	// 			"database.sm.resources.requests.cpu":    testlib.MINIMAL_VIABLE_ENGINE_CPU,
+	// 			"database.sm.resources.requests.memory": testlib.MINIMAL_VIABLE_ENGINE_MEMORY,
+	// 			"database.te.resources.requests.cpu":    testlib.MINIMAL_VIABLE_ENGINE_CPU,
+	// 			"database.te.resources.requests.memory": testlib.MINIMAL_VIABLE_ENGINE_MEMORY,
+	// 			"backup.persistence.enabled":            "true",
+	// 			"backup.persistence.size":               "1Gi",
+	// 			"database.enableDaemonSet":              "true",
+	// 			// prevent non-backup SM from scheduling
+	// 			"database.sm.nodeSelectorNoHotCopyDS.nonexistantTag": "required",
+	// 		},
+	// 	}
+
+	// 	testlib.StartDatabase(t, namespaceName, admin0, &databaseOptions)
+
+	// 	databaseChartName := testlib.StartDatabase(t, namespaceName, admin0, &databaseOptions)
+
+	// 	opt := testlib.GetExtractedOptions(&databaseOptions)
+	// 	smPodTemplate := fmt.Sprintf("sm-%s-nuodb-%s-%s", databaseChartName, opt.ClusterName, opt.DbName)
+	// 	sm0 := testlib.GetPodName(t, namespaceName, smPodTemplate)
+
+	// 	t.Run("verifyRestore", func(t *testing.T) { verifyRestorePasses(t, namespaceName, sm0, "archive", ":latest") })
+	// 	t.Run("verifyNonexstentRestore", func(t *testing.T) { verifyRestoreFails(t, namespaceName, sm0, "archive", "urgle-furgle") })
+	// 	t.Run("fixArchive1", func(t *testing.T) { healDatabase(t, namespaceName, sm0, admin0, &databaseOptions) })
+	// 	t.Run("verifynonexistentRestoreURL", func(t *testing.T) { verifyRestoreFails(t, namespaceName, sm0, "archive", "urgle://furgle/gurgle") })
+	// 	t.Run("fixArchive2", func(t *testing.T) { healDatabase(t, namespaceName, sm0, admin0, &databaseOptions) })
+	// 	// t.Run("verifyEmptyRestore", func(t *testing.T) {
+	// 	// 	verifyRestoreFails(t, namespaceName, sm0, "archive", testlib.RESTORE_EMPTYARCHIVE_URL)
+	// 	// })
+	// 	// t.Run("fixArchive3", func(t *testing.T) { verifyRestorePasses(t, namespaceName, sm0, "archive", ":latest") })
+	// 	// t.Run("verifyWrongRestore", func(t *testing.T) { verifyRestoreFails(t, namespaceName, sm0, "archive", testlib.RESTORE_ARCHIVE2_URL) })
+	// 	// t.Run("fixArchive4", func(t *testing.T) { verifyRestorePasses(t, namespaceName, sm0, "archive", ":latest") })
+	// })
+
+}
+
+func TestKubernetesRestartSM(t *testing.T) {
+	testlib.AwaitTillerUp(t)
+	defer testlib.VerifyTeardown(t)
+
+	adminOptions := helm.Options{}
+
+	defer testlib.Teardown(testlib.TEARDOWN_ADMIN)
+	helmChartReleaseName, namespaceName := testlib.StartAdmin(t, &adminOptions, 1, "")
+
+	admin0 := fmt.Sprintf("%s-nuodb-cluster0-0", helmChartReleaseName)
+
+	t.Run("startDatabaseStatefulSet", func(t *testing.T) {
+		defer testlib.Teardown(testlib.TEARDOWN_DATABASE)
+		databaseOptions := helm.Options{
+			SetValues: map[string]string{
+				"database.sm.resources.requests.cpu":    testlib.MINIMAL_VIABLE_ENGINE_CPU,
+				"database.sm.resources.requests.memory": testlib.MINIMAL_VIABLE_ENGINE_MEMORY,
+				"database.te.resources.requests.cpu":    testlib.MINIMAL_VIABLE_ENGINE_CPU,
+				"database.te.resources.requests.memory": testlib.MINIMAL_VIABLE_ENGINE_MEMORY,
+				"backup.persistence.enabled":            "true",
+				"backup.persistence.size":               "1Gi",
+				"database.autoRestore.source":           ":latest",
+				"database.env[0].name":                  "NUODB_DEBUG",
+				"database.env[0].value":                 "debug",
+			},
+		}
+
+		databaseChartName := testlib.StartDatabase(t, namespaceName, admin0, &databaseOptions)
+
+		fmt.Println("startDatabase returned...")
+
+		opt := testlib.GetExtractedOptions(&databaseOptions)
+		smPodTemplate := fmt.Sprintf("sm-%s-nuodb-%s-%s", databaseChartName, opt.ClusterName, opt.DbName)
+		sm0 := testlib.GetPodName(t, namespaceName, smPodTemplate)
+
+		kubectlOptions := k8s.NewKubectlOptions("", "", namespaceName)
+
+		testlib.AddDiagnosticTeardown(
+			testlib.TEARDOWN_DATABASE,
+			t,
+			func() { testlib.GetFile(t, namespaceName, sm0, "/var/log/nuodb", "nuosm.log") },
+		)
+
+		restart := func() {
+			k8s.RunKubectl(t, kubectlOptions, "exec", sm0, "--", "rm", "-rf", "/var/opt/nuodb/archive/nuodb/demo")
+
+			result, _ := testlib.RunSQL(t, namespaceName, admin0, "demo", "create table user.newtable (id bigint)")
+			t.Log(result)
+		}
+
+		defer func() {
+			status, _ := k8s.RunKubectlAndGetOutputE(t, kubectlOptions, "exec", admin0, "--", "nuocmd", "show", "database", "--db-name", opt.DbName)
+			fmt.Println("database status on EXIT", status)
+		}()
+
+		t.Run("verifyRestartOnLostArchive", func(t *testing.T) {
+			testlib.AwaitDatabaseRestart(t, namespaceName, admin0, "demo", &databaseOptions, restart)
+
+			status, _ := k8s.RunKubectlAndGetOutputE(t, kubectlOptions, "exec", sm0, "--", "ls", "-l", "/var/opt/nuodb/archive/nuodb/demo")
+			t.Log("after archive delete: ", status)
+		})
+	})
+
+	/*
+		t.Run("startDatabaseDaemonSet", func(t *testing.T) {
+			defer testlib.Teardown(testlib.TEARDOWN_DATABASE)
+			databaseOptions := helm.Options{
+				SetValues: map[string]string{
+					"database.sm.resources.requests.cpu":    testlib.MINIMAL_VIABLE_ENGINE_CPU,
+					"database.sm.resources.requests.memory": testlib.MINIMAL_VIABLE_ENGINE_MEMORY,
+					"database.te.resources.requests.cpu":    testlib.MINIMAL_VIABLE_ENGINE_CPU,
+					"database.te.resources.requests.memory": testlib.MINIMAL_VIABLE_ENGINE_MEMORY,
+					"backup.persistence.enabled":            "true",
+					"backup.persistence.size":               "1Gi",
+					"database.enableDaemonSet":              "true",
+					// prevent non-backup SM from scheduling
+					"database.sm.nodeSelectorNoHotCopyDS.nonexistantTag": "required",
+					"database.autoRestore.source":                        ":latest",
+				},
+			}
+
+			testlib.StartDatabase(t, namespaceName, admin0, &databaseOptions)
+
+			databaseChartName := testlib.StartDatabase(t, namespaceName, admin0, &databaseOptions)
+
+			opt := testlib.GetExtractedOptions(&databaseOptions)
+			smPodTemplate := fmt.Sprintf("sm-%s-nuodb-%s-%s", databaseChartName, opt.ClusterName, opt.DbName)
+			sm0 := testlib.GetPodName(t, namespaceName, smPodTemplate)
+
+			restart := func() {
+				kubectlOptions := k8s.NewKubectlOptions("", "")
+				kubectlOptions.Namespace = namespaceName
+
+				k8s.RunKubectl(t, kubectlOptions, "exec", sm0, "--", "rm", "-rf", "/var/opt/nuodb/archive/nuodb/demo")
+				testlib.RunSQL(t, namespaceName, admin0, "demo", "select 1 from dual")
+			}
+
+			t.Run("verifyRestartOnLostArchive", func(t *testing.T) {
+				testlib.AwaitDatabaseRestart(t, namespaceName, admin0, "demo", &databaseOptions, restart)
+			})
+		})
+	*/
+
+}
+
+func healDatabase(t *testing.T, namespaceName string, podName string, adminName string, databaseOptions *helm.Options) {
+	opts := testlib.GetExtractedOptions(databaseOptions)
+
+	restoreArchive(t, namespaceName, podName, "archive", ":latest")
+	testlib.AwaitDatabaseUp(t, namespaceName, adminName, opts.DbName, opts.NrTePods+opts.NrSmPods)
+}
+
+func verifyRestoreFails(t *testing.T, namespaceName string, podName string, backupType string, backupName string) {
+	kubectlOptions := k8s.NewKubectlOptions("", "", namespaceName)
+
+	restoreArchive(t, namespaceName, podName, backupType, backupName)
+	testlib.VerifyProcessRestartFails(t, namespaceName, podName, func() { k8s.RunKubectl(t, kubectlOptions, "exec", podName, "--", "kill", "1") })
+}
+
+func verifyRestorePasses(t *testing.T, namespaceName string, podName string, backupType string, backupName string) {
+	kubectlOptions := k8s.NewKubectlOptions("", "", namespaceName)
+
+	restoreArchive(t, namespaceName, podName, backupType, backupName)
+	testlib.AwaitProcessRestart(t, namespaceName, podName, func() { k8s.RunKubectl(t, kubectlOptions, "exec", podName, "--", "kill", "1") })
+}
+
+func restoreArchive(t *testing.T, namespaceName string, podName string, backupType string, backupName string) {
+	// run the restore chart - and then manually restart the SM
+	randomSuffix := strings.ToLower(random.UniqueId())
+
+	restoreName := fmt.Sprintf("restore-demo-%s", randomSuffix)
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"database.name":       "demo",
+			"restore.target":      "demo",
+			"restore.source":      backupName,
+			"restore.type":        backupType,
+			"restore.autoRestart": "false",
+		},
+	}
+	kubectlOptions := k8s.NewKubectlOptions("", "", namespaceName)
+	options.KubectlOptions = kubectlOptions
+
+	testlib.InjectTestVersion(t, options)
+
+	helm.Install(t, options, testlib.RESTORE_HELM_CHART_PATH, restoreName)
+	defer helm.Delete(t, options, restoreName, true)
+	defer k8s.RunKubectl(t, kubectlOptions, "delete", "job", "restore-demo")
+
+	testlib.AwaitPodPhase(t, namespaceName, "restore-demo-", corev1.PodSucceeded, 120*time.Second)
+	restorePod := testlib.GetPodName(t, namespaceName, "restore-demo")
+	req, _ := k8s.RunKubectlAndGetOutputE(t, kubectlOptions, "exec", podName, "--", "nuocmd", "get", "value", "--key", "$NUODB_RESTORE_REQUEST_PREFIX/demo/restore")
+	t.Log("restore pod=", restorePod, "; restore request=", req)
+
+	testlib.GetFile(t, namespaceName, "restore-demo", "/var/log/nuodb", "nuorestore.log")
+}

--- a/test/minikube/minikube_sm_test.go
+++ b/test/minikube/minikube_sm_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/nuodb/nuodb-helm-charts/test/testlib"
+	"github.com/stretchr/testify/assert"
 
 	corev1 "k8s.io/api/core/v1"
 
@@ -236,8 +237,11 @@ func TestKubernetesRestartSM(t *testing.T) {
 
 func healDatabase(t *testing.T, namespaceName string, podName string, adminName string, databaseOptions *helm.Options) {
 	opts := testlib.GetExtractedOptions(databaseOptions)
+	kubectlOptions := k8s.NewKubectlOptions("", "", namespaceName)
 
 	restoreArchive(t, namespaceName, podName, "archive", ":latest")
+	err := k8s.RunKubectlE(t, kubectlOptions, "exec", adminName, "--", "nuocmd", "shutdown", "database", "--db-name", opts.DbName)
+	assert.NoError(t, err, "'nuocmd shutdown database' failed")
 	testlib.AwaitDatabaseUp(t, namespaceName, adminName, opts.DbName, opts.NrTePods+opts.NrSmPods)
 }
 

--- a/test/testlib/constants.go
+++ b/test/testlib/constants.go
@@ -37,6 +37,11 @@ const INJECT_VALUES_FILE = "../../valuesInject.yaml"
 
 const IMPORT_ARCHIVE_URL = "https://download.nuohub.org/ce_releases/restore.bak.tz"
 
+// const RESTORE_EMPTYARCHIVE_URL = "https://download.nuohub.org/ce_releases/empty.bak.tz"
+// const RESTORE_ARCHIVE2_URL = "https://download.nuohub.org/ce_releases/restore2.bak.tz"
+const RESTORE_EMPTYARCHIVE_URL = "https://download.nuohub.org/ce_releases/empty.bak.tz"
+const RESTORE_ARCHIVE2_URL = "https://download.nuohub.org/ce_releases/restore2.bak.tz"
+
 // suffix "m" for spec.containers[].resources.requests.cpu denotes "millicores",
 // and 1 CPU is equivalent to 1000m
 const MINIMAL_VIABLE_ENGINE_CPU = "500m"
@@ -45,3 +50,15 @@ const MINIMAL_VIABLE_ENGINE_MEMORY = "500Mi"
 const K8S_EVENT_LOG_FILE = "kubernetes_event.log"
 
 const ALWAYS_RUN_DIAGNOSTIC_TEARDOWNS = "ALWAYS_RUN_DIAGNOSTIC_TEARDOWNS"
+
+// Ok-Ko enum
+type OkKo int
+
+const (
+	Pass OkKo = iota
+	Fail
+)
+
+func (i OkKo) String() string {
+	return [...]string{"Pass", "Fail"}[i]
+}

--- a/test/testlib/minikube_utilities.go
+++ b/test/testlib/minikube_utilities.go
@@ -562,7 +562,9 @@ func AwaitDatabaseRestart(t *testing.T, namespace string, podName string, databa
 	restart()
 
 	Await(t, func() bool {
-		return GetDatabaseIncarnation(t, namespace, podName, databaseName).Major > incarnation.Major
+		newIncarnation := GetDatabaseIncarnation(t, namespace, podName, databaseName)
+		t.Log("incarnation ->", newIncarnation)
+		return newIncarnation.Major > incarnation.Major
 	}, 300*time.Second)
 
 	opts := GetExtractedOptions(databaseOptions)
@@ -860,15 +862,11 @@ func RunSQL(t *testing.T, namespace string, podName string, databaseName string,
 
 	// secrets := getSecret(t, namespace, databaseName)
 
-	result, err = k8s.RunKubectlAndGetOutputE(t, options,
+	return k8s.RunKubectlAndGetOutputE(t, options,
 		"exec", podName, "--",
 		"bash", "-c",
 		fmt.Sprintf("echo \"%s;\" | /opt/nuodb/bin/nuosql --user dba --password secret %s", sql, databaseName),
 	)
-
-	require.NoError(t, err, "runSQL: error trying to run ", sql)
-
-	return result, err
 }
 
 func GetNuoDBK8sConfigDump(t *testing.T, namespace string, podName string) NuoDBKubeConfig {


### PR DESCRIPTION
Primary work is to improve the `nuorestore` script to cause the sM startup to exit in the event of clearly fatal errors in the restore.

A secondary change is to add logging output to the `restore` chart to better guide the user's expectations.

Finally, some associated changes removing any dependence in the `restore` chart on any values in the `database` chart.
