### PR TITLE
Change GoLang module to v3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/nuodb/nuodb-helm-charts
+module github.com/nuodb/nuodb-helm-charts/v3
 
 go 1.14
 

--- a/test/integration/database_marshall_test.go
+++ b/test/integration/database_marshall_test.go
@@ -1,7 +1,7 @@
 package integration
 
 import (
-	"github.com/nuodb/nuodb-helm-charts/test/testlib"
+	"github.com/nuodb/nuodb-helm-charts/v3/test/testlib"
 	"github.com/stretchr/testify/assert"
 
 	"testing"

--- a/test/integration/kube_config_marshall_test.go
+++ b/test/integration/kube_config_marshall_test.go
@@ -1,7 +1,7 @@
 package integration
 
 import (
-	"github.com/nuodb/nuodb-helm-charts/test/testlib"
+	"github.com/nuodb/nuodb-helm-charts/v3/test/testlib"
 	"github.com/stretchr/testify/assert"
 
 	"io/ioutil"

--- a/test/integration/process_marshall_test.go
+++ b/test/integration/process_marshall_test.go
@@ -2,7 +2,7 @@ package integration
 
 import (
 	"encoding/json"
-	"github.com/nuodb/nuodb-helm-charts/test/testlib"
+	"github.com/nuodb/nuodb-helm-charts/v3/test/testlib"
 	"github.com/stretchr/testify/assert"
 
 	"testing"

--- a/test/integration/registry_entry_marshall_test.go
+++ b/test/integration/registry_entry_marshall_test.go
@@ -1,7 +1,7 @@
 package integration
 
 import (
-	"github.com/nuodb/nuodb-helm-charts/test/testlib"
+	"github.com/nuodb/nuodb-helm-charts/v3/test/testlib"
 	"github.com/stretchr/testify/assert"
 
 	"testing"

--- a/test/integration/template_admin_test.go
+++ b/test/integration/template_admin_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/gruntwork-io/terratest/modules/helm"
 
-	"github.com/nuodb/nuodb-helm-charts/test/testlib"
+	"github.com/nuodb/nuodb-helm-charts/v3/test/testlib"
 
 )
 

--- a/test/integration/template_collector_test.go
+++ b/test/integration/template_collector_test.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/gruntwork-io/terratest/modules/helm"
 
-	"github.com/nuodb/nuodb-helm-charts/test/testlib"
+	"github.com/nuodb/nuodb-helm-charts/v3/test/testlib"
 )
 
 func checkSidecarContainers(t *testing.T, containers []v1.Container, options *helm.Options, chartPath string) {

--- a/test/integration/template_database_test.go
+++ b/test/integration/template_database_test.go
@@ -10,7 +10,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 
 	"github.com/gruntwork-io/terratest/modules/helm"
-	"github.com/nuodb/nuodb-helm-charts/test/testlib"
+	"github.com/nuodb/nuodb-helm-charts/v3/test/testlib"
 )
 
 func TestDatabaseSecretsDefault(t *testing.T) {

--- a/test/integration/template_resources_test.go
+++ b/test/integration/template_resources_test.go
@@ -11,7 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 
 	"github.com/gruntwork-io/terratest/modules/helm"
-	"github.com/nuodb/nuodb-helm-charts/test/testlib"
+	"github.com/nuodb/nuodb-helm-charts/v3/test/testlib"
 )
 
 func listContains(arr []string, s string) bool {

--- a/test/integration/template_storage_class_test.go
+++ b/test/integration/template_storage_class_test.go
@@ -2,7 +2,7 @@ package integration
 
 import (
 	"fmt"
-	"github.com/nuodb/nuodb-helm-charts/test/testlib"
+	"github.com/nuodb/nuodb-helm-charts/v3/test/testlib"
 	"github.com/stretchr/testify/assert"
 	"math/rand"
 	"regexp"

--- a/test/integration/template_ycsb_test.go
+++ b/test/integration/template_ycsb_test.go
@@ -1,7 +1,7 @@
 package integration
 
 import (
-	"github.com/nuodb/nuodb-helm-charts/test/testlib"
+	"github.com/nuodb/nuodb-helm-charts/v3/test/testlib"
 	"github.com/stretchr/testify/assert"
 	"strings"
 	"testing"

--- a/test/minikube/minikube_base_admin_test.go
+++ b/test/minikube/minikube_base_admin_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/helm"
-	"github.com/nuodb/nuodb-helm-charts/test/testlib"
+	"github.com/nuodb/nuodb-helm-charts/v3/test/testlib"
 )
 
 func TestKubernetesBasicAdminSingleReplica(t *testing.T) {

--- a/test/minikube/minikube_base_collector_test.go
+++ b/test/minikube/minikube_base_collector_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/nuodb/nuodb-helm-charts/test/testlib"
+	"github.com/nuodb/nuodb-helm-charts/v3/test/testlib"
 
 	"github.com/gruntwork-io/terratest/modules/helm"
 	"github.com/gruntwork-io/terratest/modules/k8s"

--- a/test/minikube/minikube_base_database_test.go
+++ b/test/minikube/minikube_base_database_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/nuodb/nuodb-helm-charts/test/testlib"
+	"github.com/nuodb/nuodb-helm-charts/v3/test/testlib"
 
 	corev1 "k8s.io/api/core/v1"
 

--- a/test/minikube/minikube_base_thp_test.go
+++ b/test/minikube/minikube_base_thp_test.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/nuodb/nuodb-helm-charts/test/testlib"
+	"github.com/nuodb/nuodb-helm-charts/v3/test/testlib"
 
 	"strings"
 	"testing"

--- a/test/minikube/minikube_crash_handling_test.go
+++ b/test/minikube/minikube_crash_handling_test.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"github.com/gruntwork-io/terratest/modules/helm"
 	"github.com/gruntwork-io/terratest/modules/k8s"
-	"github.com/nuodb/nuodb-helm-charts/test/testlib"
+	"github.com/nuodb/nuodb-helm-charts/v3/test/testlib"
 	"github.com/stretchr/testify/require"
 	"io/ioutil"
 	"regexp"

--- a/test/minikube/minikube_domain_resync_test.go
+++ b/test/minikube/minikube_domain_resync_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/nuodb/nuodb-helm-charts/test/testlib"
+	"github.com/nuodb/nuodb-helm-charts/v3/test/testlib"
 
 	"github.com/gruntwork-io/terratest/modules/helm"
 	"github.com/gruntwork-io/terratest/modules/k8s"

--- a/test/minikube/minikube_e2e_demo_test.go
+++ b/test/minikube/minikube_e2e_demo_test.go
@@ -5,7 +5,7 @@ package minikube
 import (
 	"fmt"
 	"github.com/gruntwork-io/terratest/modules/k8s"
-	"github.com/nuodb/nuodb-helm-charts/test/testlib"
+	"github.com/nuodb/nuodb-helm-charts/v3/test/testlib"
 	v12 "k8s.io/api/core/v1"
 	"testing"
 	"time"

--- a/test/minikube/minikube_kaa_additions_test.go
+++ b/test/minikube/minikube_kaa_additions_test.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/nuodb/nuodb-helm-charts/test/testlib"
+	"github.com/nuodb/nuodb-helm-charts/v3/test/testlib"
 
 	"github.com/ghodss/yaml"
 

--- a/test/minikube/minikube_long_admin_test.go
+++ b/test/minikube/minikube_long_admin_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/helm"
-	"github.com/nuodb/nuodb-helm-charts/test/testlib"
+	"github.com/nuodb/nuodb-helm-charts/v3/test/testlib"
 )
 
 func TestKubernetesBasicAdminThreeReplicas(t *testing.T) {

--- a/test/minikube/minikube_rolling_upgrade_test.go
+++ b/test/minikube/minikube_rolling_upgrade_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/gruntwork-io/terratest/modules/helm"
 	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/gruntwork-io/terratest/modules/random"
-	"github.com/nuodb/nuodb-helm-charts/test/testlib"
+	"github.com/nuodb/nuodb-helm-charts/v3/test/testlib"
 )
 
 const OLD_RELEASE = "4.0.4"

--- a/test/minikube/minikube_test_test.go
+++ b/test/minikube/minikube_test_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/gruntwork-io/terratest/modules/helm"
 
-	"github.com/nuodb/nuodb-helm-charts/test/testlib"
+	"github.com/nuodb/nuodb-helm-charts/v3/test/testlib"
 )
 
 /**

--- a/test/minikube/minikube_tls_admin_test.go
+++ b/test/minikube/minikube_tls_admin_test.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/nuodb/nuodb-helm-charts/test/testlib"
+	"github.com/nuodb/nuodb-helm-charts/v3/test/testlib"
 
 	"github.com/gruntwork-io/terratest/modules/helm"
 	"github.com/gruntwork-io/terratest/modules/k8s"

--- a/test/minikube/minikube_tls_rotation_test.go
+++ b/test/minikube/minikube_tls_rotation_test.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/nuodb/nuodb-helm-charts/test/testlib"
+	"github.com/nuodb/nuodb-helm-charts/v3/test/testlib"
 
 	"github.com/gruntwork-io/terratest/modules/helm"
 	"github.com/gruntwork-io/terratest/modules/k8s"

--- a/test/minikube/minikube_upgrade_helm_test.go
+++ b/test/minikube/minikube_upgrade_helm_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/gruntwork-io/terratest/modules/helm"
 	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/gruntwork-io/terratest/modules/random"
-	"github.com/nuodb/nuodb-helm-charts/test/testlib"
+	"github.com/nuodb/nuodb-helm-charts/v3/test/testlib"
 	v12 "k8s.io/api/core/v1"
 )
 

--- a/test/minikube/verify_utility.go
+++ b/test/minikube/verify_utility.go
@@ -1,7 +1,7 @@
 package minikube
 
 import (
-	"github.com/nuodb/nuodb-helm-charts/test/testlib"
+	"github.com/nuodb/nuodb-helm-charts/v3/test/testlib"
 	"github.com/stretchr/testify/require"
 	"testing"
 	"time"


### PR DESCRIPTION
This is required to import the module and resolve it to 3.0.0 rather than 2.4.1.

Without it, go get fails like follows:
```
go get -u -v github.com/nuodb/nuodb-helm-charts@v3.0.0
go get github.com/nuodb/nuodb-helm-charts@v3.0.0: github.com/nuodb/nuodb-helm-charts@v3.0.0: invalid version: module contains a go.mod file, so major version must be compatible: should be v0 or v1, not v3
```

With the change, it can be done like this:
```
go get -u -v github.com/nuodb/nuodb-helm-charts/v3
go: downloading github.com/nuodb/nuodb-helm-charts/v3 v3.0.0
go: github.com/nuodb/nuodb-helm-charts/v3 upgrade => v3.0.0
```

We use this module in the insights project.