### PR TITLE
Add "leases" resource for NuoDB role

### DIFF
--- a/stable/admin/templates/role.yaml
+++ b/stable/admin/templates/role.yaml
@@ -6,10 +6,17 @@ metadata:
 rules:
 - apiGroups:
   - ""
-  - apps
   resources:
   - persistentvolumeclaims
   - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
   - statefulsets
   verbs:
   - get

--- a/stable/admin/templates/role.yaml
+++ b/stable/admin/templates/role.yaml
@@ -9,11 +9,18 @@ rules:
   - apps
   resources:
   - persistentvolumeclaims
-  - persistentvolumes
   - pods
   - statefulsets
   verbs:
   - get
   - list
   - watch
+- apiGroups:
+  - "coordination.k8s.io"
+  resources:
+  - leases
+  verbs:
+  - get
+  - create
+  - update
 {{- end }}

--- a/test/minikube/minikube_base_database_test.go
+++ b/test/minikube/minikube_base_database_test.go
@@ -70,6 +70,11 @@ func verifyKubernetesAccess(t *testing.T, namespaceName string, podName string) 
 	output, err = k8s.RunKubectlAndGetOutputE(t, options, "exec", podName, "--", "bash", "-c", curlCmdPrefix+url)
 	assert.Check(t, strings.Contains(output, "\"kind\": \"PersistentVolumeClaimList\""), output)
 
+	// check that we can access Deployments
+	url = "/apis/apps/v1/namespaces/" + namespaceName + "/deployments"
+	output, err = k8s.RunKubectlAndGetOutputE(t, options, "exec", podName, "--", "bash", "-c", curlCmdPrefix+url)
+	assert.Check(t, strings.Contains(output, "\"kind\": \"DeploymentList\""), output)
+
 	// check that we can access StatefulSets
 	url = "/apis/apps/v1/namespaces/" + namespaceName + "/statefulsets"
 	output, err = k8s.RunKubectlAndGetOutputE(t, options, "exec", podName, "--", "bash", "-c", curlCmdPrefix+url)


### PR DESCRIPTION
The "leases" resource will be used to coordinate updates to the Admin
layer generated by Kubernetes events. Also remove the
"persistentvolumes" resource, which is not available within a namespace
and is therefore unusable.