### PR TITLE
Add regression testing for multi-admin deployments

### DIFF
--- a/scripts/ci/determine_and_run_tests.sh
+++ b/scripts/ci/determine_and_run_tests.sh
@@ -6,7 +6,7 @@ if [[ $TEST_SUITE = "basic"  ]]; then
   ./test/test_suite.sh
   go test -timeout 10m -v ./test/integration
 elif [[ $TEST_SUITE = "minikube-short"  ]]; then
-  go test -timeout 35m -v ./test/minikube -tags=short
+  go test -timeout 50m -v ./test/minikube -tags=short
 elif [[ $TEST_SUITE = "minikube-long"  ]]; then
-  go test -timeout 35m -v ./test/minikube -tags=long
+  go test -timeout 50m -v ./test/minikube -tags=long
 fi

--- a/test/minikube/minikube_base_admin_test.go
+++ b/test/minikube/minikube_base_admin_test.go
@@ -41,8 +41,11 @@ func TestKubernetesBasicAdminSingleReplica(t *testing.T) {
 	t.Run("verifyAdminHeadlessService", func(t *testing.T) { verifyAdminService(t, namespaceName, admin0, headlessServiceName, true) })
 	t.Run("verifyAdminClusterService", func(t *testing.T) { verifyAdminService(t, namespaceName, admin0, clusterServiceName, false) })
 	t.Run("verifyLBPolicy", func(t *testing.T) { verifyLBPolicy(t, namespaceName, admin0) })
-	t.Run("verifyPodKill", func(t *testing.T) { verifyPodKill(t, namespaceName, admin0, helmChartReleaseName, 1) })
 	t.Run("verifyProcessKill", func(t *testing.T) { verifyKillProcess(t, namespaceName, admin0, helmChartReleaseName, 1) })
+	t.Run("verifyPodKill", func(t *testing.T) {
+		t.Skip("verifyPodKill is flaky")
+		verifyPodKill(t, namespaceName, admin0, helmChartReleaseName, 1)
+	})
 }
 
 func TestKubernetesInvalidLicense(t *testing.T) {

--- a/test/minikube/minikube_long_admin_test.go
+++ b/test/minikube/minikube_long_admin_test.go
@@ -1,4 +1,4 @@
-// +build short
+// +build long
 
 package minikube
 
@@ -12,8 +12,6 @@ import (
 )
 
 func TestKubernetesBasicAdminThreeReplicas(t *testing.T) {
-	t.Skip("Flaky! DB-29422")
-
 	testlib.AwaitTillerUp(t)
 	defer testlib.VerifyTeardown(t)
 
@@ -26,6 +24,8 @@ func TestKubernetesBasicAdminThreeReplicas(t *testing.T) {
 	helmChartReleaseName, namespaceName := testlib.StartAdmin(t, &options, 3, "")
 
 	admin0 := fmt.Sprintf("%s-nuodb-cluster0-0", helmChartReleaseName)
+	admin1 := fmt.Sprintf("%s-nuodb-cluster0-1", helmChartReleaseName)
+	admin2 := fmt.Sprintf("%s-nuodb-cluster0-2", helmChartReleaseName)
 	headlessServiceName := fmt.Sprintf("nuodb")
 	clusterServiceName := fmt.Sprintf("nuodb-clusterip")
 
@@ -40,6 +40,17 @@ func TestKubernetesBasicAdminThreeReplicas(t *testing.T) {
 	t.Run("verifyAdminHeadlessService", func(t *testing.T) { verifyAdminService(t, namespaceName, admin0, headlessServiceName, true) })
 	t.Run("verifyAdminClusterService", func(t *testing.T) { verifyAdminService(t, namespaceName, admin0, clusterServiceName, false) })
 	t.Run("verifyLBPolicy", func(t *testing.T) { verifyLBPolicy(t, namespaceName, admin0) })
-	t.Run("verifyPodKill", func(t *testing.T) { verifyPodKill(t, namespaceName, admin0, helmChartReleaseName, 3) })
-	t.Run("verifyProcessKill", func(t *testing.T) { verifyKillProcess(t, namespaceName, admin0, helmChartReleaseName, 3) })
+
+	t.Run("verifyProcessKill", func(t *testing.T) {
+		verifyKillProcess(t, namespaceName, admin0, helmChartReleaseName, 3)
+		verifyKillProcess(t, namespaceName, admin1, helmChartReleaseName, 3)
+		verifyKillProcess(t, namespaceName, admin2, helmChartReleaseName, 3)
+	})
+
+	t.Run("verifyPodKill", func(t *testing.T) {
+		t.Skip("verifyPodKill is flaky")
+		verifyPodKill(t, namespaceName, admin0, helmChartReleaseName, 3)
+		verifyPodKill(t, namespaceName, admin1, helmChartReleaseName, 3)
+		verifyPodKill(t, namespaceName, admin2, helmChartReleaseName, 3)
+	})
 }

--- a/test/minikube/minikube_tls_rotation_test.go
+++ b/test/minikube/minikube_tls_rotation_test.go
@@ -50,8 +50,6 @@ func startDomainWithTLSCertificates(t *testing.T, options *helm.Options, namespa
 }
 
 func TestKubernetesTLSRotation(t *testing.T) {
-	t.Skip("Flaky! DB-29423")
-
 	if testlib.IsOpenShiftEnvironment(t) {
 		t.Skip("TLS subPath bind does not work as expected")
 	}

--- a/test/testlib/minikube_utilities.go
+++ b/test/testlib/minikube_utilities.go
@@ -188,6 +188,10 @@ func AwaitTillerUp(t *testing.T) {
 }
 
 func AwaitNrReplicasScheduled(t *testing.T, namespace string, expectedName string, nrReplicas int) {
+	timeout := 30 * time.Second
+	if nrReplicas > 1 {
+		timeout *= time.Duration(nrReplicas)
+	}
 	Await(t, func() bool {
 		var cnt int
 		for _, pod := range findAllPodsInSchema(t, namespace) {
@@ -201,7 +205,7 @@ func AwaitNrReplicasScheduled(t *testing.T, namespace string, expectedName strin
 		t.Logf("%d pods SCHEDULED for name '%s'\n", cnt, expectedName)
 
 		return cnt == nrReplicas
-	}, 30*time.Second)
+	}, timeout)
 }
 
 func AwaitNrReplicasReady(t *testing.T, namespace string, expectedName string, nrReplicas int) {
@@ -432,7 +436,6 @@ func AwaitDatabaseRestart(t *testing.T, namespace string, podName string, databa
 	opts := GetExtractedOptions(databaseOptions)
 	AwaitDatabaseUp(t, namespace, podName, databaseName, opts.NrTePods+opts.NrSmPods)
 }
-
 
 func AwaitPodRestartCountGreaterThan(t *testing.T, namespace string, podName string, expectedRestartCount int32) {
 	options := k8s.NewKubectlOptions("", "")
@@ -797,7 +800,7 @@ func LabelNodes(t *testing.T, namespaceName string, labelName string, labelValue
 		labelString = fmt.Sprintf("%s-", labelName)
 	}
 
-	nodes := k8s.GetNodes(t , options)
+	nodes := k8s.GetNodes(t, options)
 
 	assert.Assert(t, len(nodes) > 0)
 

--- a/test/testlib/nuodb_admin_utilities.go
+++ b/test/testlib/nuodb_admin_utilities.go
@@ -13,7 +13,6 @@ import (
 	"github.com/gruntwork-io/terratest/modules/random"
 )
 
-
 func getFunctionCallerName() string {
 	pc, _, _, _ := runtime.Caller(2)
 	nameFull := runtime.FuncForPC(pc).Name() // main.foo
@@ -64,7 +63,7 @@ func StartAdmin(t *testing.T, options *helm.Options, replicaCount int, namespace
 	AddTeardown(TEARDOWN_ADMIN, func() {
 		helm.Delete(t, options, helmChartReleaseName, true)
 	})
-	
+
 	adminNames := make([]string, replicaCount)
 	var adminStatefulSet string
 
@@ -72,11 +71,11 @@ func StartAdmin(t *testing.T, options *helm.Options, replicaCount int, namespace
 		if options.SetValues["admin.fullnameOverride"] != "" {
 			adminStatefulSet = fmt.Sprintf("%s", options.SetValues["admin.fullnameOverride"])
 			adminNames[i] = fmt.Sprintf("%s-%d", adminStatefulSet, i)
-		} else if  options.SetValues["admin.nameOverride"] != "" {
+		} else if options.SetValues["admin.nameOverride"] != "" {
 			adminStatefulSet = fmt.Sprintf("%s-nuodb-cluster0-%s", helmChartReleaseName, options.SetValues["admin.nameOverride"])
-			adminNames[i]  = fmt.Sprintf("%s-%d", adminStatefulSet, i)
+			adminNames[i] = fmt.Sprintf("%s-%d", adminStatefulSet, i)
 		} else {
-			adminStatefulSet =  fmt.Sprintf("%s-nuodb-cluster0", helmChartReleaseName)
+			adminStatefulSet = fmt.Sprintf("%s-nuodb-cluster0", helmChartReleaseName)
 			adminNames[i] = fmt.Sprintf("%s-%d", adminStatefulSet, i)
 		}
 	}


### PR DESCRIPTION
This basically the PR @vegichan posted a week or two ago, but with the `verifyPodKill` variants disabled, since they are currently flaky.