### PR TITLE
Upgrade kiwigrid/sidecar NuoDB Collector dependency to 1.10.8

### DIFF
--- a/stable/admin/values.yaml
+++ b/stable/admin/values.yaml
@@ -270,7 +270,7 @@ nuocollector:
   watcher:
     registry: docker.io
     repository: kiwigrid/k8s-sidecar
-    tag: 0.1.259
+    tag: 1.10.8
     pullPolicy: IfNotPresent
   plugins:
     ## NuoDB Collector compatible plugins specific for admin services

--- a/stable/database/values.yaml
+++ b/stable/database/values.yaml
@@ -398,7 +398,7 @@ nuocollector:
   watcher:
     registry: docker.io
     repository: kiwigrid/k8s-sidecar
-    tag: 0.1.259
+    tag: 1.10.8
     pullPolicy: IfNotPresent
   plugins:
     ## NuoDB Collector compatible plugins specific for database services


### PR DESCRIPTION
… current version has problems on Azure that leads to REQ_URL being called too frequently which reloads telegraf and drops 1-3 collection cycles.