### PR TITLE
LB policy job affinity

### DIFF
--- a/stable/admin/templates/job.yaml
+++ b/stable/admin/templates/job.yaml
@@ -21,6 +21,18 @@ spec:
         release: {{ .Release.Name | quote }}
       name: job-lb-policy-{{ .Values.admin.lbPolicy | lower }}
     spec:
+      {{- with .Values.admin.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | trim | indent 8 }}
+      {{- end }}
+{{- if .Values.admin.affinity }}
+      affinity:
+{{ tpl .Values.admin.affinity . | trim | indent 8 }}
+{{- end }}
+      {{- if .Values.admin.tolerations }}
+      tolerations:
+{{ toYaml .Values.admin.tolerations | trim | indent 8 }}
+      {{- end }}
       initContainers:
       - name: wait
         image: {{ template "nuodb.image" . }}


### PR DESCRIPTION
in some use cases it's desirable to control where the lb policy
kubernetes job will be scheduled.

use the nodeSelector, affinity or tolerations parameters if they are
defined in the admin chart to control on which kuberentes node the
job will run.
