### PR TITLE
Fix TestKubernetesAutoRestore random failures

### DIFF
--- a/test/minikube/minikube_base_restore_test.go
+++ b/test/minikube/minikube_base_restore_test.go
@@ -363,7 +363,7 @@ func TestKubernetesAutoRestore(t *testing.T) {
 	backupset := testlib.BackupDatabase(t, namespaceName, smPodName0, opt.DbName, "full", opt.ClusterName)
 
 	moveArchiveData := func(podName string) {
-		// Move the archive data which will cause the SM to ASSERT when a atom needs to be loaded
+		// Move the archive data which will cause the SM to ASSERT when an atom needs to be loaded
 		k8s.RunKubectl(t, kubectlOptions, "exec", podName, "--",
 			"mv", "-f", "/var/opt/nuodb/archive/nuodb/demo", "/var/opt/nuodb/archive/nuodb/demo-moved")
 		testlib.RunSQL(t, namespaceName, admin0, "demo", "select * from system.nodes")


### PR DESCRIPTION
**Changes**
* Move archive content instead of removing it. Removing directory underuse recursively may lead to random `Directory not empty` when `rmdir` system call is used.
* Test `autoRestore` for non-HC SM. Previously, the HC SM pod name was used incorrectly.