### PR TITLE
Fix helm upgrade test

### DIFF
--- a/test/testlib/minikube_utilities.go
+++ b/test/testlib/minikube_utilities.go
@@ -296,7 +296,12 @@ func AwaitPodObjectRecreated(t *testing.T, namespace string, pod *corev1.Pod, ti
 	options.Namespace = namespace
 
 	Await(t, func() bool {
-		currentPod := k8s.GetPod(t, options, pod.Name)
+		currentPod, err := k8s.GetPodE(t, options, pod.Name)
+
+		if err != nil {
+			return false
+		}
+
 		return currentPod.UID != pod.UID
 	}, timeout)
 }


### PR DESCRIPTION
```TestUpgradeHelm/NuoDB405_From231_ToLocal 2020-06-16T04:22:20-04:00 command.go:87: Running command kubectl with args [--namespace upgradeadmintest-6m8yb3 cp upgradeadmintest-6m8yb3/admin-6m8yb3-nuodb-cluster0-0:/var/log/nuodb/nuoadmin_event.log /space/builds/MASTER-NH-JOB1/obj/REPOS/src/github.com/nuodb/nuodb-helm-charts/results/upgradeadmintest-6m8yb3/nuoadmin_event.log]
TestUpgradeHelm/NuoDB405_From231_ToLocal 2020-06-16T04:22:20-04:00 command.go:158: error: unable to upgrade connection: container not found ("admin")
minikube_utilities.go:205: 0 pods SCHEDULED for name 'admin-6m8yb3'
minikube_utilities.go:205: 0 pods SCHEDULED for name 'admin-6m8yb3'
minikube_utilities.go:205: 1 pods SCHEDULED for name 'admin-6m8yb3'
minikube_utilities.go:355: Pod (job-lb-policy) TERMINATED
pod.go:42: 
        kubectl.go:16: 
            				minikube_utilities.go:299
            				minikube_utilities.go:168
            				minikube_utilities.go:298
            				minikube_upgrade_helm_test.go:42
            				minikube_upgrade_helm_test.go:97
Error:      	Received unexpected error:
            	pods "admin-6m8yb3-nuodb-cluster0-0" not found
Test:       	TestUpgradeHelm/NuoDB405_From231_ToLocal
kubectl.go:16: 
Error Trace:	kubectl.go:16
            				minikube_utilities.go:673
            				nuodb_admin_utilities.go:118
            				minikube_utilities.go:45
            				panic.go:406
            				testing.go:609
            				pod.go:42
            				minikube_utilities.go:299
            				minikube_utilities.go:168
            				minikube_utilities.go:298
            				minikube_upgrade_helm_test.go:42
            				minikube_upgrade_helm_test.go:97
Error:      	Received unexpected error:
            	exit status 1
Test:       	TestUpgradeHelm/NuoDB405_From231_ToLocal
```

Fix is simple and straight-forward