### PR TITLE
skip doc builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,18 @@ env:
     - NUODB_GET_DIAGNOSE=true
 
 before_install:
+  - |
+    set -e
+    # fail loudly when force-pushed
+    MODIFIED_FILES=$(git diff --name-only $TRAVIS_COMMIT_RANGE)
+    # waiting for native solution https://github.com/travis-ci/travis-ci/issues/6301
+    if [ -z "${MODIFIED_FILES}" ]; then
+      # $TRAVIS_COMMIT_RANGE will be empty for builds triggered by the initial commit of a new branch.
+      echo "No changes found, can not determine what to skip"
+    elif ! echo ${MODIFIED_FILES} | grep -qvE '(\.md$)'; then
+      echo "Only docs were updated, stopping build process."
+      exit
+    fi
   - sudo apt-get update
   - sudo apt-get install socat
   - chmod +x scripts/ci/install_deps.sh


### PR DESCRIPTION
Skip travis builds on a doc only change
- the first build of a branch is always build
- subsequent builds are only build if the change contains a non-doc change