### PR TITLE
Initial backup job in multicluster deployment fails

### DIFF
--- a/stable/database/files/nuobackup
+++ b/stable/database/files/nuobackup
@@ -48,59 +48,59 @@ wait_for_num_processes=0
 wait_timeout=300
 
 function await() {
-	local timeout=$1
-	shift
-	local end_time=$(( $(date -u +%s) + $timeout ))
-	local rc=0
-	while [ "$(date -u +%s)" -lt "$end_time" ]; do
-		eval "$*"
-		rc=$?
-		if [ $rc -eq 0 ]; then
-			return $rc
-		fi
-		sleep 1
-	done
-	return 124
+   local timeout=$1
+   shift
+   local end_time=$(( $(date -u +%s) + $timeout ))
+   local rc=0
+   while [ "$(date -u +%s)" -lt "$end_time" ]; do
+      eval "$*"
+      rc=$?
+      if [ $rc -eq 0 ]; then
+         return $rc
+      fi
+      sleep 1
+   done
+   return 124
 }
 
 function check_backup_processes() {
-	declare -a label_patterns=()
+   declare -a label_patterns=()
    local all_process_labels=""
 
-	for ((i=0; i<${#labels_arr[@]}; i+=2)); do
-	  label_patterns[${#label_patterns[@]}]="\"${labels_arr[i]}\"\s*:\s*\"${labels_arr[i+1]}\""
-	done
+   for ((i=0; i<${#labels_arr[@]}; i+=2)); do
+     label_patterns[${#label_patterns[@]}]="\"${labels_arr[i]}\"\s*:\s*\"${labels_arr[i+1]}\""
+   done
 
    all_process_labels="$(nuocmd --api-server $NUOCMD_API_SERVER show database \
       --db-name $db_name \
       --process-format '#{engine_type} {state} {labels}')" || return $?
 
-	num_processes=0
-	while read process_labels; do
+   num_processes=0
+   while read process_labels; do
       [ -z "$process_labels" ] && continue
-		parsed_labels=$(echo "$process_labels" | tr "'" '"' | python -m json.tool 2>&1)
-		if [ $? -ne 0 ];then
-			echo "Unable to parse SM process labels ${process_labels}: ${parsed_labels}" 2>&1
-			continue
-		fi
-		match=true
-		for pattern in ${label_patterns[@]}; do
-			if ! echo "${parsed_labels}" | grep -E -q "${pattern}"; then
-				# Some of the labels are not found
-				match=""
-				break
-			fi
-		done
-		if [ -n "$match" ]; then
-			num_processes=$(( num_processes+1 ))
-		fi
-	done <<< "$( echo "$all_process_labels" | sed -n -e 's/\s*#SM RUNNING //p')"
+      parsed_labels=$(echo "$process_labels" | tr "'" '"' | python -m json.tool 2>&1)
+      if [ $? -ne 0 ];then
+         echo "Unable to parse SM process labels ${process_labels}: ${parsed_labels}" 2>&1
+         continue
+      fi
+      match=true
+      for pattern in ${label_patterns[@]}; do
+         if ! echo "${parsed_labels}" | grep -E -q "${pattern}"; then
+            # Some of the labels are not found
+            match=""
+            break
+         fi
+      done
+      if [ -n "$match" ]; then
+         num_processes=$(( num_processes+1 ))
+      fi
+   done <<< "$( echo "$all_process_labels" | sed -n -e 's/\s*#SM RUNNING //p')"
 
-	if [ "$num_processes" -eq "$wait_for_num_processes" ]; then
-		return 0
-	else
-		return 1
-	fi
+   if [ "$num_processes" -eq "$wait_for_num_processes" ]; then
+      return 0
+   else
+      return 1
+   fi
 }
 
 while [ $# -gt 0 ];

--- a/stable/database/files/nuobackup
+++ b/stable/database/files/nuobackup
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # simple script to automate backup.
 #
@@ -28,6 +28,8 @@
 #   --labels   - additional arbitrary labels to select the SMs to backup
 #   --timeout  - timeout (in seconds) to synchronously wait for the backup to complete. 0 => async backup.
 #   --backup-root - directory tree to create the backupsets inside - eg /var/opt/nuodb/backup
+#   --wait-for-num-processes - wait for a specified number of SM processes in a backup group to be in RUNNING state before starting a backup
+#   --wait-timeout - timeout (in seconds) to wait for specified amount of SM processes
 
 # for debugging...
 [ -n "$NUODB_DEBUG" ] && set -x 
@@ -42,6 +44,64 @@ labels=""
 semaphore=""
 timeout=1800
 backup_root=$BACKUP_DIR
+wait_for_num_processes=0
+wait_timeout=300
+
+function await() {
+	local timeout=$1
+	shift
+	local end_time=$(( $(date -u +%s) + $timeout ))
+	local rc=0
+	while [ "$(date -u +%s)" -lt "$end_time" ]; do
+		eval "$*"
+		rc=$?
+		if [ $rc -eq 0 ]; then
+			return $rc
+		fi
+		sleep 1
+	done
+	return 124
+}
+
+function check_backup_processes() {
+	declare -a label_patterns=()
+   local all_process_labels=""
+
+	for ((i=0; i<${#labels_arr[@]}; i+=2)); do
+	  label_patterns[${#label_patterns[@]}]="\"${labels_arr[i]}\"\s*:\s*\"${labels_arr[i+1]}\""
+	done
+
+   all_process_labels="$(nuocmd --api-server $NUOCMD_API_SERVER show database \
+      --db-name $db_name \
+      --process-format '#{engine_type} {state} {labels}')" || return $?
+
+	num_processes=0
+	while read process_labels; do
+      [ -z "$process_labels" ] && continue
+		parsed_labels=$(echo "$process_labels" | tr "'" '"' | python -m json.tool 2>&1)
+		if [ $? -ne 0 ];then
+			echo "Unable to parse SM process labels ${process_labels}: ${parsed_labels}" 2>&1
+			continue
+		fi
+		match=true
+		for pattern in ${label_patterns[@]}; do
+			if ! echo "${parsed_labels}" | grep -E -q "${pattern}"; then
+				# Some of the labels are not found
+				match=""
+				break
+			fi
+		done
+		if [ -n "$match" ]; then
+			num_processes=$(( num_processes+1 ))
+		fi
+	done <<< "$( echo "$all_process_labels" | sed -n -e 's/\s*#SM RUNNING //p')"
+
+	if [ "$num_processes" -eq "$wait_for_num_processes" ]; then
+		return 0
+	else
+		return 1
+	fi
+}
 
 while [ $# -gt 0 ];
 do
@@ -69,10 +129,18 @@ do
            semaphore="$1"; shift;;
         "--semaphore="* )
            semaphore="${opt#*=}";;
+        "--wait-for-num-processes" )
+           wait_for_num_processes="$1"; shift;;
+        "--wait-for-num-processes="* )
+           wait_for_num_processes="${opt#*=}";;
         "--timeout" )
            timeout="$1"; shift;;
         "--timeout="* )
            timeout="${opt#*=}";;
+        "--wait-timeout" )
+           wait_timeout="$1"; shift;;
+        "--wait-timeout="* )
+           wait_timeout="${opt#*=}";;
         "--backup-root" )
            backup_root="$1"; shift;;
         "--backup-root="* )
@@ -83,6 +151,7 @@ done
 
 backup_type=$(echo $backup_type | tr '[:upper:]' '[:lower:]')
 label=$(echo $label | tr '[:upper:]' '[:lower:]')
+read -a labels_arr <<< "backup $backup_group $labels"
 
 # Return which group made the latest backup
 if [ "$backup_type" = "report-latest" -a "$backup_group" = "" ]; then
@@ -143,13 +212,22 @@ if [ "$backup_type" = "report-latest" ]; then
    exit 0
 fi
 
+if [ "$wait_for_num_processes" -ne 0 ]; then
+   # Wait for num of processes is specified, so wait for SMs to start
+   await $wait_timeout check_backup_processes
+   if [ $? -eq 124 ]; then
+      echo "Timed out waiting for ${wait_for_num_processes} SM processes with labels: ${labels_arr[@]}"
+      exit 1
+   fi
+fi
+
 # call nuodocker to perform the actual backup
 nuodocker backup database \
     --db-name ${db_name} \
     --type ${backup_type} \
     --backup-root ${backup_root} \
     --backup-name ${backupset} \
-    --labels "backup ${backup_group} ${labels}" \
+    --labels "${labels_arr[*]}" \
     --timeout ${timeout}
 
 retval=$?

--- a/stable/database/files/nuobackup
+++ b/stable/database/files/nuobackup
@@ -71,7 +71,7 @@ function check_backup_processes() {
      label_patterns[${#label_patterns[@]}]="\"${labels_arr[i]}\"\s*:\s*\"${labels_arr[i+1]}\""
    done
 
-   all_process_labels="$(nuocmd --api-server $NUOCMD_API_SERVER show database \
+   all_process_labels="$(nuocmd show database \
       --db-name $db_name \
       --process-format '#{engine_type} {state} {labels}')" || return $?
 
@@ -155,22 +155,22 @@ read -a labels_arr <<< "backup $backup_group $labels"
 
 # Return which group made the latest backup
 if [ "$backup_type" = "report-latest" -a "$backup_group" = "" ]; then
-   echo "$(nuocmd --api-server $NUOCMD_API_SERVER get value --key $NUODB_BACKUP_KEY/$db_name/latest )"
+   echo "$(nuocmd get value --key $NUODB_BACKUP_KEY/$db_name/latest )"
    exit 0
 fi
 
 # if $semaphore is not null, then check the value in Raft
 if [ -n "$semaphore" ]; then
    if [ "$backup_group" != "" ]; then
-      gate=$(nuocmd --api-server $NUOCMD_API_SERVER get value --key $semaphore/$db_name/$backup_group)
+      gate=$(nuocmd get value --key $semaphore/$db_name/$backup_group)
 
       # and reset the semaphore
-      nuocmd --api-server $NUOCMD_API_SERVER set value --key $semaphore/$db_name/$backup_group --value '' --expected-value "$gate"
+      nuocmd set value --key $semaphore/$db_name/$backup_group --value '' --expected-value "$gate"
    else
-      gate=$(nuocmd --api-server $NUOCMD_API_SERVER get value --key $semaphore/$db_name)
+      gate=$(nuocmd get value --key $semaphore/$db_name)
 
       # and reset the semaphore
-      nuocmd --api-server $NUOCMD_API_SERVER set value --key $semaphore/$db_name --value '' --expected-value "$gate"
+      nuocmd set value --key $semaphore/$db_name --value '' --expected-value "$gate"
    fi
 
 
@@ -180,11 +180,11 @@ if [ -n "$semaphore" ]; then
    fi
 
    # wait for the database to be RUNNING
-   nuocmd --api-server $NUOCMD_API_SERVER check database --db-name $db_name --check-running --wait-forever
+   nuocmd check database --db-name $db_name --check-running --wait-forever
 fi
 
 # find the index for the latest backup info
-latest=$(nuocmd --api-server $NUOCMD_API_SERVER get value --key $NUODB_BACKUP_KEY/$db_name/${backup_group}/latest )
+latest=$(nuocmd get value --key $NUODB_BACKUP_KEY/$db_name/${backup_group}/latest )
 current=$latest
 
 if [ "$backup_type" = "full" ]; then
@@ -203,7 +203,7 @@ else
    fi
 
    # retrieve the latest backupset name
-   backupset=$(nuocmd --api-server $NUOCMD_API_SERVER get value --key $NUODB_BACKUP_KEY/$db_name/${backup_group}/${latest} )
+   backupset=$(nuocmd get value --key $NUODB_BACKUP_KEY/$db_name/${backup_group}/${latest} )
    echo >&2 "Looking up $NUODB_BACKUP_KEY/$db_name/${backup_group}/${latest} returned: $backupset"
 fi
 
@@ -242,16 +242,16 @@ if [ "$backup_type" = "full" ]; then
    echo >&2 "$NUODB_BACKUP_KEY/$db_name/${backup_group}/$next = $backupset"
    echo >&2 "$NUODB_BACKUP_KEY/$db_name/latest = $backup_group"
 
-   nuocmd --api-server $NUOCMD_API_SERVER set value --key $NUODB_BACKUP_KEY/$db_name/${backup_group}/$next --value $backupset --unconditional
-   nuocmd --api-server $NUOCMD_API_SERVER set value --key $NUODB_BACKUP_KEY/$db_name/${backup_group}/latest --value $next --expected-value "$latest"
-   nuocmd --api-server $NUOCMD_API_SERVER set value --key $NUODB_BACKUP_KEY/$db_name/latest --value $backup_group --unconditional
+   nuocmd set value --key $NUODB_BACKUP_KEY/$db_name/${backup_group}/$next --value $backupset --unconditional
+   nuocmd set value --key $NUODB_BACKUP_KEY/$db_name/${backup_group}/latest --value $next --expected-value "$latest"
+   nuocmd set value --key $NUODB_BACKUP_KEY/$db_name/latest --value $backup_group --unconditional
 
    # update the list of known backup groups for this database
-   group_list="$(nuocmd --api-server $NUOCMD_API_SERVER get value --key $NUODB_BACKUP_KEY/$db_name/backup-groups)"
+   group_list="$(nuocmd get value --key $NUODB_BACKUP_KEY/$db_name/backup-groups)"
    if [ -z $(echo "$group_list" | grep -o $backup_group) ]; then
       new_list="$group_list $backup_group"
 
       echo >&2 "$NUODB_BACKUP_KEY/$db_name/backup-groups = $new_list"
-      nuocmd --api-server $NUOCMD_API_SERVER set value --key $NUODB_BACKUP_KEY/$db_name/backup-groups --value "$new_list" --expected-value "$group_list"
+      nuocmd set value --key $NUODB_BACKUP_KEY/$db_name/backup-groups --value "$new_list" --expected-value "$group_list"
    fi
 fi

--- a/stable/database/templates/job.yaml
+++ b/stable/database/templates/job.yaml
@@ -13,21 +13,6 @@ spec:
   completions: 1
   template:
     spec:
-      initContainers:
-      - name: wait-for-database-running
-        image: {{ template "nuodb.image" . }}
-        imagePullPolicy: {{ .Values.nuodb.image.pullPolicy }}
-        args:
-        - "nuocmd"
-        - "--api-server"
-        - "{{ template "admin.address" . }}:8888"
-        - "check"
-        - "database"
-        - "--db-name"
-        - "{{ .Values.database.name }}"
-        - "--check-running"
-        - "--wait-forever"
-
       containers:
       - name: nuodb
         image: {{ template "nuodb.image" . }}
@@ -44,6 +29,8 @@ spec:
         - "{{ .Values.database.sm.hotCopy.timeout }}"      
         - "--backup-root"
         - "{{ .Values.database.sm.hotCopy.backupDir }}"
+        - "--wait-for-num-processes"
+        - "{{ .Values.database.sm.hotCopy.replicas }}"
         env:
         - name: NODE_NAME
           valueFrom:


### PR DESCRIPTION
**Issue**
The initial backup job will fail in multicluster deployments on every cluster other than `cluster0` with:
```
'backup database' failed: No SMs found matching the provided labels backup cluster1
```
This happens because the init container will check if database is in `RUNNING` state which is already the case as there will be engines already deployed in `cluster0`. If the initial backup job fails, then all other incremental and journal backups will fail until the regular full backup is performed on schedule.

**Changes**
- `nuobackup` has been changed so that it can wait for a certain number of SMs with requested labels to become `RUNNING` before performing a backup.
- The init container of the initial job has been replaced by using the new functionality

**Testing**
- Automatic testing is already available in `TestKubernetesRestoreDatabase` test
- Regression testing
- Manual testing using Calico multi-cluster with three k3d clusters