### PR TITLE
[DB-30945] Add bootstrapServers label to Admin StatefulSet

### DIFF
--- a/stable/admin/templates/statefulset.yaml
+++ b/stable/admin/templates/statefulset.yaml
@@ -7,6 +7,9 @@ metadata:
     release: {{ .Release.Name | quote }}
     group: nuodb
     domain: {{ .Values.admin.domain }}
+    {{- if (eq (default "cluster0" .Values.cloud.cluster.name) (default "cluster0" .Values.cloud.cluster.entrypointName)) }}
+    bootstrapServers: {{ default 0 .Values.admin.bootstrapServers | quote }}
+    {{- end }}
   name: {{ template "admin.fullname" . }}
 spec:
   serviceName: {{ .Values.admin.domain }}

--- a/stable/admin/values.yaml
+++ b/stable/admin/values.yaml
@@ -82,6 +82,24 @@ admin:
   # Admin Service
   replicas: 1
 
+  # If specified and set to a value greater than 0, an initial membership
+  # consisting of server IDs <statefulset name>-0, <statefulset name>-1, ...,
+  # <statefulset name>-<n-1> is defined for all Admins. Defining this to a
+  # value larger than 1 allows a bootstrap server (e.g. <statefulset name>-0)
+  # that has to be reprovisioned from scratch to rejoin its peers when it is
+  # restarted, rather than bootstrapping a new domain consisting of itself.
+  #
+  # For multi-cluster configurations, only the Admin StatefulSet in the
+  # entrypoint cluster (i.e. the one with cloud.cluster.name equal to
+  # cloud.cluster.entrypointName) can specify bootstrapServers.
+  #
+  # For backwards-compatibility, the default value is 0 so that it is disabled
+  # by default. Changing the value of bootstrapServers on a running domain,
+  # either by reinstantiating the Helm chart with a new value or by updating
+  # the bootstrapServers label on an existing Admin StatefulSet, is illegal
+  # because the domain can only be bootstrapped once.
+  bootstrapServers: 0
+
   lbPolicy: nearest
   lbQuery: random(first(label(pod ${pod:-}) label(node ${node:-}) label(zone ${zone:-}) any))
 

--- a/stable/admin/values.yaml
+++ b/stable/admin/values.yaml
@@ -93,12 +93,13 @@ admin:
   # entrypoint cluster (i.e. the one with cloud.cluster.name equal to
   # cloud.cluster.entrypointName) can specify bootstrapServers.
   #
-  # For backwards-compatibility, the default value is 0 so that it is disabled
-  # by default. Changing the value of bootstrapServers on a running domain,
-  # either by reinstantiating the Helm chart with a new value or by updating
-  # the bootstrapServers label on an existing Admin StatefulSet, is illegal
-  # because the domain can only be bootstrapped once.
-  bootstrapServers: 0
+  # Changing the value of bootstrapServers on a existing domain, either by
+  # reinstantiating the Helm chart with a new value or by updating the
+  # bootstrapServers label on an existing Admin StatefulSet, is illegal because
+  # the domain can only be bootstrapped once. When upgrading nuodb-helm-charts
+  # from a version that does not support bootstrapServers, bootstrapServers
+  # must be set to 0.
+  bootstrapServers: 1
 
   lbPolicy: nearest
   lbQuery: random(first(label(pod ${pod:-}) label(node ${node:-}) label(zone ${zone:-}) any))

--- a/test/minikube/minikube_rolling_upgrade_test.go
+++ b/test/minikube/minikube_rolling_upgrade_test.go
@@ -31,18 +31,17 @@ func verifyAllProcessesRunning(t *testing.T, namespaceName string, adminPod stri
 	}, 30*time.Second)
 }
 
-
-
 func TestKubernetesUpgradeAdminMinorVersion(t *testing.T) {
 	testlib.AwaitTillerUp(t)
 	defer testlib.VerifyTeardown(t)
 
 	options := helm.Options{
 		SetValues: map[string]string{
-			"nuodb.image.registry": "docker.io",
+			"nuodb.image.registry":   "docker.io",
 			"nuodb.image.repository": "nuodb/nuodb-ce",
-			"nuodb.image.tag": OLD_RELEASE,
-			},
+			"nuodb.image.tag":        OLD_RELEASE,
+			"admin.bootstrapServers": "0",
+		},
 	}
 
 	defer testlib.Teardown(testlib.TEARDOWN_ADMIN)
@@ -74,9 +73,10 @@ func TestKubernetesUpgradeFullDatabaseMinorVersion(t *testing.T) {
 
 	options := helm.Options{
 		SetValues: map[string]string{
-			"nuodb.image.registry": "docker.io",
+			"nuodb.image.registry":   "docker.io",
 			"nuodb.image.repository": "nuodb/nuodb-ce",
-			"nuodb.image.tag": OLD_RELEASE,
+			"nuodb.image.tag":        OLD_RELEASE,
+			"admin.bootstrapServers": "0",
 		},
 	}
 
@@ -94,8 +94,8 @@ func TestKubernetesUpgradeFullDatabaseMinorVersion(t *testing.T) {
 			"database.sm.resources.requests.memory": testlib.MINIMAL_VIABLE_ENGINE_MEMORY,
 			"database.te.resources.requests.cpu":    "250m", // during upgrade we will be running 2 of these
 			"database.te.resources.requests.memory": testlib.MINIMAL_VIABLE_ENGINE_MEMORY,
-			"nuodb.image.registry": 				"docker.io",
-			"nuodb.image.repository": 				"nuodb/nuodb-ce",
+			"nuodb.image.registry":                  "docker.io",
+			"nuodb.image.repository":                "nuodb/nuodb-ce",
 			"nuodb.image.tag":                       OLD_RELEASE,
 		},
 	}
@@ -155,10 +155,11 @@ func TestKubernetesRollingUpgradeAdminMinorVersion(t *testing.T) {
 
 	options := helm.Options{
 		SetValues: map[string]string{
-			"admin.replicas":  "3",
-			"nuodb.image.registry": "docker.io",
+			"admin.replicas":         "3",
+			"admin.bootstrapServers": "0",
+			"nuodb.image.registry":   "docker.io",
 			"nuodb.image.repository": "nuodb/nuodb-ce",
-			"nuodb.image.tag": OLD_RELEASE,
+			"nuodb.image.tag":        OLD_RELEASE,
 		},
 	}
 


### PR DESCRIPTION
Add `boostrapServers` label for the Admin StatefulSet that defines the number of servers that should be part of the initial membership of the domain, which will be generated by `nuodocker start admin`. This enables reprovisioning of a fresh admin-0 instance so it rejoins its peers. Previously, a reprovisioned admin-0 would instance consider itself the lone member of a new domain (since there is no Raft state to replay, which is the only place where added peers would be made durable) and would bootstrap a new disjoint domain.

In multi-cluster deployments, this label is only added to the Admin StatefulSet in the entrypoint cluster.