### PR TITLE
Start Kubernetes Aware Admin module with limited permissions

### DIFF
--- a/test/minikube/minikube_domain_resync_test.go
+++ b/test/minikube/minikube_domain_resync_test.go
@@ -10,9 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
@@ -24,12 +22,9 @@ import (
 
 	"github.com/nuodb/nuodb-helm-charts/test/testlib"
 
-	"github.com/ghodss/yaml"
-
 	"github.com/gruntwork-io/terratest/modules/helm"
 	"github.com/gruntwork-io/terratest/modules/k8s"
 	appsv1 "k8s.io/api/apps/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -192,23 +187,6 @@ func checkInitialMembership(t assert.TestingT, configJson string, expectedSize i
 		assert.NoError(t, err, "Unable to deserialize admin config")
 	}
 	assert.Equal(t, expectedSize, len(adminConfig.InitialMembership))
-}
-
-func modifyKubeInspectorRoleInPlace(t *testing.T, modificationFunc func(role *rbacv1.Role)) {
-	inspectorRoleFile := filepath.Join(testlib.ADMIN_HELM_CHART_PATH, "templates", "role.yaml")
-	originalData, err := ioutil.ReadFile(inspectorRoleFile)
-	assert.NoError(t, err)
-	testlib.AddTeardown(testlib.TEARDOWN_ADMIN, func() { ioutil.WriteFile(inspectorRoleFile, originalData, 0644) })
-
-	output := helm.RenderTemplate(t, &helm.Options{}, testlib.ADMIN_HELM_CHART_PATH, "release-name", []string{"templates/role.yaml"})
-	roles := testlib.SplitAndRenderRole(t, output, 1)
-	modificationFunc(&roles[0])
-	roleBytes, err := yaml.Marshal(&roles[0])
-	assert.NoError(t, err)
-	err = ioutil.WriteFile(inspectorRoleFile, roleBytes, 0644)
-	assert.NoError(t, err)
-	out, _ := ioutil.ReadFile(inspectorRoleFile)
-	t.Log("Modified roles file:\n" + string(out))
 }
 
 func TestReprovisionAdmin0(t *testing.T) {
@@ -488,61 +466,4 @@ func TestLoadBalancerConfigurationResync(t *testing.T) {
 	options.SetValues["admin.lbConfig.default"] = "random(first(label(node node1) any))"
 	options.SetValues["admin.lbConfig.policies.manual"] = "random(any)"
 	verifyLoadBalancer(t, namespaceName, admin0, options.SetValues)
-}
-
-func TestKaaLimitedPermissions(t *testing.T) {
-	if os.Getenv("NUODB_LICENSE") != "ENTERPRISE" {
-		t.Skip("This test requires NuoDB 4.1.1+")
-	}
-	testlib.AwaitTillerUp(t)
-	defer testlib.VerifyTeardown(t)
-	defer testlib.Teardown(testlib.TEARDOWN_ADMIN)
-
-	modifyKubeInspectorRoleInPlace(t, func(role *rbacv1.Role) {
-		// Remove "daemonsets" from the resources list
-		role.Rules[1].Resources = []string{"statefulsets", "deployments"}
-		// Remove "list" verb for pods and PVCs
-		// The KAA resync logic should not remove processes or archives due to missing permissions
-		role.Rules[0].Verbs = []string{"get", "watch"}
-	})
-
-	helmChartReleaseName, namespaceName := testlib.StartAdmin(t, &helm.Options{}, 1, "")
-
-	admin0 := fmt.Sprintf("%s-nuodb-cluster0-0", helmChartReleaseName)
-
-	defer testlib.Teardown(testlib.TEARDOWN_DATABASE)
-
-	databaseHelmChartReleaseName := testlib.StartDatabase(t, namespaceName, admin0, &helm.Options{
-		SetValues: map[string]string{
-			"database.sm.resources.requests.cpu":    testlib.MINIMAL_VIABLE_ENGINE_CPU,
-			"database.sm.resources.requests.memory": testlib.MINIMAL_VIABLE_ENGINE_MEMORY,
-			"database.te.resources.requests.cpu":    testlib.MINIMAL_VIABLE_ENGINE_CPU,
-			"database.te.resources.requests.memory": testlib.MINIMAL_VIABLE_ENGINE_MEMORY,
-		},
-	})
-
-	// Verify that KAA will not register informer for daemonsets
-	testlib.Await(t, func() bool {
-		return testlib.GetStringOccurrenceInLog(t, namespaceName, admin0,
-			"Informer for resource 'daemonsets' not registered", &v12.PodLogOptions{}) == 1
-	}, 30*time.Second)
-	// Verify that KAA will not register informer for pods
-	testlib.Await(t, func() bool {
-		return testlib.GetStringOccurrenceInLog(t, namespaceName, admin0,
-			"Informer for resource 'pods' not registered", &v12.PodLogOptions{}) == 1
-	}, 30*time.Second)
-	// Verify that KAA will not register informer for PVCs
-	testlib.Await(t, func() bool {
-		return testlib.GetStringOccurrenceInLog(t, namespaceName, admin0,
-			"Informer for resource 'persistentvolumeclaims' not registered", &v12.PodLogOptions{}) == 1
-	}, 30*time.Second)
-
-	// Verify that resources that KAA have permissions for are available
-	adminStatefulSet := fmt.Sprintf("%s-nuodb-cluster0", helmChartReleaseName)
-	teDeployment := fmt.Sprintf("te-%s-nuodb-cluster0-demo", databaseHelmChartReleaseName)
-	config := testlib.GetNuoDBK8sConfigDump(t, namespaceName, admin0)
-	assert.True(t, func() bool { _, ok := config.StatefulSets[adminStatefulSet]; return ok }())
-	assert.True(t, func() bool { _, ok := config.Deployments[teDeployment]; return ok }())
-	assert.True(t, len(config.Volumes) == 0)
-	assert.True(t, len(config.Pods) == 0)
 }

--- a/test/minikube/minikube_domain_resync_test.go
+++ b/test/minikube/minikube_domain_resync_test.go
@@ -10,20 +10,26 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	v12 "k8s.io/api/core/v1"
+	"io/ioutil"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
 	"time"
 
+	v12 "k8s.io/api/core/v1"
+
 	"github.com/stretchr/testify/assert"
 
 	"github.com/nuodb/nuodb-helm-charts/test/testlib"
 
+	"github.com/ghodss/yaml"
+
 	"github.com/gruntwork-io/terratest/modules/helm"
 	"github.com/gruntwork-io/terratest/modules/k8s"
 	appsv1 "k8s.io/api/apps/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -186,6 +192,23 @@ func checkInitialMembership(t assert.TestingT, configJson string, expectedSize i
 		assert.NoError(t, err, "Unable to deserialize admin config")
 	}
 	assert.Equal(t, expectedSize, len(adminConfig.InitialMembership))
+}
+
+func modifyKubeInspectorRoleInPlace(t *testing.T, modificationFunc func(role *rbacv1.Role)) {
+	inspectorRoleFile := filepath.Join(testlib.ADMIN_HELM_CHART_PATH, "templates", "role.yaml")
+	originalData, err := ioutil.ReadFile(inspectorRoleFile)
+	assert.NoError(t, err)
+	testlib.AddTeardown(testlib.TEARDOWN_ADMIN, func() { ioutil.WriteFile(inspectorRoleFile, originalData, 0644) })
+
+	output := helm.RenderTemplate(t, &helm.Options{}, testlib.ADMIN_HELM_CHART_PATH, "release-name", []string{"templates/role.yaml"})
+	roles := testlib.SplitAndRenderRole(t, output, 1)
+	modificationFunc(&roles[0])
+	roleBytes, err := yaml.Marshal(&roles[0])
+	assert.NoError(t, err)
+	err = ioutil.WriteFile(inspectorRoleFile, roleBytes, 0644)
+	assert.NoError(t, err)
+	out, _ := ioutil.ReadFile(inspectorRoleFile)
+	t.Log("Modified roles file:\n" + string(out))
 }
 
 func TestReprovisionAdmin0(t *testing.T) {
@@ -465,4 +488,61 @@ func TestLoadBalancerConfigurationResync(t *testing.T) {
 	options.SetValues["admin.lbConfig.default"] = "random(first(label(node node1) any))"
 	options.SetValues["admin.lbConfig.policies.manual"] = "random(any)"
 	verifyLoadBalancer(t, namespaceName, admin0, options.SetValues)
+}
+
+func TestKaaLimitedPermissions(t *testing.T) {
+	if os.Getenv("NUODB_LICENSE") != "ENTERPRISE" {
+		t.Skip("This test requires NuoDB 4.1.1+")
+	}
+	testlib.AwaitTillerUp(t)
+	defer testlib.VerifyTeardown(t)
+	defer testlib.Teardown(testlib.TEARDOWN_ADMIN)
+
+	modifyKubeInspectorRoleInPlace(t, func(role *rbacv1.Role) {
+		// Remove "daemonsets" from the resources list
+		role.Rules[1].Resources = []string{"statefulsets", "deployments"}
+		// Remove "list" verb for pods and PVCs
+		// The KAA resync logic should not remove processes or archives due to missing permissions
+		role.Rules[0].Verbs = []string{"get", "watch"}
+	})
+
+	helmChartReleaseName, namespaceName := testlib.StartAdmin(t, &helm.Options{}, 1, "")
+
+	admin0 := fmt.Sprintf("%s-nuodb-cluster0-0", helmChartReleaseName)
+
+	defer testlib.Teardown(testlib.TEARDOWN_DATABASE)
+
+	databaseHelmChartReleaseName := testlib.StartDatabase(t, namespaceName, admin0, &helm.Options{
+		SetValues: map[string]string{
+			"database.sm.resources.requests.cpu":    testlib.MINIMAL_VIABLE_ENGINE_CPU,
+			"database.sm.resources.requests.memory": testlib.MINIMAL_VIABLE_ENGINE_MEMORY,
+			"database.te.resources.requests.cpu":    testlib.MINIMAL_VIABLE_ENGINE_CPU,
+			"database.te.resources.requests.memory": testlib.MINIMAL_VIABLE_ENGINE_MEMORY,
+		},
+	})
+
+	// Verify that KAA will not register informer for daemonsets
+	testlib.Await(t, func() bool {
+		return testlib.GetStringOccurrenceInLog(t, namespaceName, admin0,
+			"Informer for resource 'daemonsets' not registered", &v12.PodLogOptions{}) == 1
+	}, 30*time.Second)
+	// Verify that KAA will not register informer for pods
+	testlib.Await(t, func() bool {
+		return testlib.GetStringOccurrenceInLog(t, namespaceName, admin0,
+			"Informer for resource 'pods' not registered", &v12.PodLogOptions{}) == 1
+	}, 30*time.Second)
+	// Verify that KAA will not register informer for PVCs
+	testlib.Await(t, func() bool {
+		return testlib.GetStringOccurrenceInLog(t, namespaceName, admin0,
+			"Informer for resource 'persistentvolumeclaims' not registered", &v12.PodLogOptions{}) == 1
+	}, 30*time.Second)
+
+	// Verify that resources that KAA have permissions for are available
+	adminStatefulSet := fmt.Sprintf("%s-nuodb-cluster0", helmChartReleaseName)
+	teDeployment := fmt.Sprintf("te-%s-nuodb-cluster0-demo", databaseHelmChartReleaseName)
+	config := testlib.GetNuoDBK8sConfigDump(t, namespaceName, admin0)
+	assert.True(t, func() bool { _, ok := config.StatefulSets[adminStatefulSet]; return ok }())
+	assert.True(t, func() bool { _, ok := config.Deployments[teDeployment]; return ok }())
+	assert.True(t, len(config.Volumes) == 0)
+	assert.True(t, len(config.Pods) == 0)
 }

--- a/test/minikube/minikube_kaa_additions_test.go
+++ b/test/minikube/minikube_kaa_additions_test.go
@@ -1,7 +1,5 @@
 // +build enterprise
 
-// tests in this file require NuoDB 4.0.7 or newer
-
 package minikube
 
 import (

--- a/test/minikube/minikube_kaa_additions_test.go
+++ b/test/minikube/minikube_kaa_additions_test.go
@@ -1,0 +1,96 @@
+// +build enterprise
+
+// tests in this file require NuoDB 4.0.7 or newer
+
+package minikube
+
+import (
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	"testing"
+	"time"
+
+	v12 "k8s.io/api/core/v1"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/nuodb/nuodb-helm-charts/test/testlib"
+
+	"github.com/ghodss/yaml"
+
+	"github.com/gruntwork-io/terratest/modules/helm"
+	rbacv1 "k8s.io/api/rbac/v1"
+)
+
+func modifyKubeInspectorRoleInPlace(t *testing.T, modificationFunc func(role *rbacv1.Role)) {
+	inspectorRoleFile := filepath.Join(testlib.ADMIN_HELM_CHART_PATH, "templates", "role.yaml")
+	originalData, err := ioutil.ReadFile(inspectorRoleFile)
+	assert.NoError(t, err)
+	testlib.AddTeardown(testlib.TEARDOWN_ADMIN, func() { ioutil.WriteFile(inspectorRoleFile, originalData, 0644) })
+
+	output := helm.RenderTemplate(t, &helm.Options{}, testlib.ADMIN_HELM_CHART_PATH, "release-name", []string{"templates/role.yaml"})
+	roles := testlib.SplitAndRenderRole(t, output, 1)
+	modificationFunc(&roles[0])
+	roleBytes, err := yaml.Marshal(&roles[0])
+	assert.NoError(t, err)
+	err = ioutil.WriteFile(inspectorRoleFile, roleBytes, 0644)
+	assert.NoError(t, err)
+	out, _ := ioutil.ReadFile(inspectorRoleFile)
+	t.Log("Modified roles file:\n" + string(out))
+}
+
+func TestKaaLimitedPermissions(t *testing.T) {
+	// This test requires NuoDB 4.1.1+
+	testlib.AwaitTillerUp(t)
+	defer testlib.VerifyTeardown(t)
+	defer testlib.Teardown(testlib.TEARDOWN_ADMIN)
+
+	modifyKubeInspectorRoleInPlace(t, func(role *rbacv1.Role) {
+		// Remove "daemonsets" from the resources list
+		role.Rules[1].Resources = []string{"statefulsets", "deployments"}
+		// Remove "list" verb for pods and PVCs
+		// The KAA resync logic should not remove processes or archives due to missing permissions
+		role.Rules[0].Verbs = []string{"get", "watch"}
+	})
+
+	helmChartReleaseName, namespaceName := testlib.StartAdmin(t, &helm.Options{}, 1, "")
+
+	admin0 := fmt.Sprintf("%s-nuodb-cluster0-0", helmChartReleaseName)
+
+	defer testlib.Teardown(testlib.TEARDOWN_DATABASE)
+
+	databaseHelmChartReleaseName := testlib.StartDatabase(t, namespaceName, admin0, &helm.Options{
+		SetValues: map[string]string{
+			"database.sm.resources.requests.cpu":    testlib.MINIMAL_VIABLE_ENGINE_CPU,
+			"database.sm.resources.requests.memory": testlib.MINIMAL_VIABLE_ENGINE_MEMORY,
+			"database.te.resources.requests.cpu":    testlib.MINIMAL_VIABLE_ENGINE_CPU,
+			"database.te.resources.requests.memory": testlib.MINIMAL_VIABLE_ENGINE_MEMORY,
+		},
+	})
+
+	// Verify that KAA will not register informer for daemonsets
+	testlib.Await(t, func() bool {
+		return testlib.GetStringOccurrenceInLog(t, namespaceName, admin0,
+			"Informer for resource 'daemonsets' not registered", &v12.PodLogOptions{}) == 1
+	}, 30*time.Second)
+	// Verify that KAA will not register informer for pods
+	testlib.Await(t, func() bool {
+		return testlib.GetStringOccurrenceInLog(t, namespaceName, admin0,
+			"Informer for resource 'pods' not registered", &v12.PodLogOptions{}) == 1
+	}, 30*time.Second)
+	// Verify that KAA will not register informer for PVCs
+	testlib.Await(t, func() bool {
+		return testlib.GetStringOccurrenceInLog(t, namespaceName, admin0,
+			"Informer for resource 'persistentvolumeclaims' not registered", &v12.PodLogOptions{}) == 1
+	}, 30*time.Second)
+
+	// Verify that resources that KAA have permissions for are available
+	adminStatefulSet := fmt.Sprintf("%s-nuodb-cluster0", helmChartReleaseName)
+	teDeployment := fmt.Sprintf("te-%s-nuodb-cluster0-demo", databaseHelmChartReleaseName)
+	config := testlib.GetNuoDBK8sConfigDump(t, namespaceName, admin0)
+	assert.True(t, func() bool { _, ok := config.StatefulSets[adminStatefulSet]; return ok }())
+	assert.True(t, func() bool { _, ok := config.Deployments[teDeployment]; return ok }())
+	assert.True(t, len(config.Volumes) == 0)
+	assert.True(t, len(config.Pods) == 0)
+}


### PR DESCRIPTION
**Changes**
- Make sure that KAA starts when a limited set of permissions are present in RBAC
- This addresses the backward compatibility issue described in https://github.com/nuodb/nuodb-helm-charts/issues/140