### PR TITLE
Improve retention and handling of multiple files or folder in $NUODB_CRASHDIR

### DIFF
--- a/stable/admin/files/nuoadmin
+++ b/stable/admin/files/nuoadmin
@@ -25,12 +25,13 @@ fi
 export NUODB_LOGDIR NUODB_CFGDIR NUODB_VARDIR NUODB_BINDIR NUODB_RUNDIR
 
 # attempt to retain the previous crash directory (within the configured window to avoid filling the disk)
-if [ -f $NUODB_CRASHDIR/* ]; then
-  crashcount=$(find $NUODB_LOGDIR/crash-* -type d -cmin -$OVERWRITE_WINDOW ! -path . | wc -l)
-  if [ $crashcount -lt $OVERWRITE_COPIES ]; then
+crashcount=$(find $NUODB_CRASHDIR/core* -maxdepth 1 ! -type d | wc -l)
+if [ $crashcount -ge 1 ]; then
+  retainedcrashcount=$(find $NUODB_LOGDIR/crash-* -maxdepth 1 -type d -cmin -$OVERWRITE_WINDOW | wc -l)
+  if [ $retainedcrashcount -lt $OVERWRITE_COPIES ]; then
     crashbackupdir="$NUODB_LOGDIR/crash-$( date +%Y%m%dT%H%M%S )/"
     mkdir $crashbackupdir
-    mv $NUODB_CRASHDIR/* $crashbackupdir
+    mv $NUODB_CRASHDIR/core* $crashbackupdir
   fi
 fi
 

--- a/stable/admin/files/nuoadmin
+++ b/stable/admin/files/nuoadmin
@@ -25,9 +25,9 @@ fi
 export NUODB_LOGDIR NUODB_CFGDIR NUODB_VARDIR NUODB_BINDIR NUODB_RUNDIR
 
 # attempt to retain the previous crash directory (within the configured window to avoid filling the disk)
-crashcount=$(find $NUODB_CRASHDIR/core* -maxdepth 1 ! -type d | wc -l)
+crashcount=$(find $NUODB_CRASHDIR/core* -maxdepth 0 ! -type d | wc -l)
 if [ $crashcount -ge 1 ]; then
-  retainedcrashcount=$(find $NUODB_LOGDIR/crash-* -maxdepth 1 -type d -cmin -$OVERWRITE_WINDOW | wc -l)
+  retainedcrashcount=$(find $NUODB_LOGDIR/crash-* -maxdepth 0 -type d -cmin -$OVERWRITE_WINDOW | wc -l)
   if [ $retainedcrashcount -lt $OVERWRITE_COPIES ]; then
     crashbackupdir="$NUODB_LOGDIR/crash-$( date +%Y%m%dT%H%M%S )/"
     mkdir $crashbackupdir

--- a/stable/database/files/nuosm
+++ b/stable/database/files/nuosm
@@ -22,9 +22,9 @@ NUODB_BINDIR=$NUODB_HOME/bin
 [ -z "$NUOCMD" ] && NUOCMD="$NUODB_BINDIR/nuocmd --api-server $NUOCMD_API_SERVER"
 
 # attempt to retain the previous crash directory (within the configured window to avoid filling the disk)
-crashcount=$(find $NUODB_CRASHDIR/core* -maxdepth 1 ! -type d | wc -l)
+crashcount=$(find $NUODB_CRASHDIR/core* -maxdepth 0 ! -type d | wc -l)
 if [ $crashcount -ge 1 ]; then
-  retainedcrashcount=$(find $NUODB_LOGDIR/crash-* -maxdepth 1 -type d -cmin -$OVERWRITE_WINDOW | wc -l)
+  retainedcrashcount=$(find $NUODB_LOGDIR/crash-* -maxdepth 0 -type d -cmin -$OVERWRITE_WINDOW | wc -l)
   if [ $retainedcrashcount -lt $OVERWRITE_COPIES ]; then
     crashbackupdir="$NUODB_LOGDIR/crash-$( date +%Y%m%dT%H%M%S )/"
     mkdir $crashbackupdir

--- a/stable/database/files/nuosm
+++ b/stable/database/files/nuosm
@@ -22,12 +22,13 @@ NUODB_BINDIR=$NUODB_HOME/bin
 [ -z "$NUOCMD" ] && NUOCMD="$NUODB_BINDIR/nuocmd --api-server $NUOCMD_API_SERVER"
 
 # attempt to retain the previous crash directory (within the configured window to avoid filling the disk)
-if [ -f $NUODB_CRASHDIR/* ]; then
-  crashcount=$(find $NUODB_LOGDIR/crash-* -type d -cmin -$OVERWRITE_WINDOW ! -path . | wc -l)
-  if [ $crashcount -lt $OVERWRITE_COPIES ]; then
+crashcount=$(find $NUODB_CRASHDIR/core* -maxdepth 1 ! -type d | wc -l)
+if [ $crashcount -ge 1 ]; then
+  retainedcrashcount=$(find $NUODB_LOGDIR/crash-* -maxdepth 1 -type d -cmin -$OVERWRITE_WINDOW | wc -l)
+  if [ $retainedcrashcount -lt $OVERWRITE_COPIES ]; then
     crashbackupdir="$NUODB_LOGDIR/crash-$( date +%Y%m%dT%H%M%S )/"
     mkdir $crashbackupdir
-    mv $NUODB_CRASHDIR/* $crashbackupdir
+    mv $NUODB_CRASHDIR/core* $crashbackupdir
   fi
 fi
 

--- a/stable/database/files/nuote
+++ b/stable/database/files/nuote
@@ -5,12 +5,13 @@ export NUODB_CRASHDIR="$NUODB_LOGDIR"/crash
 mkdir -p $NUODB_CRASHDIR
 
 # attempt to retain the previous crash directory (within the configured window to avoid filling the disk)
-if [ -f $NUODB_CRASHDIR/* ]; then
-  crashcount=$(find $NUODB_LOGDIR/crash-* -type d -cmin -$OVERWRITE_WINDOW ! -path . | wc -l)
-  if [ $crashcount -lt $OVERWRITE_COPIES ]; then
+crashcount=$(find $NUODB_CRASHDIR/core* -maxdepth 1 ! -type d | wc -l)
+if [ $crashcount -ge 1 ]; then
+  retainedcrashcount=$(find $NUODB_LOGDIR/crash-* -maxdepth 1 -type d -cmin -$OVERWRITE_WINDOW | wc -l)
+  if [ $retainedcrashcount -lt $OVERWRITE_COPIES ]; then
     crashbackupdir="$NUODB_LOGDIR/crash-$( date +%Y%m%dT%H%M%S )/"
     mkdir $crashbackupdir
-    mv $NUODB_CRASHDIR/* $crashbackupdir
+    mv $NUODB_CRASHDIR/core* $crashbackupdir
   fi
 fi
 

--- a/stable/database/files/nuote
+++ b/stable/database/files/nuote
@@ -5,9 +5,9 @@ export NUODB_CRASHDIR="$NUODB_LOGDIR"/crash
 mkdir -p $NUODB_CRASHDIR
 
 # attempt to retain the previous crash directory (within the configured window to avoid filling the disk)
-crashcount=$(find $NUODB_CRASHDIR/core* -maxdepth 1 ! -type d | wc -l)
+crashcount=$(find $NUODB_CRASHDIR/core* -maxdepth 0 ! -type d | wc -l)
 if [ $crashcount -ge 1 ]; then
-  retainedcrashcount=$(find $NUODB_LOGDIR/crash-* -maxdepth 1 -type d -cmin -$OVERWRITE_WINDOW | wc -l)
+  retainedcrashcount=$(find $NUODB_LOGDIR/crash-* -maxdepth 0 -type d -cmin -$OVERWRITE_WINDOW | wc -l)
   if [ $retainedcrashcount -lt $OVERWRITE_COPIES ]; then
     crashbackupdir="$NUODB_LOGDIR/crash-$( date +%Y%m%dT%H%M%S )/"
     mkdir $crashbackupdir

--- a/test/minikube/minikube_crash_handling_test.go
+++ b/test/minikube/minikube_crash_handling_test.go
@@ -37,6 +37,7 @@ func verifyKillAndInfoInLog(t *testing.T, namespaceName string, adminPodName str
 	// check that the core was moved to a dated crash directory for managing the number of core dumps
 	kubectlOptions := k8s.NewKubectlOptions("", "", namespaceName)
 	output, err := k8s.RunKubectlAndGetOutputE(t, kubectlOptions, "exec", podName, "--", "find", "/var/log/nuodb/crash-*", "-maxdepth", "0", "-type", "d", "|", "wc", "-l")
+	assert.NoError(t, err, output)
 	assert.Equal(t, output, 1)
 }
 

--- a/test/minikube/minikube_crash_handling_test.go
+++ b/test/minikube/minikube_crash_handling_test.go
@@ -36,7 +36,7 @@ func verifyKillAndInfoInLog(t *testing.T, namespaceName string, adminPodName str
 
 	// check that the core was moved to a dated crash directory for managing the number of core dumps
 	kubectlOptions := k8s.NewKubectlOptions("", "", namespaceName)
-	output, err := k8s.RunKubectlAndGetOutputE(t, kubectlOptions, "exec", podName, "--", "find", "/var/log/nuodb/crash-*", "-maxdepth", "0", "-type", "d", "|", "wc", "-l")
+	output, err := k8s.RunKubectlAndGetOutputE(t, kubectlOptions, "exec", podName, "--", "sh", "-c", "'find /var/log/nuodb/crash-* -maxdepth 0 -type d | wc -l'")
 	assert.NoError(t, err, output)
 	assert.Equal(t, output, 1)
 }

--- a/test/minikube/minikube_crash_handling_test.go
+++ b/test/minikube/minikube_crash_handling_test.go
@@ -33,6 +33,10 @@ func verifyKillAndInfoInLog(t *testing.T, namespaceName string, adminPodName str
 		&corev1.PodLogOptions {Previous:true})
 
 	assert.Greater(t, stringOccurrence, 0, "Could not find core parsing in log file")
+
+	// check that the core was moved to a dated crash directory for managing the number of core dumps
+	output, err := k8s.RunKubectlAndGetOutputE(t, kubectlOptions, "exec", podName, "--", "find", "/var/log/nuodb/crash-*", "-maxdepth", "0", "-type", "d", "|", "wc", "-l")
+	assert.Equal(t, output, 1)
 }
 
 func TestKubernetesPrintCores(t *testing.T) {

--- a/test/minikube/minikube_crash_handling_test.go
+++ b/test/minikube/minikube_crash_handling_test.go
@@ -35,6 +35,7 @@ func verifyKillAndInfoInLog(t *testing.T, namespaceName string, adminPodName str
 	assert.Greater(t, stringOccurrence, 0, "Could not find core parsing in log file")
 
 	// check that the core was moved to a dated crash directory for managing the number of core dumps
+	kubectlOptions := k8s.NewKubectlOptions("", "", namespaceName)
 	output, err := k8s.RunKubectlAndGetOutputE(t, kubectlOptions, "exec", podName, "--", "find", "/var/log/nuodb/crash-*", "-maxdepth", "0", "-type", "d", "|", "wc", "-l")
 	assert.Equal(t, output, 1)
 }


### PR DESCRIPTION
- Modified crash dump management to avoid error when multiple files or folders exist in the crash directory, such as when different PIDs happened to be used or users modify the directory.
- Added test to ensure dated crash dirs are used

Reminder: the purpose of this was to keep around the original core of a given episode of crashes, which gets overwritten when the PID is the same (often), while trying not to fill up the log persistence disk if it is used using a configurable backoff.

It also appears we do not produced compressed dumps, this is being looked at separately.

Full lifecycle test performed manually (requires 4+ kill cycles in automated tests, avoiding making tests longer than necessary). Results below:

Populated crash dir with two files and two folders before kill to check interference (this seemed to be Kalooms issue):
./crash
./crash/core-dir
./crash/core-dir/core-file
./crash/another-dir
./crash/another-dir/another-file
./crash/core-file
./crash/another-file

After 1st kill, anything prefixed core is moved to dated crash dir:
./crash
./crash/another-dir
./crash/another-dir/another-file
./crash/another-file
./crash-20200827T162230
./crash-20200827T162230/core-dir
./crash-20200827T162230/core-dir/core-file
./crash-20200827T162230/core-file
./crash-20200827T162230/core.nuodb.sm-database-nuodb-amazon0-t24-hotcopy-0.76

After 2nd kill, new core moves to new dated crash dir:
./crash
./crash/another-dir
./crash/another-dir/another-file
./crash/another-file
./crash-20200827T162230
./crash-20200827T162230/core-dir
./crash-20200827T162230/core-dir/core-file
./crash-20200827T162230/core-file
./crash-20200827T162230/core.nuodb.sm-database-nuodb-amazon0-t24-hotcopy-0.76
./crash-20200827T162534
./crash-20200827T162534/core.nuodb.sm-database-nuodb-amazon0-t24-hotcopy-0.82

After 3rd kill, another new core moves to another new dated crash dir::
./crash
./crash/another-dir
./crash/another-dir/another-file
./crash/another-file
./crash-20200827T162230
./crash-20200827T162230/core-dir
./crash-20200827T162230/core-dir/core-file
./crash-20200827T162230/core-file
./crash-20200827T162230/core.nuodb.sm-database-nuodb-amazon0-t24-hotcopy-0.76
./crash-20200827T162534
./crash-20200827T162534/core.nuodb.sm-database-nuodb-amazon0-t24-hotcopy-0.82
./crash-20200827T162831
./crash-20200827T162831/core.nuodb.sm-database-nuodb-amazon0-t24-hotcopy-0.82

After 4th kill, core remains in undated crash dir:
./crash
./crash/another-dir
./crash/another-dir/another-file
./crash/another-file
./crash/core.nuodb.sm-database-nuodb-amazon0-t24-hotcopy-0.82
./crash-20200827T162230
./crash-20200827T162230/core-dir
./crash-20200827T162230/core-dir/core-file
./crash-20200827T162230/core-file
./crash-20200827T162230/core.nuodb.sm-database-nuodb-amazon0-t24-hotcopy-0.76
./crash-20200827T162534
./crash-20200827T162534/core.nuodb.sm-database-nuodb-amazon0-t24-hotcopy-0.82
./crash-20200827T162831
./crash-20200827T162831/core.nuodb.sm-database-nuodb-amazon0-t24-hotcopy-0.82

After 5th, 6th and 7th kill, another core remains in crash dir (one new pid(79) was re-used 3 times).  Note a .gz exists with same PID which NuoDB was not able to extract
./crash
./crash/another-dir
./crash/another-dir/another-file
./crash/another-file
./crash/core.nuodb.sm-database-nuodb-amazon0-t24-hotcopy-0.82
./crash/core.nuodb.sm-database-nuodb-amazon0-t24-hotcopy-0.79
./crash/core.nuodb.sm-database-nuodb-amazon0-t24-hotcopy-0.79.gz
./crash-20200827T162230
./crash-20200827T162230/core-dir
./crash-20200827T162230/core-dir/core-file
./crash-20200827T162230/core-file
./crash-20200827T162230/core.nuodb.sm-database-nuodb-amazon0-t24-hotcopy-0.76
./crash-20200827T162534
./crash-20200827T162534/core.nuodb.sm-database-nuodb-amazon0-t24-hotcopy-0.82
./crash-20200827T162831
./crash-20200827T162831/core.nuodb.sm-database-nuodb-amazon0-t24-hotcopy-0.82

After waiting for the window to pass, 8th kill moves anything in crash dir to another dated folder:
18:12
./crash
./crash/another-dir
./crash/another-dir/another-file
./crash/another-file
./crash-20200827T162230
./crash-20200827T162230/core-dir
./crash-20200827T162230/core-dir/core-file
./crash-20200827T162230/core-file
./crash-20200827T162230/core.nuodb.sm-database-nuodb-amazon0-t24-hotcopy-0.76
./crash-20200827T162534
./crash-20200827T162534/core.nuodb.sm-database-nuodb-amazon0-t24-hotcopy-0.82
./crash-20200827T162831
./crash-20200827T162831/core.nuodb.sm-database-nuodb-amazon0-t24-hotcopy-0.82
./crash-20200827T170359
./crash-20200827T170359/core.nuodb.sm-database-nuodb-amazon0-t24-hotcopy-0.79
./crash-20200827T170359/core.nuodb.sm-database-nuodb-amazon0-t24-hotcopy-0.79.gz
./crash-20200827T170359/core.nuodb.sm-database-nuodb-amazon0-t24-hotcopy-0.82