### PR TITLE
Add readiness probe timeouts in values

### DIFF
--- a/stable/admin/README.md
+++ b/stable/admin/README.md
@@ -178,6 +178,7 @@ The following tables list the configurable parameters for the `admin` option of 
 | `tlsClientPEM.key` | TLS client PEM secret key | `nil` |
 | `serviceSuffix.balancer` | The suffix to use for the LoadBalancer service name | `balancer` |
 | `serviceSuffix.clusterip` | The suffix to use for the ClusterIP service name | `clusterip` |
+| `readinessTimeoutSeconds` | Admin readiness probe timeout, sometimes needs adjusting depending on environment and pod resources | `1` |
 
 For example, when using GlusterFS storage class, you would supply the following parameter:
 

--- a/stable/admin/templates/statefulset.yaml
+++ b/stable/admin/templates/statefulset.yaml
@@ -114,7 +114,7 @@ spec:
             command: [ "nuodocker", "check", "servers", "--check-connected", "--check-active", "--check-leader" ]
           failureThreshold: 30
           successThreshold: 2
-          timeoutSeconds: 1
+          timeoutSeconds: {{ default 1 .Values.admin.readinessTimeoutSeconds }}
         volumeMounts:
         - name: log-volume
           mountPath: /var/log/nuodb

--- a/stable/admin/values.yaml
+++ b/stable/admin/values.yaml
@@ -190,3 +190,6 @@ admin:
   serviceSuffix:
     clusterip: clusterip
     balancer: balancer
+
+  #Some clusters require longer readiness probe timeouts
+  readinessTimeoutSeconds: 1

--- a/stable/database/README.md
+++ b/stable/database/README.md
@@ -257,7 +257,7 @@ The following tables list the configurable parameters of the `database` chart an
 | `sm.affinity` | Affinity rules for NuoDB SM | `{}` |
 | `sm.nodeSelector` | Node selector rules for NuoDB SM | `{}` |
 | `sm.tolerations` | Tolerations for NuoDB SM | `[]` |
-| `sm.readinessTimeoutSeconds` | Admin readiness probe timeout, sometimes needs adjusting depending on environment and pod resources | `5` |
+| `sm.readinessTimeoutSeconds` | SM readiness probe timeout, sometimes needs adjusting depending on environment and pod resources | `5` |
 | `te.externalAccess.enabled` | Whether to deploy a Layer 4 cloud load balancer service for the admin layer | `false` |
 | `te.externalAccess.internalIP` | Whether to use an internal (to the cloud) or external (public) IP address for the load balancer | `nil` |
 | `te.dbServices.enabled` | Whether to deploy clusterip and headless services for direct TE connections (defaults true) | `nil` |
@@ -281,7 +281,7 @@ The following tables list the configurable parameters of the `database` chart an
 | `sm.nodeSelectorNoHotCopyDS` | Node selector rules for non-hot-copy SMs (DaemonSet) | `{}` |
 | `sm.tolerationsDS` | Tolerations for SMs (DaemonSet) | `[]` |
 | `sm.otherOptions` | Additional key/value Docker options | `{}` |
-| `te.readinessTimeoutSeconds` | Admin readiness probe timeout, sometimes needs adjusting depending on environment and pod resources | `5` |
+| `te.readinessTimeoutSeconds` | TE readiness probe timeout, sometimes needs adjusting depending on environment and pod resources | `5` |
 
 #### database.configFiles.*
 

--- a/stable/database/README.md
+++ b/stable/database/README.md
@@ -257,6 +257,7 @@ The following tables list the configurable parameters of the `database` chart an
 | `sm.affinity` | Affinity rules for NuoDB SM | `{}` |
 | `sm.nodeSelector` | Node selector rules for NuoDB SM | `{}` |
 | `sm.tolerations` | Tolerations for NuoDB SM | `[]` |
+| `sm.readinessTimeoutSeconds` | Admin readiness probe timeout, sometimes needs adjusting depending on environment and pod resources | `5` |
 | `te.externalAccess.enabled` | Whether to deploy a Layer 4 cloud load balancer service for the admin layer | `false` |
 | `te.externalAccess.internalIP` | Whether to use an internal (to the cloud) or external (public) IP address for the load balancer | `nil` |
 | `te.dbServices.enabled` | Whether to deploy clusterip and headless services for direct TE connections (defaults true) | `nil` |
@@ -280,6 +281,7 @@ The following tables list the configurable parameters of the `database` chart an
 | `sm.nodeSelectorNoHotCopyDS` | Node selector rules for non-hot-copy SMs (DaemonSet) | `{}` |
 | `sm.tolerationsDS` | Tolerations for SMs (DaemonSet) | `[]` |
 | `sm.otherOptions` | Additional key/value Docker options | `{}` |
+| `te.readinessTimeoutSeconds` | Admin readiness probe timeout, sometimes needs adjusting depending on environment and pod resources | `5` |
 
 #### database.configFiles.*
 

--- a/stable/database/templates/daemonset.yaml
+++ b/stable/database/templates/daemonset.yaml
@@ -368,7 +368,7 @@ spec:
           failureThreshold: 58
           # the SM becomes unready if it does not start within 15 minutes = 30s + 15s*58
           successThreshold: 2
-          timeoutSeconds: {{ default 5 .Values.database.te.readinessTimeoutSeconds }}
+          timeoutSeconds: {{ default 5 .Values.database.sm.readinessTimeoutSeconds }}
 {{- include "nuodb.imagePullSecrets" . | indent 6 }}
       volumes:
       - name: log-volume

--- a/stable/database/templates/daemonset.yaml
+++ b/stable/database/templates/daemonset.yaml
@@ -368,7 +368,7 @@ spec:
           failureThreshold: 58
           # the SM becomes unready if it does not start within 15 minutes = 30s + 15s*58
           successThreshold: 2
-          timeoutSeconds: 5
+          timeoutSeconds: {{ default 5 .Values.database.te.readinessTimeoutSeconds }}
 {{- include "nuodb.imagePullSecrets" . | indent 6 }}
       volumes:
       - name: log-volume

--- a/stable/database/templates/deployment.yaml
+++ b/stable/database/templates/deployment.yaml
@@ -138,7 +138,7 @@ spec:
           failureThreshold: 54
           # the TE becomes unready if it does not start within 5 minutes = 30s + 5s*54
           successThreshold: 2
-          timeoutSeconds: 5
+          timeoutSeconds: {{ default 5 .Values.database.te.readinessTimeoutSeconds }}
 {{- include "nuodb.imagePullSecrets" . | indent 6 }}
       volumes:
         {{- if .Values.database.configFiles }}

--- a/stable/database/templates/statefulset.yaml
+++ b/stable/database/templates/statefulset.yaml
@@ -194,7 +194,7 @@ spec:
           failureThreshold: 58
           # the SM becomes unready if it does not start within 15 minutes = 30s + 15s*58
           successThreshold: 2
-          timeoutSeconds: {{ default 5 .Values.database.sm.readinessTimeout }}
+          timeoutSeconds: {{ default 5 .Values.database.sm.readinessTimeoutSeconds }}
 {{- include "nuodb.imagePullSecrets" . | indent 6 }}
       volumes:
       {{- if .Values.database.configFiles }}

--- a/stable/database/templates/statefulset.yaml
+++ b/stable/database/templates/statefulset.yaml
@@ -194,7 +194,7 @@ spec:
           failureThreshold: 58
           # the SM becomes unready if it does not start within 15 minutes = 30s + 15s*58
           successThreshold: 2
-          timeoutSeconds: 5
+          timeoutSeconds: {{ default 5 .Values.database.sm.readinessTimeout }}
 {{- include "nuodb.imagePullSecrets" . | indent 6 }}
       volumes:
       {{- if .Values.database.configFiles }}
@@ -494,7 +494,7 @@ spec:
           failureThreshold: 58
           # the SM becomes unready if it does not start within 15 minutes = 30s + 15s*58
           successThreshold: 2
-          timeoutSeconds: 5
+          timeoutSeconds: {{ default 5 .Values.database.sm.readinessTimeoutSeconds }}
 {{- include "nuodb.imagePullSecrets" . | indent 6 }}
       volumes:
       {{- if .Values.database.configFiles }}

--- a/stable/database/values.yaml
+++ b/stable/database/values.yaml
@@ -341,15 +341,15 @@ database:
     # named key/value pairs that need to be passed to the image, such as
     # keystore: "/etc/nuodb/keys/nuoadmin.p12"
     otherOptions: {}
+
+    #Some clusters require longer readiness probe timeouts
+    readinessTimeoutSeconds: 5
   
   enableDaemonSet: false
   # Set to true if you are using manually created volumes or restoring
   # from a previously existing backup.
   isManualVolumeProvisioning: false
   isRestore: false
-
-  #Some clusters require longer readiness probe timeouts
-  readinessTimeoutSeconds: 5
 
 openshift:
   # change this to true if you want to deploy using OpenShift proprietary features

--- a/stable/database/values.yaml
+++ b/stable/database/values.yaml
@@ -282,6 +282,9 @@ database:
     # nodeSelectorHotCopyDS: {}
     # tolerationsDS: []
 
+    #Some clusters require longer readiness probe timeouts
+    readinessTimeoutSeconds: 5
+
   te:
     ## Enable persistent log volumes to retain logs when an external logging solution is not used.
     logPersistence:
@@ -344,6 +347,9 @@ database:
   # from a previously existing backup.
   isManualVolumeProvisioning: false
   isRestore: false
+
+  #Some clusters require longer readiness probe timeouts
+  readinessTimeoutSeconds: 5
 
 openshift:
   # change this to true if you want to deploy using OpenShift proprietary features


### PR DESCRIPTION
I have found, depending on the type of cluster being used and the resources set for the containers, that some deployments require longer readiness timeouts.  If a readiness probe timeout is hit too many times, we can also hit a zombie thread reaping issue.

This change 

- adds a readinessTimeoutSeconds to option to the values file
- add to readme
- defaults to the existing settings for 1s in admin and 5s in engines

Related to DB-31293