### PR TITLE
Test for permanent loss of admin

### DIFF
--- a/test/minikube/minikube_crash_handling_test.go
+++ b/test/minikube/minikube_crash_handling_test.go
@@ -93,6 +93,10 @@ func TestPermanentLossOfAdmin(t *testing.T) {
 	adminToKill, err := GetAdminOfEnginePodE(t, namespaceName, admin0, tePodName)
 	assert.NilError(t, err)
 
+	if adminToKill == admin0 {
+		t.Skip("Can not delete storage of entry node admin-0. Abandoning test.")
+	}
+
 	kubectlOptions := k8s.NewKubectlOptions("", "")
 	kubectlOptions.Namespace = namespaceName
 

--- a/test/minikube/minikube_crash_handling_test.go
+++ b/test/minikube/minikube_crash_handling_test.go
@@ -11,6 +11,7 @@ import (
 	"gotest.tools/assert"
 	corev1 "k8s.io/api/core/v1"
 	"testing"
+	"time"
 )
 
 func verifyKillAndInfoInLog(t *testing.T, namespaceName string, adminPodName string, podName string) {
@@ -106,10 +107,10 @@ func TestPermanentLossOfAdmin(t *testing.T) {
 
 	testlib.AwaitDatabaseUp(t, namespaceName, admin0, "demo", 2)
 
-	stringOccurrence := testlib.GetStringOccurrenceInLog(t, namespaceName, tePodName, "Evicted by management",
-		&corev1.PodLogOptions {Previous:true})
-
-	assert.Assert(t, stringOccurrence > 0)
+	testlib.Await(t, func() bool {
+		return testlib.GetStringOccurrenceInLog(t, namespaceName, adminToKill,
+			"Reconnected with process with connectKey", &corev1.PodLogOptions{} ) >= 1
+	}, 30*time.Second)
 
 }
 

--- a/test/testlib/minikube_utilities.go
+++ b/test/testlib/minikube_utilities.go
@@ -746,7 +746,7 @@ func RunSQL(t *testing.T, namespace string, podName string, databaseName string,
 	return result, err
 }
 
-func ExecuteCommandsInPod(t *testing.T, podName string, namespaceName string, commands []string) {
+func ExecuteCommandsInPod(t *testing.T, namespaceName string, podName string, commands []string) {
 	tmpfile, err := ioutil.TempFile("", "script")
 	if err != nil {
 		assert.NilError(t, err)

--- a/test/testlib/tls.go
+++ b/test/testlib/tls.go
@@ -80,7 +80,7 @@ func GenerateCustomCertificates(t *testing.T, podName string, namespaceName stri
 	}
 	finalCommands := append(prependCommands, commands...)
 	// Execute certificate generation commands
-	ExecuteCommandsInPod(t, podName, namespaceName, finalCommands)
+	ExecuteCommandsInPod(t, namespaceName, podName, finalCommands)
 }
 
 func CopyCertificatesToControlHost(t *testing.T, podName string, namespaceName string) string {


### PR DESCRIPTION
This test deletes the admin storage on disk and waits for k8s to get rescheduled.

Once the admin is back up, the engines reconnect without interruption of service.