### PR TITLE
All journal backups fail while a full backup is running

### DIFF
--- a/stable/database/files/nuobackup
+++ b/stable/database/files/nuobackup
@@ -123,8 +123,6 @@ if [ "$backup_type" = "full" ]; then
       current=0
    fi
 
-   backupset=$( date "+%Y%m%dT%H%M%S" )
-
    # bump latest, and wrap around (simple ring-buffer)
    next=$(( (current + 1) % $NUODB_MAX_BACKUP_HISTORY ))
 else
@@ -132,13 +130,12 @@ else
       echo >&2 "No full backup has completed yet - try again later"
       exit -1
    fi
-
-   # retrieve the latest backupset name
-   backupset=$(nuocmd --api-server $NUOCMD_API_SERVER get value --key $NUODB_BACKUP_KEY/$db_name/${backup_group}/${latest} )
-   echo >&2 "Looking up $NUODB_BACKUP_KEY/$db_name/${backup_group}/${latest} returned: $backupset"
 fi
 
 if [ "$backup_type" = "report-latest" ]; then
+   # retrieve the latest backupset name
+   backupset=$(nuocmd --api-server $NUOCMD_API_SERVER get value --key $NUODB_BACKUP_KEY/$db_name/${backup_group}/${latest} )
+   echo >&2 "Looking up $NUODB_BACKUP_KEY/$db_name/${backup_group}/${latest} returned: $backupset"
    echo "$backupset"
    exit 0
 fi
@@ -148,7 +145,6 @@ nuodocker backup database \
     --db-name ${db_name} \
     --type ${backup_type} \
     --backup-root ${backup_root} \
-    --backup-name ${backupset} \
     --labels "backup ${backup_group} ${labels}" \
     --timeout ${timeout}
 
@@ -160,6 +156,9 @@ fi
 
 if [ "$backup_type" = "full" ]; then
    # store the new backupset as latest, and store the new latest index
+   backupset=$( nuodocker get current-backup \
+      --db-name ${db_name} \
+      --labels "backup ${backup_group} ${labels}" | head -1 | awk '{print $2}' )
    echo >&2 "$NUODB_BACKUP_KEY/$db_name/${backup_group}/latest = $next"
    echo >&2 "$NUODB_BACKUP_KEY/$db_name/${backup_group}/$next = $backupset"
    echo >&2 "$NUODB_BACKUP_KEY/$db_name/latest = $backup_group"


### PR DESCRIPTION
**Issue**
All journal backups fail while a full backup is running. Error message is:
```
'backup database' failed: Failure while performing hot-copy: Error while sending engine request: Backup set ids in backup set /var/opt/nuodb/backup/20200514T090003 and archive do not match, journal hot copy is not allowed
```
Journal hotcopy **must** be started into the newest created backupset regardless if a full hotcopy has completed or not. `nuodocker backup database` stores the newest *created* backupset into admin KV store and will automatically retrieve it if `--backup-name` is not specified.
`nuobackup` stores the latest *completed* backupset into KV store per backup group. 

**Changes**
- Rely on `nuodocker` to manage the newest backupset name and retrieve it once a full backup is completed. This will guarantee that the newest created backup set will be used for journal hotcopy instead of the latest successful one.

**Caveats**
If an incremental hotcopy is executed while a full hotcopy is running, it will fail with:
```
'backup database' failed: Failure while performing hot-copy: Error while sending engine request: Cannot create incremental element. No full hot copy exists in backup set
```
This is expected behavior as there is no point in doing incremental while full is already running. If using the default backup schedules, there is 24h gap between full and next incremental, which will leave enough time for the full to finish. Users should configure incremental backup schedule in such a way so that they don't overlap with a full backup.

**Testing**
- Manual testing with the following schedule:
```
fullSchedule: "?/10 * * * *"
incrementalSchedule: "?/7 * * * *"
journalBackup:
  enabled: true
  intervalMinutes: 5
```