### PR TITLE
Expose bootstrapServers value as Admin statefulset annotation

### DIFF
--- a/stable/admin/templates/statefulset.yaml
+++ b/stable/admin/templates/statefulset.yaml
@@ -5,6 +5,9 @@ metadata:
     description: |-
       NuoAdmin statefulset resource for NuoDB Admin layer.
 {{- include "admin.loadBalancerConfig" . | indent 4 }}
+    {{- if (eq (default "cluster0" .Values.cloud.cluster.name) (default "cluster0" .Values.cloud.cluster.entrypointName)) }}
+    nuodb.com/bootstrap-servers: {{ default 0 .Values.admin.bootstrapServers | quote }}
+    {{- end }}
   labels:
     app: {{ template "admin.fullname" . }}
     chart: {{ template "admin.chart" . }}

--- a/stable/admin/values.yaml
+++ b/stable/admin/values.yaml
@@ -94,8 +94,9 @@ admin:
   # cloud.cluster.entrypointName) can specify bootstrapServers.
   #
   # Changing the value of bootstrapServers on a existing domain, either by
-  # reinstantiating the Helm chart with a new value or by updating the
-  # bootstrapServers label on an existing Admin StatefulSet, is illegal because
+  # reinstantiating the Helm chart with a new value or by updating the 
+  # corresponding nuodb.com/bootstrap-servers annotation or bootstrapServers label 
+  # on an existing Admin StatefulSet, is illegal because
   # the domain can only be bootstrapped once. When upgrading nuodb-helm-charts
   # from a version that does not support bootstrapServers, bootstrapServers
   # must be set to 0.


### PR DESCRIPTION
This will expose `boostrapServers` value as `nuodb.com/bootstrap-servers` annotation for the Admin StatefulSet. Newer versions of NuoDB will take into account the value of the annotation and prefer it over the value of the `boostrapServers` label.