### PR TITLE
Add more diagnostics for TestKubernetesTLSRotation test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ results/
 .vscode/
 venv/
 versionInject.yaml
+valuesInject.yaml

--- a/scripts/ci/install_deps.sh
+++ b/scripts/ci/install_deps.sh
@@ -25,6 +25,7 @@ if [[ -n "$REQUIRES_MINIKUBE" ]]; then
   # after pods have been re-created which causes problems with inter pod communicataion.
   # Set CoreDNS TTL to 0 so that DNS entries are not cached. 
   kubectl get cm coredns -n kube-system -o yaml | sed -e 's/ttl [0-9]*$/ttl 0/' | kubectl apply -n kube-system -f -
+  kubectl delete pods -l k8s-app=kube-dns -n kube-system
 
   helm version
 

--- a/scripts/ci/install_deps.sh
+++ b/scripts/ci/install_deps.sh
@@ -21,6 +21,11 @@ if [[ -n "$REQUIRES_MINIKUBE" ]]; then
   sudo chown -R travis: /home/travis/.minikube/
   kubectl cluster-info
 
+  # In some tests (specifically TestKubernetesTLSRotation), we observe incorrect DNS resolution 
+  # after pods have been re-created which causes problems with inter pod communicataion.
+  # Set CoreDNS TTL to 0 so that DNS entries are not cached. 
+  kubectl get cm coredns -n kube-system -o yaml | sed -e 's/ttl [0-9]*$/ttl 0/' | kubectl apply -n kube-system -f -
+
   helm version
 
   kubectl version

--- a/test/minikube/minikube_base_database_test.go
+++ b/test/minikube/minikube_base_database_test.go
@@ -4,10 +4,11 @@ package minikube
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/nuodb/nuodb-helm-charts/test/testlib"
 
@@ -233,7 +234,7 @@ func restoreDatabase(t *testing.T, namespaceName string, podName string, databas
 	options.KubectlOptions = kubectlOptions
 
 	restore := func() {
-		testlib.InjectTestVersion(t, options)
+		testlib.InjectTestValues(t, options)
 		helm.Install(t, options, testlib.RESTORE_HELM_CHART_PATH, restName)
 		testlib.AddTeardown(testlib.TEARDOWN_RESTORE, func() { helm.Delete(t, options, restName, true) })
 

--- a/test/minikube/minikube_test_test.go
+++ b/test/minikube/minikube_test_test.go
@@ -338,6 +338,5 @@ func TestInjection(t *testing.T) {
 	options := helm.Options{
 		SetValues: map[string]string{},
 	}
-
-	testlib.InjectTestVersion(t, &options)
+	testlib.InjectTestValues(t, &options)
 }

--- a/test/minikube/minikube_tls_rotation_test.go
+++ b/test/minikube/minikube_tls_rotation_test.go
@@ -4,18 +4,18 @@ package minikube
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/nuodb/nuodb-helm-charts/test/testlib"
 
 	"github.com/gruntwork-io/terratest/modules/helm"
 	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/gruntwork-io/terratest/modules/random"
-
 )
 
 func verifyAdminCertificates(t *testing.T, certificateInfoJSON string, expectedDN string) {
@@ -57,7 +57,7 @@ func TestKubernetesTLSRotation(t *testing.T) {
 
 	testlib.AwaitTillerUp(t)
 	defer testlib.VerifyTeardown(t)
-	
+
 	randomSuffix := strings.ToLower(random.UniqueId())
 	namespaceName := fmt.Sprintf("testtlsrotation-%s", randomSuffix)
 	testlib.CreateNamespace(t, namespaceName)
@@ -116,10 +116,16 @@ func TestKubernetesTLSRotation(t *testing.T) {
 	testlib.CreateSecret(t, namespaceName, testlib.CA_CERT_FILE, testlib.CA_CERT_SECRET, newTLSKeysLocation)
 	testlib.CreateSecretWithPassword(t, namespaceName, testlib.KEYSTORE_FILE, testlib.KEYSTORE_SECRET, testlib.SECRET_PASSWORD, newTLSKeysLocation)
 
+	kubectlOptions := k8s.NewKubectlOptions("", "", namespaceName)
+	testlib.AddDiagnosticTeardown(testlib.TEARDOWN_ADMIN, t, func() {
+		output, _ := k8s.RunKubectlAndGetOutputE(t, kubectlOptions, "get", "pods", "-o", "wide")
+		t.Logf("All pods in namespace=%s:", namespaceName)
+		t.Logf(output)
+	})
+
 	testlib.RotateTLSCertificates(t, &options, namespaceName, adminReleaseName, databaseReleaseName, newTLSKeysLocation, false)
 	admin0 := fmt.Sprintf("%s-nuodb-cluster0-0", adminReleaseName)
 
-	kubectlOptions := k8s.NewKubectlOptions("", "", namespaceName)
 	certificateInfo, err := k8s.RunKubectlAndGetOutputE(t, kubectlOptions, "exec", admin0, "--", "nuocmd", "--show-json", "get", "certificate-info")
 	assert.NoError(t, err)
 

--- a/test/minikube/minikube_tls_rotation_test.go
+++ b/test/minikube/minikube_tls_rotation_test.go
@@ -118,9 +118,7 @@ func TestKubernetesTLSRotation(t *testing.T) {
 
 	kubectlOptions := k8s.NewKubectlOptions("", "", namespaceName)
 	testlib.AddDiagnosticTeardown(testlib.TEARDOWN_ADMIN, t, func() {
-		output, _ := k8s.RunKubectlAndGetOutputE(t, kubectlOptions, "get", "pods", "-o", "wide")
-		t.Logf("All pods in namespace=%s:", namespaceName)
-		t.Logf(output)
+		k8s.RunKubectl(t, kubectlOptions, "get", "pods", "-o", "wide")
 	})
 
 	testlib.RotateTLSCertificates(t, &options, namespaceName, adminReleaseName, databaseReleaseName, newTLSKeysLocation, false)

--- a/test/testlib/constants.go
+++ b/test/testlib/constants.go
@@ -33,6 +33,7 @@ const YCSB_HELM_CHART_PATH = "../../incubator/demo-ycsb"
 
 const RESULT_DIR = "../../results"
 const INJECT_FILE = "../../versionInject.yaml"
+const INJECT_VALUES_FILE = "../../valuesInject.yaml"
 
 const IMPORT_ARCHIVE_URL = "https://download.nuohub.org/ce_releases/restore.bak.tz"
 

--- a/test/testlib/minikube_utilities.go
+++ b/test/testlib/minikube_utilities.go
@@ -166,6 +166,15 @@ func RemoveEmptyLines(s string) string {
 	return s
 }
 
+func InjectTestValuesFile(t *testing.T, options *helm.Options) {
+	dat, err := ioutil.ReadFile(INJECT_VALUES_FILE)
+	if err != nil {
+		return
+	}
+	t.Logf("Using injected values file=%s with content:%s\n", INJECT_VALUES_FILE, string(dat))
+	options.ValuesFiles = append(options.ValuesFiles, INJECT_VALUES_FILE)
+}
+
 func InjectTestVersion(t *testing.T, options *helm.Options) {
 	dat, err := ioutil.ReadFile(INJECT_FILE)
 	if err != nil {
@@ -194,6 +203,11 @@ func InjectTestVersion(t *testing.T, options *helm.Options) {
 	options.SetValues["nuodb.image.registry"] = image.Nuodb.Image.Registry
 	options.SetValues["nuodb.image.repository"] = image.Nuodb.Image.Repository
 	options.SetValues["nuodb.image.tag"] = image.Nuodb.Image.Tag
+}
+
+func InjectTestValues(t *testing.T, options *helm.Options) {
+	InjectTestValuesFile(t, options)
+	InjectTestVersion(t, options)
 }
 
 func GetUpgradedReleaseVersion(t *testing.T, options *helm.Options, suggestedVersion string) string {

--- a/test/testlib/nuodb_admin_utilities.go
+++ b/test/testlib/nuodb_admin_utilities.go
@@ -59,7 +59,7 @@ func StartAdminTemplate(t *testing.T, options *helm.Options, replicaCount int, n
 	options.KubectlOptions = kubectlOptions
 	options.KubectlOptions.Namespace = namespaceName
 
-	InjectTestVersion(t, options)
+	InjectTestValues(t, options)
 	installStep(t, options, helmChartReleaseName)
 
 	AddTeardown(TEARDOWN_ADMIN, func() {

--- a/test/testlib/nuodb_database_utilities.go
+++ b/test/testlib/nuodb_database_utilities.go
@@ -2,11 +2,12 @@ package testlib
 
 import (
 	"fmt"
-	v12 "k8s.io/api/core/v1"
 	"strconv"
 	"strings"
 	"testing"
 	"time"
+
+	v12 "k8s.io/api/core/v1"
 
 	"github.com/gruntwork-io/terratest/modules/helm"
 	"github.com/gruntwork-io/terratest/modules/k8s"
@@ -67,7 +68,7 @@ type DatabaseInstallationStep func(t *testing.T, options *helm.Options, helmChar
 func StartDatabaseTemplate(t *testing.T, namespaceName string, adminPod string, options *helm.Options, installationStep DatabaseInstallationStep) (helmChartReleaseName string) {
 	randomSuffix := strings.ToLower(random.UniqueId())
 
-	InjectTestVersion(t, options)
+	InjectTestValues(t, options)
 	opt := GetExtractedOptions(options)
 
 	helmChartReleaseName = fmt.Sprintf("database-%s", randomSuffix)
@@ -95,7 +96,9 @@ func StartDatabaseTemplate(t *testing.T, namespaceName string, adminPod string, 
 
 	tePodName := GetPodName(t, namespaceName, tePodNameTemplate)
 
-	AddTeardown(TEARDOWN_DATABASE, func() { GetAppLog(t, namespaceName, GetPodName(t, namespaceName, tePodNameTemplate), "", &v12.PodLogOptions{}) })
+	AddTeardown(TEARDOWN_DATABASE, func() {
+		GetAppLog(t, namespaceName, GetPodName(t, namespaceName, tePodNameTemplate), "", &v12.PodLogOptions{})
+	})
 	AwaitPodUp(t, namespaceName, tePodName, 180*time.Second)
 
 	smPodName0 := GetPodName(t, namespaceName, smPodName)

--- a/test/testlib/nuodb_ycsb_utilities.go
+++ b/test/testlib/nuodb_ycsb_utilities.go
@@ -2,18 +2,19 @@ package testlib
 
 import (
 	"fmt"
-	"github.com/gruntwork-io/terratest/modules/helm"
-	"github.com/gruntwork-io/terratest/modules/k8s"
-	"github.com/gruntwork-io/terratest/modules/random"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/gruntwork-io/terratest/modules/helm"
+	"github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/gruntwork-io/terratest/modules/random"
 )
 
 func StartYCSBWorkload(t *testing.T, namespaceName string, options *helm.Options) (helmChartReleaseName string) {
 	randomSuffix := strings.ToLower(random.UniqueId())
 
-	InjectTestVersion(t, options)
+	InjectTestValues(t, options)
 
 	helmChartReleaseName = fmt.Sprintf("ycsb-%s", randomSuffix)
 


### PR DESCRIPTION
*Changes*
- Disable CoreDNS entries caching (https://kubernetes.io/docs/tasks/administer-cluster/dns-custom-nameservers/)
- Print pods if `TestKubernetesTLSRotation` test fails using diagnostics teardown
- General ability to inject arbitrarily custom values file `valuesInject.yaml` for all tests. This is useful in case there is need to overwrite some of the inline values like admin config files or affinity rules.