### PR TITLE
Bump NuoDB version to 4.0.7 [2.4-dev branch]

### DIFF
--- a/stable/admin/values.yaml
+++ b/stable/admin/values.yaml
@@ -49,7 +49,7 @@ nuodb:
   image:
     registry: docker.io
     repository: nuodb/nuodb-ce
-    tag: 4.0.6
+    tag: 4.0.7
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/stable/database/values.yaml
+++ b/stable/database/values.yaml
@@ -41,7 +41,7 @@ nuodb:
   image:
     registry: docker.io
     repository: nuodb/nuodb-ce
-    tag: 4.0.6
+    tag: 4.0.7
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/stable/restore/values.yaml
+++ b/stable/restore/values.yaml
@@ -32,7 +32,7 @@ nuodb:
   image:
     registry: docker.io
     repository: nuodb/nuodb-ce
-    tag: 4.0.6
+    tag: 4.0.7
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/test/minikube/minikube_rolling_upgrade_test.go
+++ b/test/minikube/minikube_rolling_upgrade_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 const OLD_RELEASE = "4.0"
-const NEW_RELEASE = "4.0.6"
+const NEW_RELEASE = "4.0.7"
 
 func verifyAllProcessesRunning(t *testing.T, namespaceName string, adminPod string, expectedNrProcesses int) {
 	testlib.Await(t, func() bool {

--- a/test/minikube/minikube_upgrade_helm_test.go
+++ b/test/minikube/minikube_upgrade_helm_test.go
@@ -25,7 +25,13 @@ func upgradeAdminTest(t *testing.T, nuodbVersion string, fromHelmVersion string)
 
 	defer testlib.Teardown(testlib.TEARDOWN_ADMIN)
 
+	testlib.AdminRolesRequirePatching = true
+	defer func() {
+		testlib.AdminRolesRequirePatching = false
+	}()
+
 	helmChartReleaseName, namespaceName := testlib.StartAdminFromHelmRepository(t, options, fromHelmVersion,1, "")
+
 	admin0 := fmt.Sprintf("%s-nuodb-cluster0-0", helmChartReleaseName)
 
 	testlib.AwaitBalancerTerminated(t, namespaceName, "job-lb-policy")
@@ -61,7 +67,13 @@ func upgradeDatabaseTest(t *testing.T, nuodbVersion string, fromHelmVersion stri
 
 	defer testlib.Teardown(testlib.TEARDOWN_ADMIN)
 
+	testlib.AdminRolesRequirePatching = true
+	defer func() {
+		testlib.AdminRolesRequirePatching = false
+	}()
+
 	helmChartReleaseName, namespaceName := testlib.StartAdminFromHelmRepository(t, options, fromHelmVersion,1, "")
+
 	admin0 := fmt.Sprintf("%s-nuodb-cluster0-0", helmChartReleaseName)
 
 	defer testlib.Teardown(testlib.TEARDOWN_DATABASE)

--- a/test/minikube/minikube_upgrade_helm_test.go
+++ b/test/minikube/minikube_upgrade_helm_test.go
@@ -20,6 +20,7 @@ func upgradeAdminTest(t *testing.T, nuodbVersion string, fromHelmVersion string)
 			"nuodb.image.registry": "docker.io",
 			"nuodb.image.repository": "nuodb/nuodb-ce",
 			"nuodb.image.tag": nuodbVersion,
+			"admin.bootstrapServers": "0",
 		},
 	}
 
@@ -58,6 +59,7 @@ func upgradeDatabaseTest(t *testing.T, nuodbVersion string, fromHelmVersion stri
 			"nuodb.image.registry": "docker.io",
 			"nuodb.image.repository": "nuodb/nuodb-ce",
 			"nuodb.image.tag": nuodbVersion,
+			"admin.bootstrapServers": "0",
 			"database.sm.resources.requests.cpu":    "250m",
 			"database.sm.resources.requests.memory": "250Mi",
 			"database.te.resources.requests.cpu":    "250m",

--- a/test/minikube/minikube_upgrade_helm_test.go
+++ b/test/minikube/minikube_upgrade_helm_test.go
@@ -94,12 +94,12 @@ func upgradeDatabaseTest(t *testing.T, nuodbVersion string, fromHelmVersion stri
 
 func TestUpgradeHelm(t *testing.T) {
 	t.Run("NuoDB40X_From231_ToLocal", func(t *testing.T) {
-		upgradeAdminTest(t, "4.0.6", "2.3.1")
+		upgradeAdminTest(t, "4.0.7", "2.3.1")
 	})
 }
 
 func TestUpgradeHelmFullDB(t *testing.T) {
 	t.Run("NuoDB40X_From231_ToLocal", func(t *testing.T) {
-		upgradeDatabaseTest(t, "4.0.6", "2.3.1")
+		upgradeDatabaseTest(t, "4.0.7", "2.3.1")
 	})
 }

--- a/test/testlib/nuodb_admin_utilities.go
+++ b/test/testlib/nuodb_admin_utilities.go
@@ -103,7 +103,7 @@ func StartAdminTemplate(t *testing.T, options *helm.Options, replicaCount int, n
 
 	if AdminRolesRequirePatching {
 		// workaround for https://github.com/nuodb/nuodb-helm-charts/issues/140
-		output := helm.RenderTemplate(t, options, ADMIN_HELM_CHART_PATH, helmChartReleaseName, []string{"templates/role.yaml"})
+		output := helm.RenderTemplate(t, options, ADMIN_HELM_CHART_PATH, []string{"templates/role.yaml"})
 		k8s.RunKubectl(t, kubectlOptions, "patch", "role", "nuodb-kube-inspector", "-p", output)
 	}
 

--- a/test/testlib/nuodb_admin_utilities.go
+++ b/test/testlib/nuodb_admin_utilities.go
@@ -16,6 +16,8 @@ import (
 	"github.com/gruntwork-io/terratest/modules/random"
 )
 
+var AdminRolesRequirePatching = false
+
 func getFunctionCallerName() string {
 	pc, _, _, _ := runtime.Caller(3)
 	nameFull := runtime.FuncForPC(pc).Name() // main.foo
@@ -99,8 +101,7 @@ func StartAdminTemplate(t *testing.T, options *helm.Options, replicaCount int, n
 		AwaitNrReplicasScheduled(t, namespaceName, helmChartReleaseName, replicaCount)
 	}
 
-	admin0Pod := GetPod(t, namespaceName, adminNames[0])
-	if admin0Pod.Spec.Containers[0].Image == "docker.io/nuodb/nuodb-ce:4.0.7" {
+	if AdminRolesRequirePatching {
 		// workaround for https://github.com/nuodb/nuodb-helm-charts/issues/140
 		output := helm.RenderTemplate(t, options, ADMIN_HELM_CHART_PATH, helmChartReleaseName, []string{"templates/role.yaml"})
 		k8s.RunKubectl(t, kubectlOptions, "patch", "role", "nuodb-kube-inspector", "-p", output)

--- a/test/testlib/nuodb_admin_utilities.go
+++ b/test/testlib/nuodb_admin_utilities.go
@@ -99,6 +99,13 @@ func StartAdminTemplate(t *testing.T, options *helm.Options, replicaCount int, n
 		AwaitNrReplicasScheduled(t, namespaceName, helmChartReleaseName, replicaCount)
 	}
 
+	admin0Pod := GetPod(t, namespaceName, adminNames[0])
+	if admin0Pod.Spec.Containers[0].Image == "docker.io/nuodb/nuodb-ce:4.0.7" {
+		// workaround for https://github.com/nuodb/nuodb-helm-charts/issues/140
+		output := helm.RenderTemplate(t, options, ADMIN_HELM_CHART_PATH, helmChartReleaseName, []string{"templates/role.yaml"})
+		k8s.RunKubectl(t, kubectlOptions, "patch", "role", "nuodb-kube-inspector", "-p", output)
+	}
+
 	for i := 0; i < replicaCount; i++ {
 		adminName := adminNames[i] // array will be out of scope for defer
 


### PR DESCRIPTION
Besides changing the default version of NuoDB in the charts, this PR contains two upgrade workarounds for issues:
#140
#143