### PR TITLE
Fix broken alt-address test in bamboo

### DIFF
--- a/test/integration/process_marshall_test.go
+++ b/test/integration/process_marshall_test.go
@@ -74,6 +74,8 @@ func TestUnmarshall(t *testing.T) {
 	_, ok = obj.Labels["zone"]
 	assert.True(t, ok)
 
+	_, ok = obj.Options["mem"]
+	assert.True(t, ok)
 }
 
 func TestUnmarshallMany(t *testing.T) {
@@ -127,6 +129,7 @@ func TestUnmarshallMany(t *testing.T) {
 
 		_, ok = obj.Labels["zone"]
 		assert.True(t, ok)
+
 	}
 
 }

--- a/test/testlib/NuoDBProcess.go
+++ b/test/testlib/NuoDBProcess.go
@@ -7,12 +7,14 @@ import (
 )
 
 type NuoDBProcess struct {
-	Address  string            `json:"address"`
-	DbName   string            `json:"dbName"`
-	Type     string            `json:"type"`
-	Host     string            `json:"host"`
-	Hostname string            `json:"hostname"`
-	Labels   map[string]string `json:"labels"`
+	Address   string            `json:"address"`
+	DbName    string            `json:"dbName"`
+	Type      string            `json:"type"`
+	Host      string            `json:"host"`
+	Hostname  string            `json:"hostname"`
+	Labels    map[string]string `json:"labels"`
+	IpAddress string            `json:"ipAddress"`
+	Options   map[string]string `json:"options"`
 }
 
 func Unmarshal(s string) (err error, processes []NuoDBProcess) {


### PR DESCRIPTION
This test stopped working in Bamboo with NuoDB 4.2.

A simple refactor to use JSON instead of a grep/cut fixes the test.