### PR TITLE
Remove version from release label + typo fixes

### DIFF
--- a/stable/admin/templates/_helpers.tpl
+++ b/stable/admin/templates/_helpers.tpl
@@ -27,10 +27,10 @@ If release name contains chart name it will be used as a full name.
 {{- end -}}
 
 {{/*
-Create chart name and version as used by the chart label.
+Create chart name as used by the chart label.
 */}}
 {{- define "admin.chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s" .Chart.Name | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*

--- a/stable/admin/values.yaml
+++ b/stable/admin/values.yaml
@@ -127,15 +127,15 @@ admin:
   # These are applied using the nuoadmin startup command
   # Add these values as appropriate for this domain
   options:
-      # this high reconnect timeout is necessary because an admin can be
-      # rescheduled on a different Node and a reconnecting engine will not
-      # connect to it until the stale DNS entry in its local cache expires,
-      # which has a default TTL of 30 seconds
-      pendingReconnectTimeout: 60000
-      # this is necessary because killed engine Pods may not generate a TCP_RST
-      # packet to close the admin connection, leaving a database process entry
-      # in the domain state that has no running Pod associated with it
-      processLivenessCheckSec: 30
+    # this high reconnect timeout is necessary because an admin can be
+    # rescheduled on a different Node and a reconnecting engine will not
+    # connect to it until the stale DNS entry in its local cache expires,
+    # which has a default TTL of 30 seconds
+    pendingReconnectTimeout: 60000
+    # this is necessary because killed engine Pods may not generate a TCP_RST
+    # packet to close the admin connection, leaving a database process entry
+    # in the domain state that has no running Pod associated with it
+    processLivenessCheckSec: 30
 
   ## nuodb-admin resource requests and limits
   ## Ref: http://kubernetes.io/docs/user-guide/compute-resources/

--- a/stable/database/templates/_helpers.tpl
+++ b/stable/database/templates/_helpers.tpl
@@ -26,10 +26,10 @@ and we have to allow for added suffixes including "-hotcopy" and "-NN" where NN 
 {{- end -}}
 
 {{/*
-Create chart name and version as used by the chart label.
+Create chart name as used by the chart label.
 */}}
 {{- define "database.chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s" .Chart.Name | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*

--- a/stable/database/values.yaml
+++ b/stable/database/values.yaml
@@ -201,7 +201,7 @@ database:
       replicas: 1
 
       # Deadline for starting a hotcopy job - if a job hasn't started in this time - give up
-      deadine: 1800
+      deadline: 1800
 
       # timeout for completing a hotcopy job - if a job hasn't completed in this time - stop waiting for it
       timeout: 1800
@@ -260,7 +260,7 @@ database:
         memory: 8Gi
 
     ## Affinity, selector, and tolerations
-    # There are expanded as YAML, and can include variable and template references
+    # They are expanded as YAML, and can include variable and template references
     affinity: {}
     # nodeSelector: {}
     # tolerations: []

--- a/stable/restore/templates/_helpers.tpl
+++ b/stable/restore/templates/_helpers.tpl
@@ -37,7 +37,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 Create chart name and version as used by the chart label.
 */}}
 {{- define "nuodb.chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s" .Chart.Name | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*

--- a/stable/transparent-hugepage/templates/_helpers.tpl
+++ b/stable/transparent-hugepage/templates/_helpers.tpl
@@ -27,7 +27,7 @@ If release name contains chart name it will be used as a full name.
 Create chart name and version as used by the chart label.
 */}}
 {{- define "thp.chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s" .Chart.Name | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*

--- a/test/testlib/constants.go
+++ b/test/testlib/constants.go
@@ -33,7 +33,7 @@ const THP_HELM_CHART_PATH = "../../stable/transparent-hugepage"
 const RESULT_DIR = "../../results"
 const INJECT_FILE = "../../versionInject.yaml"
 
-const IMPORT_ARCHIVE_URL = "http://download.nuohub.org/ce_releases/restore.bak.tz"
+const IMPORT_ARCHIVE_URL = "https://download.nuohub.org/ce_releases/restore.bak.tz"
 
 const MINIMAL_VIABLE_ENGINE_CPU = "500m"
 const MINIMAL_VIABLE_ENGINE_MEMORY = "500Mi"


### PR DESCRIPTION
- _release_ labels included chart version info making rolling upgrades of stateful sets impossible.  This change removes the version in all labels, avoiding arbitrary changes to artefacts caused only by the chart version being upgraded, and removing the issue in statefusets.

- Minor typos corrected

- Indentation on admin options corrected