### PR TITLE
Make LB job optional

### DIFF
--- a/stable/admin/README.md
+++ b/stable/admin/README.md
@@ -217,6 +217,15 @@ The purpose of this section is to allow customisation of the names of the cluste
 | `clusterip` | suffix for the clusterIP load-balancer | "clusterip" |
 | `balancer` | suffix for the balancer service | "balancer" |
 
+#### admin.legacy
+
+Features in this section have been deprecated but not yet removed.
+
+| Key | Description | Default |
+| ----- | ----------- | ------ |
+| `loadBalancerJob.enabled` | Create a job that sets the default load balancer policy for the admin tier. Replaced by Kubernetes Aware Admin. | false |
+
+
 #### nuocollector.*
 
 The purpose of this section is to specify the NuoDB monitoring parameters.

--- a/stable/admin/templates/job.yaml
+++ b/stable/admin/templates/job.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.admin.legacy.loadBalancerJob.enabled }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -92,3 +93,4 @@ spec:
         configMap:
           name: waitscript
           defaultMode: 0777
+{{- end }}

--- a/stable/admin/values.yaml
+++ b/stable/admin/values.yaml
@@ -251,6 +251,10 @@ admin:
       # demo: demo-tde-secret
     storagePasswordsDir: /etc/nuodb/tde
 
+  legacy:
+    loadBalancerJob:
+      enabled: false
+
 nuocollector:
   enabled: false
   image:

--- a/test/integration/template_admin_test.go
+++ b/test/integration/template_admin_test.go
@@ -428,3 +428,22 @@ func TestAdminStoragePasswordsRender(t *testing.T) {
 		}
 	}
 }
+
+func TestLoadBalancerLegacyRenders(t *testing.T) {
+	// Path to the helm chart we will test
+	helmChartPath := testlib.ADMIN_HELM_CHART_PATH
+
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"admin.legacy.loadBalancerJob.enabled": "true",
+		},
+	}
+
+	// Run RenderTemplate to render the template and capture the output.
+	output := helm.RenderTemplate(t, options, helmChartPath, "release-name", []string{"templates/job.yaml"})
+
+	for _, obj := range testlib.SplitAndRenderJob(t, output, 1) {
+		require.EqualValues(t, "job-lb-policy-nearest", obj.Name)
+	}
+}
+

--- a/test/integration/template_resources_test.go
+++ b/test/integration/template_resources_test.go
@@ -171,7 +171,10 @@ func TestResourcesDatabaseOverridden(t *testing.T) {
 
 func TestPullSecretsRenderAllNuoDB(t *testing.T) {
 	options := &helm.Options{
-		SetValues: map[string]string{"nuodb.image.pullSecrets": "{fooBar}"},
+		SetValues: map[string]string{
+			"nuodb.image.pullSecrets": "{fooBar}",
+			"admin.legacy.loadBalancerJob.enabled": "true",
+		},
 	}
 
 	helm.RenderTemplate(t, options, "../../stable/admin", "release-name", []string{"templates/job.yaml"})
@@ -189,7 +192,10 @@ func TestPullSecretsRenderAllNuoDB(t *testing.T) {
 
 func TestPullSecretsRenderAllGlobal(t *testing.T) {
 	options := &helm.Options{
-		SetValues: map[string]string{"global.imagePullSecrets": "{fooBar}"},
+		SetValues: map[string]string{
+			"global.imagePullSecrets": "{fooBar}",
+			"admin.legacy.loadBalancerJob.enabled": "true",
+		},
 	}
 
 	helm.RenderTemplate(t, options, "../../stable/admin", "release-name", []string{"templates/job.yaml"})

--- a/test/minikube/minikube_rolling_upgrade_test.go
+++ b/test/minikube/minikube_rolling_upgrade_test.go
@@ -149,13 +149,6 @@ func TestKubernetesUpgradeAdminMinorVersion(t *testing.T) {
 	// get the OLD log
 	go testlib.GetAppLog(t, namespaceName, admin0, "-previous", &v12.PodLogOptions{Follow: true})
 
-	testlib.AwaitBalancerTerminated(t, namespaceName, "job-lb-policy")
-
-	// all jobs need to be deleted before an upgrade can be performed
-	// so far we have not found an automated way to delete them as part of a pre-upgrade hook
-	// if we find it, this line can be removed and the test should still pass
-	testlib.DeletePod(t, namespaceName, "jobs/job-lb-policy-nearest")
-
 	expectedNewVersion := testlib.GetUpgradedReleaseVersion(t, &options)
 
 	helm.Upgrade(t, &options, testlib.ADMIN_HELM_CHART_PATH, helmChartReleaseName)
@@ -203,12 +196,9 @@ func TestKubernetesUpgradeFullDatabaseMinorVersion(t *testing.T) {
 
 	databaseHelmChartReleaseName := testlib.StartDatabase(t, namespaceName, admin0, &databaseOptions)
 
-	testlib.AwaitBalancerTerminated(t, namespaceName, "job-lb-policy")
-
 	// all jobs need to be deleted before an upgrade can be performed
 	// so far we have not found an automated way to delete them as part of a pre-upgrade hook
 	// if we find it, this line can be removed and the test should still pass
-	testlib.DeletePod(t, namespaceName, "jobs/job-lb-policy-nearest")
 	testlib.DeletePod(t, namespaceName, "jobs/hotcopy-demo-job-initial")
 
 	expectedNewVersion := testlib.GetUpgradedReleaseVersion(t, &options)

--- a/test/minikube/minikube_upgrade_helm_test.go
+++ b/test/minikube/minikube_upgrade_helm_test.go
@@ -16,10 +16,10 @@ import (
 )
 
 type UpdateOptions struct {
-	adminPodShouldGetRecreated            bool
-	adminRolesRequirePatching             bool
-	adminBootstrapServersOverrideRequired bool
-	adminJobWasCreated					  bool
+	adminPodShouldGetRecreated            	bool
+	adminRolesRequirePatching             	bool
+	adminBootstrapServersOverrideRequired 	bool
+	adminJobWasCreated						bool
 }
 
 func upgradeAdminTest(t *testing.T, fromHelmVersion string, updateOptions *UpdateOptions) {

--- a/test/minikube/minikube_upgrade_helm_test.go
+++ b/test/minikube/minikube_upgrade_helm_test.go
@@ -19,6 +19,7 @@ type UpdateOptions struct {
 	adminPodShouldGetRecreated            bool
 	adminRolesRequirePatching             bool
 	adminBootstrapServersOverrideRequired bool
+	adminJobWasCreated					  bool
 }
 
 func upgradeAdminTest(t *testing.T, fromHelmVersion string, updateOptions *UpdateOptions) {
@@ -59,7 +60,9 @@ func upgradeAdminTest(t *testing.T, fromHelmVersion string, updateOptions *Updat
 	// get the OLD log
 	go testlib.GetAppLog(t, namespaceName, admin0, "-previous", &v12.PodLogOptions{Follow: true})
 
-	testlib.AwaitBalancerTerminated(t, namespaceName, "job-lb-policy")
+	if updateOptions.adminJobWasCreated {
+		testlib.AwaitBalancerTerminated(t, namespaceName, "job-lb-policy")
+	}
 
 	// all jobs need to be deleted before an upgrade can be performed
 	// so far we have not found an automated way to delete them as part of a pre-upgrade hook
@@ -169,6 +172,7 @@ func TestUpgradeHelm(t *testing.T) {
 			adminPodShouldGetRecreated:            true,
 			adminRolesRequirePatching:             true,
 			adminBootstrapServersOverrideRequired: true,
+			adminJobWasCreated: 			       true,
 		})
 	})
 
@@ -176,12 +180,14 @@ func TestUpgradeHelm(t *testing.T) {
 		upgradeAdminTest(t, "2.4.0", &UpdateOptions{
 			adminPodShouldGetRecreated: true,
 			adminRolesRequirePatching:  true,
+			adminJobWasCreated: 		true,
 		})
 	})
 
 	t.Run("NuoDB40X_From241_ToLocal", func(t *testing.T) {
 		upgradeAdminTest(t, "2.4.1", &UpdateOptions{
 			adminPodShouldGetRecreated: true,
+			adminJobWasCreated: 		true,
 		})
 	})
 }

--- a/test/minikube/verify_utility.go
+++ b/test/minikube/verify_utility.go
@@ -19,7 +19,6 @@ func verifyAdminService(t *testing.T, namespaceName string, podName string, serv
 }
 
 func verifyLBPolicy(t *testing.T, namespaceName string, podName string) {
-	testlib.AwaitBalancerTerminated(t, namespaceName, "job-lb-policy")
 	testlib.VerifyPolicyInstalled(t, namespaceName, podName)
 }
 


### PR DESCRIPTION
Create new section in admin YAML for `legacy` features. Make LB job legacy, is has been superceded by the KAA module.