### PR TITLE
Move podAnnotations to create on the pod

### DIFF
--- a/stable/admin/templates/statefulset.yaml
+++ b/stable/admin/templates/statefulset.yaml
@@ -5,9 +5,6 @@ metadata:
     description: |-
       NuoAdmin statefulset resource for NuoDB Admin layer.
 {{- include "admin.loadBalancerConfig" . | indent 4 }}
-    {{- if .Values.admin.podAnnotations }}
-{{ toYaml .Values.admin.podAnnotations | trim | indent 4}}
-    {{- end }}
     {{- if (eq (default "cluster0" .Values.cloud.cluster.name) (default "cluster0" .Values.cloud.cluster.entrypointName)) }}
     nuodb.com/bootstrap-servers: {{ default 0 .Values.admin.bootstrapServers | quote }}
     {{- end }}
@@ -32,6 +29,10 @@ spec:
   template:
     metadata:
       name: {{ template "admin.fullname" . }}
+      {{- if .Values.admin.podAnnotations }}
+      annotations:
+{{ toYaml .Values.admin.podAnnotations | trim | indent 8}}
+      {{- end }}
       labels:
         app: {{ template "admin.fullname" . }}
         chart: {{ template "admin.chart" . }}

--- a/stable/database/templates/daemonset.yaml
+++ b/stable/database/templates/daemonset.yaml
@@ -7,9 +7,6 @@ metadata:
   annotations:
     description: |-
       Database deployment resource for NuoDB Storage Engines (SM).
-    {{- if .Values.database.podAnnotations }}
-{{ toYaml .Values.database.podAnnotations | trim | indent 4}}
-    {{- end }}
   labels: 
     app: {{ template "database.fullname" . }}
     group: nuodb
@@ -26,6 +23,10 @@ spec:
       role: nohotcopy
   template:
     metadata:
+      {{- if .Values.database.podAnnotations }}
+      annotations:
+{{ toYaml .Values.database.podAnnotations | trim | indent 8 }}
+      {{- end }}
       labels:
         app: {{ template "database.fullname" . }}
         component: sm
@@ -232,6 +233,10 @@ spec:
       role: hotcopy
   template:
     metadata:
+      {{- if .Values.database.podAnnotations }}
+      annotations:
+{{ toYaml .Values.database.podAnnotations | trim | indent 8 }}
+      {{- end }}
       labels:
         app: {{ template "database.fullname" . }}
         component: sm

--- a/stable/database/templates/deployment.yaml
+++ b/stable/database/templates/deployment.yaml
@@ -5,9 +5,6 @@ metadata:
     description: |-
       Database deployment resource for NuoDB Transaction Engines (TE).
 {{- include "database.loadBalancerConfig" . | indent 4 }}
-    {{- if .Values.database.podAnnotations }}
-{{ toYaml .Values.database.podAnnotations | trim | indent 4}}
-    {{- end }}
   labels:
     app: {{ template "database.fullname" . }}
     group: nuodb
@@ -26,6 +23,10 @@ spec:
     type: RollingUpdate
   template:
     metadata:
+      {{- if .Values.database.podAnnotations }}
+      annotations:
+{{ toYaml .Values.database.podAnnotations | trim | indent 8 }}
+      {{- end }}
       labels:
         app: {{ template "database.fullname" . }}
         group: nuodb

--- a/stable/database/templates/statefulset.yaml
+++ b/stable/database/templates/statefulset.yaml
@@ -7,9 +7,6 @@ metadata:
   annotations:
     description: |-
       Database deployment resource for NuoDB Storage Engines (SM).
-    {{- if .Values.database.podAnnotations }}
-{{ toYaml .Values.database.podAnnotations | trim | indent 4}}
-    {{- end }}
   labels:
     app: {{ template "database.fullname" . }}
     group: nuodb
@@ -29,6 +26,10 @@ spec:
   serviceName: {{ .Values.database.name }}
   template:
     metadata:
+      {{- if .Values.database.podAnnotations }}
+      annotations:
+{{ toYaml .Values.database.podAnnotations | trim | indent 8 }}
+      {{- end }}
       labels:
         app: {{ template "database.fullname" . }}
         component: sm
@@ -308,9 +309,6 @@ metadata:
   annotations:
     description: |-
       Database deployment resource for NuoDB Storage Engines (SM).
-    {{- if .Values.database.podAnnotations }}
-{{ toYaml .Values.database.podAnnotations | trim | indent 4}}
-    {{- end }}
   labels:
     app: {{ template "database.fullname" . }}
     group: nuodb
@@ -330,6 +328,10 @@ spec:
   serviceName: {{ .Values.database.name }}
   template:
     metadata:
+      {{- if .Values.database.podAnnotations }}
+      annotations:
+{{ toYaml .Values.database.podAnnotations | trim | indent 8 }}
+      {{- end }}
       labels:
         app: {{ template "database.fullname" . }}
         component: sm

--- a/test/integration/template_admin_test.go
+++ b/test/integration/template_admin_test.go
@@ -367,7 +367,7 @@ func TestGlobalLoadBalancerConfigRendersOnlyOnEntryPointCluster(t *testing.T) {
 	}
 }
 
-func TestAnnotationsRender(t *testing.T) {
+func TestAdminPodAnnotationsRender(t *testing.T) {
 	// Path to the helm chart we will test
 	helmChartPath := testlib.ADMIN_HELM_CHART_PATH
 
@@ -390,12 +390,12 @@ func TestAnnotationsRender(t *testing.T) {
 	output := helm.RenderTemplate(t, options, helmChartPath, "release-name", []string{"templates/statefulset.yaml"})
 
 	for _, obj := range testlib.SplitAndRenderStatefulSet(t, output, 1) {
-		assert.Equal(t, options.SetValues["admin.podAnnotations.key1"], obj.Annotations["key1"])
-		assert.Equal(t, options.SetValues["admin.podAnnotations.key2"], obj.Annotations["key2"])
-		assert.Equal(t, options.SetValues["admin.podAnnotations.key3\\.key3"], obj.Annotations["key3.key3"])
-		assert.Equal(t, options.SetValues["admin.podAnnotations.key4\\.key4/key4"], obj.Annotations["key4.key4/key4"])
-		assert.Equal(t, options.SetValues["admin.podAnnotations.key5\\.key5/key5"], obj.Annotations["key5.key5/key5"])
-		assert.Equal(t, options.SetValues["admin.podAnnotations.vault\\.hashicorp\\.com/agent-inject"], obj.Annotations["vault.hashicorp.com/agent-inject"])
-		assert.Equal(t, options.SetValues["admin.podAnnotations.vault\\.hashicorp\\.com/agent-inject-template-ca\\.cert"], obj.Annotations["vault.hashicorp.com/agent-inject-template-ca.cert"])
+		assert.Equal(t, options.SetValues["admin.podAnnotations.key1"], obj.Spec.Template.ObjectMeta.Annotations["key1"])
+		assert.Equal(t, options.SetValues["admin.podAnnotations.key2"], obj.Spec.Template.ObjectMeta.Annotations["key2"])
+		assert.Equal(t, options.SetValues["admin.podAnnotations.key3\\.key3"], obj.Spec.Template.ObjectMeta.Annotations["key3.key3"])
+		assert.Equal(t, options.SetValues["admin.podAnnotations.key4\\.key4/key4"], obj.Spec.Template.ObjectMeta.Annotations["key4.key4/key4"])
+		assert.Equal(t, options.SetValues["admin.podAnnotations.key5\\.key5/key5"], obj.Spec.Template.ObjectMeta.Annotations["key5.key5/key5"])
+		assert.Equal(t, options.SetValues["admin.podAnnotations.vault\\.hashicorp\\.com/agent-inject"], obj.Spec.Template.ObjectMeta.Annotations["vault.hashicorp.com/agent-inject"])
+		assert.Equal(t, options.SetValues["admin.podAnnotations.vault\\.hashicorp\\.com/agent-inject-template-ca\\.cert"], obj.Spec.Template.ObjectMeta.Annotations["vault.hashicorp.com/agent-inject-template-ca.cert"])
 	}
 }

--- a/test/integration/template_database_test.go
+++ b/test/integration/template_database_test.go
@@ -593,3 +593,72 @@ func TestDefaultLoadBalancerConfigurationNotRenders(t *testing.T) {
 		}
 	})
 }
+
+func TestDatabasePodAnnotationsRender(t *testing.T) {
+	// Path to the helm chart we will test
+	helmChartPath := "../../stable/database"
+
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"cc.podAnnotations.key1": "value1",
+			"database.podAnnotations.key2": "value2",
+			"database.podAnnotations.key3\\.key3": "value3",
+			"database.podAnnotations.key4\\.key4/key4": "value4",
+			"database.podAnnotations.key5\\.key5/key5": "value5/value5",
+			"database.podAnnotations.vault\\.hashicorp\\.com/agent-inject": `"true"`,
+			"database.podAnnotations.vault\\.hashicorp\\.com/agent-inject-template-ca\\.cert": "|\n"+
+			"{{- with secret \"nuodb.com/TLS\" -}}\n"+
+			"  {{ .Data.data.tlsCACert }}\n"+
+			"{{- end }}",
+		},
+	}
+
+	t.Run("testDeployment", func(t *testing.T) {
+		// Run RenderTemplate to render the template and capture the output.
+		output := helm.RenderTemplate(t, options, helmChartPath, "release-name", []string{"templates/deployment.yaml"})
+
+		for _, obj := range testlib.SplitAndRenderDeployment(t, output, 1) {
+			assert.Equal(t, options.SetValues["database.podAnnotations.key1"], obj.Spec.Template.ObjectMeta.Annotations["key1"])
+			assert.Equal(t, options.SetValues["database.podAnnotations.key2"], obj.Spec.Template.ObjectMeta.Annotations["key2"])
+			assert.Equal(t, options.SetValues["database.podAnnotations.key3\\.key3"], obj.Spec.Template.ObjectMeta.Annotations["key3.key3"])
+			assert.Equal(t, options.SetValues["database.podAnnotations.key4\\.key4/key4"], obj.Spec.Template.ObjectMeta.Annotations["key4.key4/key4"])
+			assert.Equal(t, options.SetValues["database.podAnnotations.key5\\.key5/key5"], obj.Spec.Template.ObjectMeta.Annotations["key5.key5/key5"])
+			assert.Equal(t, options.SetValues["database.podAnnotations.vault\\.hashicorp\\.com/agent-inject"], obj.Spec.Template.ObjectMeta.Annotations["vault.hashicorp.com/agent-inject"])
+			assert.Equal(t, options.SetValues["database.podAnnotations.vault\\.hashicorp\\.com/agent-inject-template-ca\\.cert"], obj.Spec.Template.ObjectMeta.Annotations["vault.hashicorp.com/agent-inject-template-ca.cert"])
+		}
+	})
+
+	t.Run("testStatefulSet", func(t *testing.T) {
+		// Run RenderTemplate to render the template and capture the output.
+		output := helm.RenderTemplate(t, options, helmChartPath, "release-name", []string{"templates/statefulset.yaml"})
+
+		for _, obj := range testlib.SplitAndRenderStatefulSet(t, output, 2) {
+			assert.Equal(t, options.SetValues["database.podAnnotations.key1"], obj.Spec.Template.ObjectMeta.Annotations["key1"])
+			assert.Equal(t, options.SetValues["database.podAnnotations.key2"], obj.Spec.Template.ObjectMeta.Annotations["key2"])
+			assert.Equal(t, options.SetValues["database.podAnnotations.key3\\.key3"], obj.Spec.Template.ObjectMeta.Annotations["key3.key3"])
+			assert.Equal(t, options.SetValues["database.podAnnotations.key4\\.key4/key4"], obj.Spec.Template.ObjectMeta.Annotations["key4.key4/key4"])
+			assert.Equal(t, options.SetValues["database.podAnnotations.key5\\.key5/key5"], obj.Spec.Template.ObjectMeta.Annotations["key5.key5/key5"])
+			assert.Equal(t, options.SetValues["database.podAnnotations.vault\\.hashicorp\\.com/agent-inject"], obj.Spec.Template.ObjectMeta.Annotations["vault.hashicorp.com/agent-inject"])
+			assert.Equal(t, options.SetValues["database.podAnnotations.vault\\.hashicorp\\.com/agent-inject-template-ca\\.cert"], obj.Spec.Template.ObjectMeta.Annotations["vault.hashicorp.com/agent-inject-template-ca.cert"])
+		}
+	})
+
+	t.Run("testDaemonSet", func(t *testing.T) {
+		// make a copy
+		localOptions := *options
+		localOptions.SetValues["database.enableDaemonSet"] = "true"
+
+		// Run RenderTemplate to render the template and capture the output.
+		output := helm.RenderTemplate(t, &localOptions, helmChartPath, "release-name", []string{"templates/daemonset.yaml"})
+
+		for _, obj := range testlib.SplitAndRenderDaemonSet(t, output, 2) {
+			assert.Equal(t, options.SetValues["database.podAnnotations.key1"], obj.Spec.Template.ObjectMeta.Annotations["key1"])
+			assert.Equal(t, options.SetValues["database.podAnnotations.key2"], obj.Spec.Template.ObjectMeta.Annotations["key2"])
+			assert.Equal(t, options.SetValues["database.podAnnotations.key3\\.key3"], obj.Spec.Template.ObjectMeta.Annotations["key3.key3"])
+			assert.Equal(t, options.SetValues["database.podAnnotations.key4\\.key4/key4"], obj.Spec.Template.ObjectMeta.Annotations["key4.key4/key4"])
+			assert.Equal(t, options.SetValues["database.podAnnotations.key5\\.key5/key5"], obj.Spec.Template.ObjectMeta.Annotations["key5.key5/key5"])
+			assert.Equal(t, options.SetValues["database.podAnnotations.vault\\.hashicorp\\.com/agent-inject"], obj.Spec.Template.ObjectMeta.Annotations["vault.hashicorp.com/agent-inject"])
+			assert.Equal(t, options.SetValues["database.podAnnotations.vault\\.hashicorp\\.com/agent-inject-template-ca\\.cert"], obj.Spec.Template.ObjectMeta.Annotations["vault.hashicorp.com/agent-inject-template-ca.cert"])
+		}
+	})
+}

--- a/test/integration/template_database_test.go
+++ b/test/integration/template_database_test.go
@@ -632,7 +632,41 @@ func TestDatabasePodAnnotationsRender(t *testing.T) {
 		// Run RenderTemplate to render the template and capture the output.
 		output := helm.RenderTemplate(t, options, helmChartPath, "release-name", []string{"templates/statefulset.yaml"})
 
+		for _, obj := range testlib.SplitAndRenderStatefulSet(t, output, 1) {
+			assert.Equal(t, options.SetValues["database.podAnnotations.key1"], obj.Spec.Template.ObjectMeta.Annotations["key1"])
+			assert.Equal(t, options.SetValues["database.podAnnotations.key2"], obj.Spec.Template.ObjectMeta.Annotations["key2"])
+			assert.Equal(t, options.SetValues["database.podAnnotations.key3\\.key3"], obj.Spec.Template.ObjectMeta.Annotations["key3.key3"])
+			assert.Equal(t, options.SetValues["database.podAnnotations.key4\\.key4/key4"], obj.Spec.Template.ObjectMeta.Annotations["key4.key4/key4"])
+			assert.Equal(t, options.SetValues["database.podAnnotations.key5\\.key5/key5"], obj.Spec.Template.ObjectMeta.Annotations["key5.key5/key5"])
+			assert.Equal(t, options.SetValues["database.podAnnotations.vault\\.hashicorp\\.com/agent-inject"], obj.Spec.Template.ObjectMeta.Annotations["vault.hashicorp.com/agent-inject"])
+			assert.Equal(t, options.SetValues["database.podAnnotations.vault\\.hashicorp\\.com/agent-inject-template-ca\\.cert"], obj.Spec.Template.ObjectMeta.Annotations["vault.hashicorp.com/agent-inject-template-ca.cert"])
+		}
+	})
+
+	t.Run("testStatefulSet", func(t *testing.T) {
+		// Run RenderTemplate to render the template and capture the output.
+		output := helm.RenderTemplate(t, options, helmChartPath, "release-name", []string{"templates/statefulset.yaml"})
+
 		for _, obj := range testlib.SplitAndRenderStatefulSet(t, output, 2) {
+			assert.Equal(t, options.SetValues["database.podAnnotations.key1"], obj.Spec.Template.ObjectMeta.Annotations["key1"])
+			assert.Equal(t, options.SetValues["database.podAnnotations.key2"], obj.Spec.Template.ObjectMeta.Annotations["key2"])
+			assert.Equal(t, options.SetValues["database.podAnnotations.key3\\.key3"], obj.Spec.Template.ObjectMeta.Annotations["key3.key3"])
+			assert.Equal(t, options.SetValues["database.podAnnotations.key4\\.key4/key4"], obj.Spec.Template.ObjectMeta.Annotations["key4.key4/key4"])
+			assert.Equal(t, options.SetValues["database.podAnnotations.key5\\.key5/key5"], obj.Spec.Template.ObjectMeta.Annotations["key5.key5/key5"])
+			assert.Equal(t, options.SetValues["database.podAnnotations.vault\\.hashicorp\\.com/agent-inject"], obj.Spec.Template.ObjectMeta.Annotations["vault.hashicorp.com/agent-inject"])
+			assert.Equal(t, options.SetValues["database.podAnnotations.vault\\.hashicorp\\.com/agent-inject-template-ca\\.cert"], obj.Spec.Template.ObjectMeta.Annotations["vault.hashicorp.com/agent-inject-template-ca.cert"])
+		}
+	})
+
+	t.Run("testDaemonSet", func(t *testing.T) {
+		// make a copy
+		localOptions := *options
+		localOptions.SetValues["database.enableDaemonSet"] = "true"
+
+		// Run RenderTemplate to render the template and capture the output.
+		output := helm.RenderTemplate(t, &localOptions, helmChartPath, "release-name", []string{"templates/daemonset.yaml"})
+
+		for _, obj := range testlib.SplitAndRenderDaemonSet(t, output, 1) {
 			assert.Equal(t, options.SetValues["database.podAnnotations.key1"], obj.Spec.Template.ObjectMeta.Annotations["key1"])
 			assert.Equal(t, options.SetValues["database.podAnnotations.key2"], obj.Spec.Template.ObjectMeta.Annotations["key2"])
 			assert.Equal(t, options.SetValues["database.podAnnotations.key3\\.key3"], obj.Spec.Template.ObjectMeta.Annotations["key3.key3"])


### PR DESCRIPTION
- podAnnotations were added but created on the pod controller not the pod itself.  Vault requires them to be on the pod, and this fits better with the naming too.
- Added more tests for the DB charts