### PR TITLE
Stop printing diagnose to stdout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,6 @@ env:
     - CHANGE_MINIKUBE_NONE_USER=true
     - KUBECONFIG=$HOME/.kube/config
     - NUODB_PRINT_TO_STDOUT=true
-    - NUODB_GET_DIAGNOSE=true
 
 before_install:
   - |


### PR DESCRIPTION
Printing diagnose to stdout overflows the log limit of a Travis build. As a result, the build gets killed.

We would rather run other tests and get a failure report than kill the tests halfway.

Motivation here: https://travis-ci.org/github/nuodb/nuodb-helm-charts/jobs/673510561