### PR TITLE
Support for installing YCSB from public charts repo

### DIFF
--- a/scripts/ci/install_deps.sh
+++ b/scripts/ci/install_deps.sh
@@ -33,6 +33,7 @@ if [[ -n "$REQUIRES_MINIKUBE" ]]; then
 
   # get the helm repo for upgrade testing
   helm repo add nuodb https://storage.googleapis.com/nuodb-charts
+  helm repo add nuodb-incubator https://storage.googleapis.com/nuodb-charts-incubator
 
 elif [[ -n "$REQUIRES_MINISHIFT" ]]; then
   wget https://github.com/openshift/origin/releases/download/v3.11.0/openshift-origin-client-tools-v3.11.0-0cbc58b-linux-64bit.tar.gz -O /tmp/oc.tar.gz
@@ -73,6 +74,7 @@ elif [[ -n "$REQUIRES_MINISHIFT" ]]; then
 
   # get the helm repo for upgrade testing
   helm repo add nuodb https://storage.googleapis.com/nuodb-charts
+  helm repo add nuodb-incubator https://storage.googleapis.com/nuodb-charts-incubator
 else
   echo "Skipping installation steps"
 fi

--- a/test/testlib/nuodb_ycsb_utilities.go
+++ b/test/testlib/nuodb_ycsb_utilities.go
@@ -29,7 +29,7 @@ func StartYCSBWorkload(t *testing.T, namespaceName string, options *helm.Options
 	if options.Version == "" {
 		helm.Install(t, options, YCSB_HELM_CHART_PATH, helmChartReleaseName)
 	} else {
-		helm.Install(t, options, "nuodb/demo-ycsb ", helmChartReleaseName)
+		helm.Install(t, options, "nuodb-incubator/demo-ycsb ", helmChartReleaseName)
 	}
 
 	Await(t, func() bool {

--- a/test/testlib/nuodb_ycsb_utilities.go
+++ b/test/testlib/nuodb_ycsb_utilities.go
@@ -26,7 +26,11 @@ func StartYCSBWorkload(t *testing.T, namespaceName string, options *helm.Options
 		helm.Delete(t, options, helmChartReleaseName, true)
 	})
 
-	helm.Install(t, options, YCSB_HELM_CHART_PATH, helmChartReleaseName)
+	if options.Version == "" {
+		helm.Install(t, options, YCSB_HELM_CHART_PATH, helmChartReleaseName)
+	} else {
+		helm.Install(t, options, "nuodb/demo-ycsb ", helmChartReleaseName)
+	}
 
 	Await(t, func() bool {
 		return GetReplicationController(t, namespaceName, helmChartReleaseName) != nil


### PR DESCRIPTION
**Changes**
- Add support for installing YCSB chart from public repo

This is needed by https://github.com/nuodb/nuodb-insights/pull/5.