### PR TITLE
Change database container names to "engine"

### DIFF
--- a/stable/database/templates/daemonset.yaml
+++ b/stable/database/templates/daemonset.yaml
@@ -44,7 +44,7 @@ spec:
 {{ toYaml .Values.database.sm.tolerationsDS | trim | indent 8 }}
       {{- end }}          
       containers:
-      - name: sm
+      - name: engine
         image: {{ template "nuodb.image" . }}
         imagePullPolicy: {{ .Values.nuodb.image.pullPolicy }}
     {{- include "database.capabilities" . | indent 8 }}
@@ -250,7 +250,7 @@ spec:
 {{ toYaml .Values.database.sm.tolerationsDS | trim | indent 8 }}
       {{- end }}
       containers:
-      - name: sm
+      - name: engine
         image: {{ template "nuodb.image" . }}
         imagePullPolicy: {{ .Values.nuodb.image.pullPolicy }}
     {{- include "database.capabilities" . | indent 8 }}

--- a/stable/database/templates/deployment.yaml
+++ b/stable/database/templates/deployment.yaml
@@ -42,7 +42,7 @@ spec:
 {{ toYaml .Values.database.te.tolerations | trim | indent 8 }}
       {{- end }}
       containers:
-      - name: te-{{ template "database.fullname" . }}
+      - name: engine
         image: {{ template "nuodb.image" . }}
         imagePullPolicy: {{ .Values.nuodb.image.pullPolicy }}
     {{- include "database.capabilities" . | indent 8 }}

--- a/stable/database/templates/statefulset.yaml
+++ b/stable/database/templates/statefulset.yaml
@@ -63,7 +63,7 @@ spec:
         - name: log-volume
           mountPath: /var/log/nuodb
       containers:
-      - name: sm
+      - name: engine
         image: {{ template "nuodb.image" . }}
         imagePullPolicy: {{ .Values.nuodb.image.pullPolicy }}
     {{- include "database.capabilities" . | indent 8 }}
@@ -360,7 +360,7 @@ spec:
         - name: log-volume
           mountPath: /var/log/nuodb
       containers:
-      - name: sm
+      - name: engine
         image: {{ template "nuodb.image" . }}
         imagePullPolicy: {{ .Values.nuodb.image.pullPolicy }}
     {{- include "database.capabilities" . | indent 8 }}


### PR DESCRIPTION
Change database container name to engine for SM and hotcopy SM
StatefulSet, SM DaemonSet, and TE Deployment. This allows us to add
sidecar containers to run in the same Pod while still being able to
detect which container is running the database process.