### PR TITLE
add sm.hotCopy.enableBackups to the database helm chart

### DIFF
--- a/stable/database/README.md
+++ b/stable/database/README.md
@@ -232,6 +232,7 @@ The following tables list the configurable parameters of the `database` chart an
 | `sm.logPersistence.storageClass` | Storage class for volume backing log storage.  This storage class must be pre-configured in the cluster | `-` |
 | `sm.hotCopy.replicas` | SM replicas with hot-copy enabled | `1` |
 | `sm.hotCopy.enablePod` | Create DS/SS for hot-copy enabled SMs | `true` |
+| `sm.hotCopy.enableBackups` | Enable full/incremental backups | `true` |
 | `sm.hotcopy.deadline` | Deadline for a hotcopy job to start (seconds) | `1800` |
 | `sm.hotcopy.timeout` | Timeout for a started hotcopy job to complete (seconds) | `1800` |
 | `sm.hotcopy.successHistory` | Number of successful Jobs to keep | `5` |

--- a/stable/database/templates/cronjob.yaml
+++ b/stable/database/templates/cronjob.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.database.sm.hotCopy.enablePod }}
+{{- if .Values.database.sm.hotCopy.enableBackups }}
 ---
 apiVersion: batch/v1beta1
 kind: CronJob
@@ -260,6 +261,7 @@ spec:
           {{- end }}
           restartPolicy: Never
 {{- include "nuodb.imagePullSecrets" . | indent 10 }}
+{{- end }}
 
 {{- if .Values.database.sm.hotCopy.journalBackup.enabled }}
 ---

--- a/stable/database/templates/job.yaml
+++ b/stable/database/templates/job.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.database.sm.hotCopy.enablePod }}
+{{- if .Values.database.sm.hotCopy.enableBackups }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -98,4 +99,5 @@ spec:
       {{- end }}
       restartPolicy: Never
 {{- include "nuodb.imagePullSecrets" . | indent 6 }}
+{{- end }}
 {{- end }}

--- a/stable/database/values.yaml
+++ b/stable/database/values.yaml
@@ -198,6 +198,7 @@ database:
     # All time values are in seconds unless the unit is included in the name.
     hotCopy:
       enablePod: true
+      enableBackups: true
       replicas: 1
 
       # Deadline for starting a hotcopy job - if a job hasn't started in this time - give up


### PR DESCRIPTION
the sm.hotCopy.enableBackups paramter is used to control whether or
not to enable database backups for the SM hotcopy pods, the default
value is true.

there are use cases where taking a database backup would be better
served if it got trigged by a workflow outside the helm charts
(e.g. on demande backup); it would be better in this case to disable
the kubernetes job/cronjob in the database helm chart that takes a
full backup and periodic incremental backups of a database

Signed-off-by: Abdallah Chatila <abdallah@kaloom.com>