### PR TITLE
Remove memoryOption and replace it with resources.requests.memory

### DIFF
--- a/samples/large.yaml
+++ b/samples/large.yaml
@@ -17,7 +17,6 @@ database:
       - ReadWriteOnce
     storageClass: fast-storage
   sm:
-    memoryOption: 32g
     resources:
       limits:
         cpu: 16
@@ -26,7 +25,6 @@ database:
         cpu: 8
         memory: 32Gi
   te:
-    memoryOption: 32g
     resources:
       limits:
         cpu: 8

--- a/samples/standard.yaml
+++ b/samples/standard.yaml
@@ -17,7 +17,6 @@ database:
       - ReadWriteOnce
     storageClass: fast-storage
   sm:
-    memoryOption: 8g
     resources:
       limits:
         cpu: 8
@@ -26,7 +25,6 @@ database:
         cpu: 4
         memory: 8Gi
   te:
-    memoryOption: 8g
     resources:
       limits:
         cpu: 4

--- a/samples/tiny.yaml
+++ b/samples/tiny.yaml
@@ -22,7 +22,6 @@ database:
       - ReadWriteOnce
     storageClass: fast-storage
   sm:
-    memoryOption: 4g
     resources:
       limits:
         cpu: 1
@@ -31,7 +30,6 @@ database:
         cpu: 1
         memory: 4Gi
   te:
-    memoryOption: 2g
     resources:
       limits:
         cpu: 1

--- a/stable/database/README.md
+++ b/stable/database/README.md
@@ -250,7 +250,6 @@ The following tables list the configurable parameters of the `database` chart an
 | `sm.hotcopy.coldStorage.credentials` | Credentials for accessing backup cold storage (user:password) | `""` |
 | `sm.noHotCopy.replicas` | SM replicas with hot-copy disabled | `0` |
 | `sm.noHotCopy.enablePod` | Create DS/SS for non-hot-copy SMs | `true` |
-| `sm.memoryOption` | SM engine memory (*future deprecation*) | `"8g"` |
 | `sm.labels` | Labels given to the SMs started | `{}` |
 | `sm.engineOptions` | Additional NuoDB engine options | `{}` |
 | `sm.resources` | Labels to apply to all resources | `{}` |
@@ -261,7 +260,6 @@ The following tables list the configurable parameters of the `database` chart an
 | `te.externalAccess.internalIP` | Whether to use an internal (to the cloud) or external (public) IP address for the load balancer | `nil` |
 | `te.dbServices.enabled` | Whether to deploy clusterip and headless services for direct TE connections (defaults true) | `nil` |
 | `te.replicas` | TE replicas | `1` |
-| `te.memoryOption` | TE engine memory (*future deprecation*) | `"8g"` |
 | `te.labels` | Labels given to the TEs started | `""` |
 | `te.engineOptions` | Additional NuoDB engine options | `""` |
 | `te.resources` | Labels to apply to all resources | `{}` |

--- a/stable/database/templates/daemonset.yaml
+++ b/stable/database/templates/daemonset.yaml
@@ -56,7 +56,7 @@ spec:
           - "--restored"
     {{end}}
           - "--options"
-          - "mem {{ .Values.database.sm.memoryOption}} {{- include "opt.key-values" .Values.database.sm.engineOptions}}"
+          - "mem {{ .Values.database.sm.resources.requests.memory}} {{- include "opt.key-values" .Values.database.sm.engineOptions}}"
     {{- with .Values.database.sm.labels }}
           - "--labels"
           - "{{- include "opt.key-values" . }}"
@@ -259,7 +259,7 @@ spec:
           - "--servers-ready-timeout"
           - "300"
           - "--options"
-          - "mem {{ .Values.database.sm.memoryOption}} {{- if .Values.database.sm.hotCopy.journalBackup.enabled }} journal-hot-copy enable {{- end }} {{- include "opt.key-values" .Values.database.sm.engineOptions}}"
+          - "mem {{ .Values.database.sm.resources.requests.memory}} {{- if .Values.database.sm.hotCopy.journalBackup.enabled }} journal-hot-copy enable {{- end }} {{- include "opt.key-values" .Values.database.sm.engineOptions}}"
           - "--labels"
           - "backup {{ include "hotcopy.group" . }} {{- include "opt.key-values" .Values.database.sm.labels }}"
     {{- with .Values.database.options }}

--- a/stable/database/templates/deployment.yaml
+++ b/stable/database/templates/deployment.yaml
@@ -53,7 +53,7 @@ spec:
           - "--servers-ready-timeout"
           - "300"
           - "--options"
-          - "mem {{ .Values.database.te.memoryOption}} {{- range $opt, $val := .Values.database.te.engineOptions }} {{$opt}} {{$val}} {{- end}}"
+          - "mem {{ .Values.database.te.resources.requests.memory}} {{- range $opt, $val := .Values.database.te.engineOptions }} {{$opt}} {{$val}} {{- end}}"
         {{- with .Values.database.te.labels }}
           - "--labels"
           - "{{- range $opt, $val := . }} {{$opt}} {{$val}} {{- end}}"

--- a/stable/database/templates/statefulset.yaml
+++ b/stable/database/templates/statefulset.yaml
@@ -75,7 +75,7 @@ spec:
           - "--restored"
     {{- end }}
           - "--options"
-          - "mem {{ .Values.database.sm.memoryOption}} {{ include "opt.key-values" .Values.database.sm.engineOptions }}"
+          - "mem {{ .Values.database.sm.resources.requests.memory}} {{ include "opt.key-values" .Values.database.sm.engineOptions }}"
     {{- with .Values.database.sm.labels }}      
           - "--labels"
           - "{{- include "opt.key-values" . }}"
@@ -369,7 +369,7 @@ spec:
           - "--servers-ready-timeout"
           - "300"
           - "--options"
-          - "mem {{ .Values.database.sm.memoryOption}} {{- if .Values.database.sm.hotCopy.journalBackup.enabled }} journal-hot-copy enable {{- end }} {{- include "opt.key-values" .Values.database.sm.engineOptions}}"
+          - "mem {{ .Values.database.sm.resources.requests.memory}} {{- if .Values.database.sm.hotCopy.journalBackup.enabled }} journal-hot-copy enable {{- end }} {{- include "opt.key-values" .Values.database.sm.engineOptions}}"
           - "--labels"
           - "backup {{ include "hotcopy.group" . }} {{- include "opt.key-values" .Values.database.sm.labels }}"
 {{- with .Values.database.options}}

--- a/stable/database/values.yaml
+++ b/stable/database/values.yaml
@@ -246,11 +246,9 @@ database:
       enablePod: true
       replicas: 0
 
-    # NuoDB mem option - target maximum memory to be used by the cache
-    memoryOption: 8g
-
     ## resources
-    # k8s resouce min (request) and max (limit)
+    # k8s resource min (request) and max (limit)
+    # min is also used for the target maximum memory used by the cache (NuoDB --mem option)
     resources:
       limits:
         cpu: 8
@@ -298,9 +296,9 @@ database:
     # Number of transaction engines (TE) nodes.  Limit is 3 in CE version of NuoDB 
     replicas: 1
 
-    # NuoDB mem option - target maximum memory to be used by the cache
-    memoryOption: 8g
-
+    ## resources
+    # k8s resource min (request) and max (limit)
+    # min is also used for the target maximum memory used by the cache (NuoDB --mem option)
     resources:
       limits:
         cpu: 4

--- a/test/integration/template_resources_test.go
+++ b/test/integration/template_resources_test.go
@@ -144,12 +144,14 @@ func TestResourcesDatabaseDefaults(t *testing.T) {
 		// the memory is confusing Gi with G. We are using power of two (1024). But scaled value is using 1000
 
 		assert.Check(t, (*containers)[0].Resources.Limits.Cpu().ScaledValue(0) == 8)
-		assert.Check(t, (*containers)[0].Resources.Limits.Memory().ScaledValue(resource.Giga) == 18,
-			(*containers)[0].Resources.Limits.Memory().ScaledValue(resource.Giga))
+		assert.Check(t, (*containers)[0].Resources.Limits.Memory().ScaledValue(0) == 16 * 1024 * 1024 * 1024,
+			(*containers)[0].Resources.Limits.Memory().ScaledValue(0))
 
 		assert.Check(t, (*containers)[0].Resources.Requests.Cpu().ScaledValue(0) == 4)
-		assert.Check(t, (*containers)[0].Resources.Requests.Memory().ScaledValue(resource.Giga) == 9,
-			(*containers)[0].Resources.Requests.Memory().ScaledValue(resource.Giga))
+		assert.Check(t, (*containers)[0].Resources.Requests.Memory().ScaledValue(0) == 8 * 1024 * 1024 * 1024,
+			(*containers)[0].Resources.Requests.Memory().ScaledValue(0))
+
+		assert.Check(t, ArgContains((*containers)[0].Args, "mem 8Gi"))
 
 		// make sure the replica counts are correct
 		if testlib.IsStatefulSetHotCopyEnabled(&ss) {
@@ -177,7 +179,7 @@ func TestResourcesDatabaseOverridden(t *testing.T) {
 	options := &helm.Options{
 		SetValues: map[string]string{
 			"database.sm.resources.requests.cpu":    "1",
-			"database.sm.resources.requests.memory": "4G",
+			"database.sm.resources.requests.memory": "4Gi",
 			"database.sm.noHotCopy.replicas":        strconv.Itoa(noHotCopyReplicas),
 			"database.sm.hotCopy.replicas":          strconv.Itoa(hotcopyReplicas),
 		},
@@ -213,12 +215,14 @@ func TestResourcesDatabaseOverridden(t *testing.T) {
 		// the memory is confusing Gi with G. We are using power of two (1024). But scaled value is using 1000
 
 		assert.Check(t, (*containers)[0].Resources.Limits.Cpu().ScaledValue(0) == 8)
-		assert.Check(t, (*containers)[0].Resources.Limits.Memory().ScaledValue(resource.Giga) == 18,
-			(*containers)[0].Resources.Limits.Memory().ScaledValue(resource.Giga))
+		assert.Check(t, (*containers)[0].Resources.Limits.Memory().ScaledValue(0) == 16 * 1024 * 1024 * 1024,
+			(*containers)[0].Resources.Limits.Memory().ScaledValue(0))
 
 		assert.Check(t, (*containers)[0].Resources.Requests.Cpu().ScaledValue(0) == 1)
-		assert.Check(t, (*containers)[0].Resources.Requests.Memory().ScaledValue(resource.Giga) == 4,
-			(*containers)[0].Resources.Requests.Memory().ScaledValue(resource.Giga))
+		assert.Check(t, (*containers)[0].Resources.Requests.Memory().ScaledValue(0) == 4 * 1024 * 1024 * 1024,
+			(*containers)[0].Resources.Requests.Memory().ScaledValue(0))
+
+		assert.Check(t, ArgContains((*containers)[0].Args, "mem 4Gi"))
 
 		// make sure the replica counts are correct
 		if testlib.IsStatefulSetHotCopyEnabled(&ss) {


### PR DESCRIPTION
Before NuoDB 4.0.1, it was not possible to use binary prefix number formats (Gi, Mi, Ki) and as such, the memory options had to be split into requests.memory and memoryOption.

Now it is possible to use only one variable to define the memory requirements of an engine (SM, TE). It accepts both scientific/metric units (G, M, K) and binary prefix numbers.

Both formats accept floating type numbers and are not restricted to integers.