### PR TITLE
Re-enable 3-admin tests

### DIFF
--- a/scripts/ci/determine_and_run_tests.sh
+++ b/scripts/ci/determine_and_run_tests.sh
@@ -6,7 +6,7 @@ if [[ $TEST_SUITE = "basic"  ]]; then
   ./test/test_suite.sh
   go test -timeout 10m -v ./test/integration
 elif [[ $TEST_SUITE = "minikube-short"  ]]; then
-  go test -timeout 35m -v ./test/minikube -tags=short
+  go test -timeout 50m -v ./test/minikube -tags=short
 elif [[ $TEST_SUITE = "minikube-long"  ]]; then
-  go test -timeout 35m -v ./test/minikube -tags=long
+  go test -timeout 50m -v ./test/minikube -tags=long
 fi

--- a/test/minikube/minikube_long_admin_test.go
+++ b/test/minikube/minikube_long_admin_test.go
@@ -1,4 +1,4 @@
-// +build short
+// +build long
 
 package minikube
 

--- a/test/minikube/minikube_long_admin_test.go
+++ b/test/minikube/minikube_long_admin_test.go
@@ -12,8 +12,6 @@ import (
 )
 
 func TestKubernetesBasicAdminThreeReplicas(t *testing.T) {
-	t.Skip("Flaky! DB-29422")
-
 	testlib.AwaitTillerUp(t)
 	defer testlib.VerifyTeardown(t)
 

--- a/test/minikube/minikube_long_admin_test.go
+++ b/test/minikube/minikube_long_admin_test.go
@@ -24,6 +24,8 @@ func TestKubernetesBasicAdminThreeReplicas(t *testing.T) {
 	helmChartReleaseName, namespaceName := testlib.StartAdmin(t, &options, 3, "")
 
 	admin0 := fmt.Sprintf("%s-nuodb-cluster0-0", helmChartReleaseName)
+	admin1 := fmt.Sprintf("%s-nuodb-cluster0-1", helmChartReleaseName)
+	admin2 := fmt.Sprintf("%s-nuodb-cluster0-2", helmChartReleaseName)
 	headlessServiceName := fmt.Sprintf("nuodb")
 	clusterServiceName := fmt.Sprintf("nuodb-clusterip")
 
@@ -38,6 +40,15 @@ func TestKubernetesBasicAdminThreeReplicas(t *testing.T) {
 	t.Run("verifyAdminHeadlessService", func(t *testing.T) { verifyAdminService(t, namespaceName, admin0, headlessServiceName, true) })
 	t.Run("verifyAdminClusterService", func(t *testing.T) { verifyAdminService(t, namespaceName, admin0, clusterServiceName, false) })
 	t.Run("verifyLBPolicy", func(t *testing.T) { verifyLBPolicy(t, namespaceName, admin0) })
-	t.Run("verifyPodKill", func(t *testing.T) { verifyPodKill(t, namespaceName, admin0, helmChartReleaseName, 3) })
-	t.Run("verifyProcessKill", func(t *testing.T) { verifyKillProcess(t, namespaceName, admin0, helmChartReleaseName, 3) })
+
+	t.Run("verifyPodKill", func(t *testing.T) {
+		verifyPodKill(t, namespaceName, admin0, helmChartReleaseName, 3)
+		verifyPodKill(t, namespaceName, admin1, helmChartReleaseName, 3)
+		verifyPodKill(t, namespaceName, admin2, helmChartReleaseName, 3)
+	})
+	t.Run("verifyProcessKill", func(t *testing.T) {
+		verifyKillProcess(t, namespaceName, admin0, helmChartReleaseName, 3)
+		verifyKillProcess(t, namespaceName, admin1, helmChartReleaseName, 3)
+		verifyKillProcess(t, namespaceName, admin2, helmChartReleaseName, 3)
+	})
 }

--- a/test/minikube/minikube_tls_rotation_test.go
+++ b/test/minikube/minikube_tls_rotation_test.go
@@ -50,8 +50,6 @@ func startDomainWithTLSCertificates(t *testing.T, options *helm.Options, namespa
 }
 
 func TestKubernetesTLSRotation(t *testing.T) {
-	t.Skip("Flaky! DB-29423")
-
 	if testlib.IsOpenShiftEnvironment(t) {
 		t.Skip("TLS subPath bind does not work as expected")
 	}


### PR DESCRIPTION
With many bugs fixed, we should be now able to re-enable all 3-admin tests.

Also increase the timeout for short/long. We have now reached 35-40 min per test family.