### PR TITLE
Fix Helm Operator Scorecard requirement of no empty blocks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ env:
     #- TEST_SUITE=minikube-short REQUIRES_MINISHIFT=true
     #- TEST_SUITE=minikube-long REQUIRES_MINISHIFT=true
   global:
-    - HELM_VERSION="v2.9.0"
+    - HELM_VERSION="v2.16.3"
     - DEP_VERSION=0.5.4
     - KUBERNETES_VERSION=1.15.0
     - OPENSHIFT_VERSION=3.11.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ os: linux
 sudo: required
 
 go:
-  - 1.14.x
+  - 1.12.x
 
 env:
   jobs:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ os: linux
 sudo: required
 
 go:
-  - 1.12.x
+  - 1.14.x
 
 env:
   jobs:

--- a/stable/admin/templates/configmap.yaml
+++ b/stable/admin/templates/configmap.yaml
@@ -11,8 +11,8 @@ metadata:
   name: waitscript
 data:
 {{ (.Files.Glob "files/waitscript").AsConfig | indent 2 }}
----
 {{- if .Values.admin.configFiles }}
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/stable/database/templates/configmap.yaml
+++ b/stable/database/templates/configmap.yaml
@@ -73,8 +73,8 @@ data:
   NUODB_AUTO_RESTORE_TYPE: {{ default "stream" .Values.database.autoRestore.type | quote }}
   NUODB_OS_USER: {{ include "os.user" . | quote }}
   NUODB_OS_GROUP: {{ include "os.group" . | quote }}
----
 {{- if .Values.database.configFiles }}
+---
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/test/integration/template_admin_test.go
+++ b/test/integration/template_admin_test.go
@@ -300,14 +300,15 @@ func TestAdminMultiClusterEnvVars(t *testing.T) {
 		var ss appsv1.StatefulSet
 		helm.UnmarshalK8SYaml(t, part, &ss)
 
-		var environmentals map[string]string
+		environmentals := make(map[string]string)
 
 		for _, val := range ss.Spec.Template.Spec.Containers[0].Env {
 			environmentals[val.Name] = val.Value
 		}
 
-		assert.Check(t, strings.Contains(environmentals["NUODB_DOMAIN_ENTRYPOINT"], "RELEASE-NAME-nuodb-cluster-1-admin-0.nuodb.$(NAMESPACE).svc.cluster1.local"))
-		assert.Check(t, strings.Contains(environmentals["NUODB_ALT_ADDRESS"], "$(POD_NAME).nuodb.$(NAMESPACE).svc.cluster2.local"))
+		assert.Check(t, strings.EqualFold(environmentals["NUODB_DOMAIN_ENTRYPOINT"], "RELEASE-NAME-nuodb-cluster-1-admin-0.nuodb.$(NAMESPACE).svc.cluster1.local"))
+		assert.Check(t, strings.EqualFold(environmentals["NUODB_ALT_ADDRESS"], "$(POD_NAME).nuodb.$(NAMESPACE).svc.cluster2.local"))
+
 	}
 }
 

--- a/test/integration/template_admin_test.go
+++ b/test/integration/template_admin_test.go
@@ -300,11 +300,14 @@ func TestAdminMultiClusterEnvVars(t *testing.T) {
 		var ss appsv1.StatefulSet
 		helm.UnmarshalK8SYaml(t, part, &ss)
 
-		// This is the NUODB_DOMAIN_ENTRYPOINT variable
-		assert.Check(t, strings.Contains(ss.Spec.Template.Spec.Containers[0].Env[4].Value, "RELEASE-NAME-nuodb-cluster-1-admin-0.nuodb.$(NAMESPACE).svc.cluster1.local"))
+		var environmentals map[string]string
 
-		// This is the NUODB_ALT_ADDRESS variable
-		assert.Check(t, strings.Contains(ss.Spec.Template.Spec.Containers[0].Env[5].Value, "$(POD_NAME).nuodb.$(NAMESPACE).svc.cluster2.local"))
+		for _, val := range ss.Spec.Template.Spec.Containers[0].Env {
+			environmentals[val.Name] = val.Value
+		}
+
+		assert.Check(t, strings.Contains(environmentals["NUODB_DOMAIN_ENTRYPOINT"], "RELEASE-NAME-nuodb-cluster-1-admin-0.nuodb.$(NAMESPACE).svc.cluster1.local"))
+		assert.Check(t, strings.Contains(environmentals["NUODB_ALT_ADDRESS"], "$(POD_NAME).nuodb.$(NAMESPACE).svc.cluster2.local"))
 	}
 }
 

--- a/test/integration/template_admin_test.go
+++ b/test/integration/template_admin_test.go
@@ -307,3 +307,19 @@ func TestAdminMultiClusterEnvVars(t *testing.T) {
 		assert.Check(t, strings.Contains(ss.Spec.Template.Spec.Containers[0].Env[5].Value, "$(POD_NAME).nuodb.$(NAMESPACE).svc.cluster2.local"))
 	}
 }
+
+func TestConfigDoesNotContainEmptyBlocks(t *testing.T) {
+	// Path to the helm chart we will test
+	helmChartPath := "../../stable/admin"
+
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"admin.configFiles": "null",
+		},
+	}
+
+	// Run RenderTemplate to render the template and capture the output.
+	output := helm.RenderTemplate(t, options, helmChartPath, []string{"templates/configmap.yaml"})
+
+	assert.Assert(t, !strings.Contains(output, "---\n---"))
+}

--- a/test/integration/template_database_test.go
+++ b/test/integration/template_database_test.go
@@ -770,3 +770,19 @@ func volumesContain(mounts []v1.Volume, expectedName string) bool {
 	}
 	return false
 }
+
+func TestDatabaseConfigDoesNotContainEmptyBlocks(t *testing.T) {
+	// Path to the helm chart we will test
+	helmChartPath := "../../stable/database"
+
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"database.configFiles": "null",
+		},
+	}
+
+	// Run RenderTemplate to render the template and capture the output.
+	output := helm.RenderTemplate(t, options, helmChartPath, []string{"templates/configmap.yaml"})
+
+	assert.Assert(t, !strings.Contains(output, "---\n---"))
+}


### PR DESCRIPTION
The scorecard test required to publish a helm operator to RHCC does not allow for blocks of this type
```
---
---
```

There were occurrences in the ConfigMaps in some cases. Fix them and add a test.