### PR TITLE
Add DaemonSets to list of NuoDB Kubernetes Aware Admin permissions

### DIFF
--- a/stable/admin/templates/role.yaml
+++ b/stable/admin/templates/role.yaml
@@ -18,6 +18,7 @@ rules:
   resources:
   - deployments
   - statefulsets
+  - daemonsets
   verbs:
   - get
   - list

--- a/test/testlib/NuoDBKubeConfig.go
+++ b/test/testlib/NuoDBKubeConfig.go
@@ -3,21 +3,22 @@ package testlib
 import (
 	"encoding/json"
 	"io"
+	"strings"
+
 	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	"strings"
 )
 
 type NuoDBKubeConfig struct {
-	Pods map[string]corev1.Pod `json:"pods"`
-	Deployments map[string]v1.Deployment `json:"deployments"`
+	Pods         map[string]corev1.Pod     `json:"pods"`
+	Deployments  map[string]v1.Deployment  `json:"deployments"`
 	StatefulSets map[string]v1.StatefulSet `json:"statefulsets"`
-	Volumes map[string]corev1.Volume `json:"volumes"`
+	Volumes      map[string]corev1.Volume  `json:"volumes"`
+	DaemonSets   map[string]v1.DaemonSet   `json:"daemonSets"`
 }
 
 func UnmarshalNuoDBKubeConfig(s string) (err error, kubeConfigs []NuoDBKubeConfig) {
 	dec := json.NewDecoder(strings.NewReader(s))
-
 
 	for {
 		var obj NuoDBKubeConfig


### PR DESCRIPTION
This is required for NuoDB 4.0.7 KAA.