### PR TITLE
Add evicted-servers to admin statefulset

### DIFF
--- a/stable/admin/README.md
+++ b/stable/admin/README.md
@@ -186,7 +186,7 @@ The following tables list the configurable parameters for the `admin` option of 
 | `podAnnotations` | Annotations to pass through to the Admin pod | `nil` |
 | `tde.secrets` | Transparent Data Encryption secret names used for different databases | `{}` |
 | `tde.storagePasswordsDir` | Transparent Data Encryption storage passwords mount path | `/etc/nuodb/tde` |
-| `evicted.servers` | A list of evicted servers excluded RAFT consensus. Used during disaster recovery. | `[]` |
+| `evicted.servers` | A list of evicted servers excluded from RAFT consensus. Used during disaster recovery. | `[]` |
 
 
 For example, when using GlusterFS storage class, you would supply the following parameter:

--- a/stable/admin/README.md
+++ b/stable/admin/README.md
@@ -186,6 +186,8 @@ The following tables list the configurable parameters for the `admin` option of 
 | `podAnnotations` | Annotations to pass through to the Admin pod | `nil` |
 | `tde.secrets` | Transparent Data Encryption secret names used for different databases | `{}` |
 | `tde.storagePasswordsDir` | Transparent Data Encryption storage passwords mount path | `/etc/nuodb/tde` |
+| `evicted.servers` | A list of evicted servers excluded RAFT consensus. Used during disaster recovery. | `[]` |
+
 
 For example, when using GlusterFS storage class, you would supply the following parameter:
 

--- a/stable/admin/templates/_helpers.tpl
+++ b/stable/admin/templates/_helpers.tpl
@@ -1,4 +1,12 @@
 {{/*
+Generic helper function to turn a list into a comma separated string
+*/}}
+{{- define "helm-toolkit.utils.joinListWithComma" -}}
+{{- $local := dict "first" true -}}
+{{- range $k, $v := . -}}{{- if not $local.first -}},{{- end -}}{{- $v -}}{{- $_ := set $local "first" false -}}{{- end -}}
+{{- end -}}
+
+{{/*
 Expand the name of the chart.
 */}}
 {{- define "admin.name" -}}

--- a/stable/admin/templates/statefulset.yaml
+++ b/stable/admin/templates/statefulset.yaml
@@ -112,9 +112,11 @@ spec:
       {{- end }}
         args:
           - "nuoadmin"
+          {{- if .Values.admin.evicted}}
           {{- if .Values.admin.evicted.servers}}
           - "--evicted-servers"
           - "{{ include "helm-toolkit.utils.joinListWithComma" .Values.admin.evicted.servers }}"
+          {{- end }}
           {{- end }}
           - "--"
           {{- if .Values.admin.tde }}

--- a/stable/admin/templates/statefulset.yaml
+++ b/stable/admin/templates/statefulset.yaml
@@ -112,6 +112,10 @@ spec:
       {{- end }}
         args:
           - "nuoadmin"
+          {{- if .Values.admin.evicted.servers}}
+          - "--evicted-servers"
+          - "{{ include "helm-toolkit.utils.joinListWithComma" .Values.admin.evicted.servers }}"
+          {{- end }}
           - "--"
           {{- if .Values.admin.tde }}
           {{- if and .Values.admin.tde.storagePasswordsDir (ne .Values.admin.tde.storagePasswordsDir "/etc/nuodb/tde") }}

--- a/stable/admin/values.yaml
+++ b/stable/admin/values.yaml
@@ -251,6 +251,11 @@ admin:
       # demo: demo-tde-secret
     storagePasswordsDir: /etc/nuodb/tde
 
+  # used for disaster recovery when a majority of admins is loss
+  # consult https://doc.nuodb.com/nuodb/latest/database-administration/recovering-from-a-lost-majority/
+  evicted:
+    servers: []
+
   legacy:
     loadBalancerJob:
       enabled: false

--- a/stable/admin/values.yaml
+++ b/stable/admin/values.yaml
@@ -251,7 +251,7 @@ admin:
       # demo: demo-tde-secret
     storagePasswordsDir: /etc/nuodb/tde
 
-  # used for disaster recovery when a majority of admins is loss
+  # A list of evicted servers excluded from RAFT consensus. Used during disaster recovery
   # consult https://doc.nuodb.com/nuodb/latest/database-administration/recovering-from-a-lost-majority/
   evicted:
     servers: []


### PR DESCRIPTION
Simplify recovery from a disaster that leaves the admin domain in a minority.

Usually, this is handled by KAA, but we allow this extension for multi-cluster installs and for environments that do not have KAA enabled.

For more info on eviction, read:
https://doc.nuodb.com/nuodb/latest/database-administration/recovering-from-a-lost-majority/