### PR TITLE
Remove database name check after restore

### DIFF
--- a/stable/database/files/nuosm
+++ b/stable/database/files/nuosm
@@ -237,14 +237,6 @@ function perform_restore() {
     return $retval
   fi
 
-  # make sure the archive i s correct for this database
-  restoredName="$($NUODB_BINDIR/nuodb --show-archive-history --archive $DB_DIR | tr -d '\n' | grep -Eo '[<]Arg[>]--database[<]/Arg[>][^<]*[<]Arg[>]([^<]+)[<]/Arg[>]' | sed -r 's;[<]Arg[>]--database[<]/Arg[>][^<]*[<]Arg[>]([^<]+)[<]/Arg[>];\1;' )"
-  if [ -n "$restoredName" -a "$restoredName" != "$DB_NAME" ]; then
-    $undo
-    error="Restore: incorrect backup specified. Database name is $DB_NAME but archive is for $restoredName"
-    return 1
-  fi
-
   # completely delete my previous archive metadata
   # this is required because nuodocker always creates a new archive
   trace "completely deleting the raft metadata for my archive $myArchive"


### PR DESCRIPTION
**Changes**
There is a valid use case when a backupset/archive is taken from database with name `A` and is used to bootstrap database with name `B` in the same domain. Currently, it's not possible to use `autoImport` to fulfill the above requirements.
Removed the database name check after the restore is performed.

There shouldn't be a problem with `autoRestore` because if a backup from a different database is used, the SM startup will fail and complain about a mismatch in the database UUIDs.

**Testing**
Regression testing