### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -28,3 +28,6 @@ A clear and concise description of what you expected to happen.
 
 **Additional context**
 Add any other context about the problem here.
+
+**External Reference**
+ZenDesk/JIRA numbers if available

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,30 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**Context**
+NuoDB Version: [e.g. 4.0.6]
+Helm Charts Version: [e.g. 2.4.0]
+Kubernetes Version: [e.g. v1.18]
+Environment: [e.g. OCP, vanilla, Rancher, CRC, minikube...]
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Install '...'
+2. kubectl '...'
+3. nuocmd '...'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Additional context**
+Add any other context about the problem here.


### PR DESCRIPTION
Do not have a bug template set up. This proposal will create a default template for anyone who files issues against this GitHub repo.

It will show up here:
https://github.com/nuodb/nuodb-helm-charts/issues/new
