### PR TITLE
Improve tests for OpenShift 4.5.7 CodeReadyContainers 

### DIFF
--- a/test/minikube/minikube_rolling_upgrade_test.go
+++ b/test/minikube/minikube_rolling_upgrade_test.go
@@ -91,7 +91,7 @@ func TestKubernetesUpgradeFullDatabaseMinorVersion(t *testing.T) {
 		SetValues: map[string]string{
 			"database.sm.resources.requests.cpu":    testlib.MINIMAL_VIABLE_ENGINE_CPU,
 			"database.sm.resources.requests.memory": testlib.MINIMAL_VIABLE_ENGINE_MEMORY,
-			"database.te.resources.requests.cpu":    "250m", // during upgrade we will be running 2 of these
+			"database.te.resources.requests.cpu":    testlib.MINIMAL_VIABLE_ENGINE_CPU,
 			"database.te.resources.requests.memory": testlib.MINIMAL_VIABLE_ENGINE_MEMORY,
 			"nuodb.image.registry":                  "docker.io",
 			"nuodb.image.repository":                "nuodb/nuodb-ce",
@@ -121,6 +121,9 @@ func TestKubernetesUpgradeFullDatabaseMinorVersion(t *testing.T) {
 
 	t.Run("verifyAdminState", func(t *testing.T) { testlib.VerifyAdminState(t, namespaceName, admin0) })
 
+	opt := testlib.GetExtractedOptions(&databaseOptions)
+	testlib.AwaitDatabaseUp(t, namespaceName, admin0, opt.DbName, opt.NrSmPods+opt.NrTePods)
+
 	t.Run("expectAllEnginesReconnect", func(t *testing.T) {
 		expectedNumberReconnects := 2
 
@@ -138,6 +141,9 @@ func TestKubernetesUpgradeFullDatabaseMinorVersion(t *testing.T) {
 		expectedNewDatabaseVersion := testlib.GetUpgradedReleaseVersion(t, &databaseOptions, NEW_RELEASE)
 
 		helm.Upgrade(t, &databaseOptions, testlib.DATABASE_HELM_CHART_PATH, databaseHelmChartReleaseName)
+
+		// make sure that we only have 1 TE and not 2
+		testlib.SetDeploymentUpgradeStrategyToRecreate(t, namespaceName, fmt.Sprintf("te-%s-nuodb-cluster0-demo", databaseHelmChartReleaseName))
 
 		testlib.AwaitPodTemplateHasVersion(t, namespaceName, "sm-database", expectedNewDatabaseVersion, 300*time.Second)
 		testlib.AwaitPodTemplateHasVersion(t, namespaceName, "te-database", expectedNewDatabaseVersion, 300*time.Second)

--- a/test/minikube/minikube_rolling_upgrade_test.go
+++ b/test/minikube/minikube_rolling_upgrade_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/gruntwork-io/terratest/modules/helm"
 	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/nuodb/nuodb-helm-charts/test/testlib"
-
 )
 
 const OLD_RELEASE = "4.0"

--- a/test/minikube/minikube_tls_admin_test.go
+++ b/test/minikube/minikube_tls_admin_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/nuodb/nuodb-helm-charts/test/testlib"
 
-
 	"github.com/gruntwork-io/terratest/modules/helm"
 	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/gruntwork-io/terratest/modules/random"
@@ -35,10 +34,6 @@ func verifyKeystore(t *testing.T, namespace string, podName string, keystore str
 }
 
 func TestKubernetesTLS(t *testing.T) {
-	if testlib.IsOpenShiftEnvironment(t) {
-		t.Skip("TLS subPath bind does not work as expected")
-	}
-
 	testlib.AwaitTillerUp(t)
 	defer testlib.VerifyTeardown(t)
 

--- a/test/minikube/minikube_tls_rotation_test.go
+++ b/test/minikube/minikube_tls_rotation_test.go
@@ -51,10 +51,6 @@ func startDomainWithTLSCertificates(t *testing.T, options *helm.Options, namespa
 }
 
 func TestKubernetesTLSRotation(t *testing.T) {
-	if testlib.IsOpenShiftEnvironment(t) {
-		t.Skip("TLS subPath bind does not work as expected")
-	}
-
 	testlib.AwaitTillerUp(t)
 	defer testlib.VerifyTeardown(t)
 

--- a/test/testlib/minikube_utilities.go
+++ b/test/testlib/minikube_utilities.go
@@ -166,6 +166,17 @@ func RemoveEmptyLines(s string) string {
 	return s
 }
 
+func InjectOpenShiftOverrides(t *testing.T, options *helm.Options) {
+	if options.SetValues["admin.readinessTimeoutSeconds"] != "" {
+		return
+	}
+
+	t.Log("Using OpenShift specific injects")
+
+	// OpenShift and CodeReadyContainers readiness probes are slower
+	options.SetValues["admin.readinessTimeoutSeconds"] = "5"
+}
+
 func InjectTestValuesFile(t *testing.T, options *helm.Options) {
 	dat, err := ioutil.ReadFile(INJECT_VALUES_FILE)
 	if err != nil {
@@ -207,6 +218,7 @@ func InjectTestVersion(t *testing.T, options *helm.Options) {
 
 func InjectTestValues(t *testing.T, options *helm.Options) {
 	InjectTestValuesFile(t, options)
+	InjectOpenShiftOverrides(t, options)
 	InjectTestVersion(t, options)
 }
 

--- a/test/testlib/minikube_utilities.go
+++ b/test/testlib/minikube_utilities.go
@@ -167,11 +167,16 @@ func RemoveEmptyLines(s string) string {
 }
 
 func InjectOpenShiftOverrides(t *testing.T, options *helm.Options) {
-	if options.SetValues["admin.readinessTimeoutSeconds"] != "" {
+	if !IsOpenShiftEnvironment(t) ||
+		options.SetValues["admin.readinessTimeoutSeconds"] != "" {
 		return
 	}
 
 	t.Log("Using OpenShift specific injects")
+
+	if options.SetValues == nil {
+		options.SetValues = make(map[string]string)
+	}
 
 	// OpenShift and CodeReadyContainers readiness probes are slower
 	options.SetValues["admin.readinessTimeoutSeconds"] = "5"

--- a/test/testlib/nuodb_database_utilities.go
+++ b/test/testlib/nuodb_database_utilities.go
@@ -71,6 +71,16 @@ func StartDatabaseTemplate(t *testing.T, namespaceName string, adminPod string, 
 	InjectTestValues(t, options)
 	opt := GetExtractedOptions(options)
 
+	if IsOpenShiftEnvironment(t) {
+		THPReleaseName := fmt.Sprintf("thp-%s", randomSuffix)
+		AddTeardown(TEARDOWN_DATABASE, func() {
+			helm.Delete(t, options, THPReleaseName, true)
+		})
+		helm.Install(t, options, THP_HELM_CHART_PATH, THPReleaseName)
+
+		AwaitNrReplicasReady(t , namespaceName, THPReleaseName, 1)
+	}
+
 	helmChartReleaseName = fmt.Sprintf("database-%s", randomSuffix)
 	tePodNameTemplate := fmt.Sprintf("te-%s-nuodb-%s-%s", helmChartReleaseName, opt.ClusterName, opt.DbName)
 	smPodName := fmt.Sprintf("sm-%s-nuodb-%s-%s", helmChartReleaseName, opt.ClusterName, opt.DbName)

--- a/test/testlib/nuodb_database_utilities.go
+++ b/test/testlib/nuodb_database_utilities.go
@@ -14,6 +14,14 @@ import (
 	"github.com/gruntwork-io/terratest/modules/random"
 )
 
+const UPGRADE_STRATEGY = `
+spec:
+  strategy:
+    $retainKeys:
+    - type
+    type: Recreate
+`
+
 type ExtractedOptions struct {
 	NrTePods          int
 	NrSmHotCopyPods   int
@@ -128,4 +136,9 @@ func StartDatabase(t *testing.T, namespace string, adminPod string, options *hel
 			helm.Install(t, options, "nuodb/database", helmChartReleaseName)
 		}
 	})
+}
+
+func SetDeploymentUpgradeStrategyToRecreate(t *testing.T, namespaceName string, deploymentName string) {
+	kubectlOptions := k8s.NewKubectlOptions("", "", namespaceName)
+	k8s.RunKubectl(t, kubectlOptions, "patch", "deployment", deploymentName, "-p", UPGRADE_STRATEGY)
 }


### PR DESCRIPTION
- CRC does not have THP disabled. Minikube does. In case the test are being run in OCP, disable them automatically.
- the admin readiness probe timeout of 1s is not long enough. Make it 5s. Same as the DB charts
- TLS test work in OCP 4+. Remove the guards.