### PR TITLE
Change initial backup policy from Never to OnFailure

### DIFF
--- a/stable/database/templates/job.yaml
+++ b/stable/database/templates/job.yaml
@@ -97,7 +97,7 @@ spec:
           secretName: {{ .Values.admin.tlsClientPEM.secret }}
           defaultMode: 0440
       {{- end }}
-      restartPolicy: Never
+      restartPolicy: OnFailure
 {{- include "nuodb.imagePullSecrets" . | indent 6 }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
The initial backup job can sometimes fail if the DB is not fully initialized when the job is being run. We can sometimes see this in our backup tests:

```
minikube_utilities.go:165: goroutine 1650 [running]:
    runtime/debug.Stack(0x0, 0xc0003175c0, 0x13d0101)
            github.com/nuodb/nuodb-helm-charts/test/testlib.Await(0xc0008b0d00, 0xc00068bd98, 0x1bf08eb000)
            github.com/nuodb/nuodb-helm-charts/test/testlib.AwaitPodPhase(0xc0008b0d00, 0xc0000eb2c0, 0x23, 0xc000558420, 0x18, 0x140c7db, 0x9, 0x1bf08eb000)
            github.com/nuodb/nuodb-helm-charts/test/minikube.backupDatabase(0xc0008b0d00, 0xc0000eb2c0, 0x23, 0xc000133600, 0x1d, 0x1409850, 0x4, 0xc00075f040)
            github.com/nuodb/nuodb-helm-charts/test/minikube.TestKubernetesBackupDatabase.func2(0xc0008b0d00)
            testing.tRunner(0xc0008b0d00, 0xc0004154d0)
            created by testing.(*T).Run
            
        minikube_utilities.go:166: function call timed out
```

I decided to change the restart policy to prevent Kubernetes from scheduling multiple pods and possibly accumulating failed jobs. The `OnFailure` policy makes more sense.

This PR fixes the flaky tests too.

We will have to also re-evaluate the restart policies for our `CronJobs`. But I am not going to do that in the PR.