### PR TITLE
add timeout and retry on wait for starting SM

### DIFF
--- a/stable/database/files/nuosm
+++ b/stable/database/files/nuosm
@@ -265,7 +265,12 @@ if [ -n "$restore_requested" -a -n "$restore_source" ]; then
     fi
 
     # wait for the starting SM to be RUNNING
-    $NUOCMD check process --start-id $owner_id --check-running --wait-forever
+    $NUOCMD check process --start-id $owner_id --check-running --timeout 600
+    if [ $? != 0 ]; then
+      echo "Timeout waiting for SM to go RUNNING - owner $owner, start-id $owner_id - retrying."
+      sleep 30
+      continue
+    fi
 
     # transfer ownership of the startup semaphore to myself
     $NUOCMD set value --key $startup_key/$DB_NAME --value $HOSTNAME --expected-value $owner


### PR DESCRIPTION
Per helm-185, if the "starting SM" encounters an error and is restarted, then the SMs waiting on it would wait forever.

Changed "nuocmd check process ... --wait-forever"
to: "nuocmd check process ... --timeout 600"

If "check process" returns an error, then print a diagnostic message and retry the enclosing loop.

In the process of retrying, the identity of the "starting SM" is re-evaluated, in case the SM restarted.