### PR TITLE
Validate restore source

### DIFF
--- a/stable/database/files/nuosm
+++ b/stable/database/files/nuosm
@@ -496,6 +496,8 @@ if isRestoreRequestSupported && [ -z "$legacy_restore_requested" ]; then
         trace "restoring damaged archive"
         if isRestoreSourceAvailable "$restore_source"; then
           perform_restore || die $? "$error"
+        else
+          log "restore source ${restore_source} is not available: skipping automatic archive repair"
         fi
         # delete damaged archive metadata as a new one will be created by
         # nuodocker start sm

--- a/stable/database/files/nuote
+++ b/stable/database/files/nuote
@@ -19,9 +19,12 @@ if [ $crashcount -ge 1 ]; then
   fi
 fi
 
+nuodocker_flags=()
+[ -n "$NUODB_DEBUG" ] && nuodocker_flags+=("--debug")
+
 # expects NUOCMD_API_SERVER to be set.
 if [ -n "${NUODB_OPTIONS}" ] ; then
-    exec nuodocker start te --db-name "${DB_NAME}" --options "${NUODB_OPTIONS}" "$@"
+    exec nuodocker "${nuodocker_flags[@]}" start te --db-name "${DB_NAME}" --options "${NUODB_OPTIONS}" "$@"
 else
-    exec nuodocker start te --db-name "${DB_NAME}" "$@"
+    exec nuodocker "${nuodocker_flags[@]}" start te --db-name "${DB_NAME}" "$@"
 fi

--- a/stable/database/templates/_helpers.tpl
+++ b/stable/database/templates/_helpers.tpl
@@ -225,9 +225,21 @@ The configuration is imported only in the entrypoint cluster.
 {{- define "autoRestore.type" -}}
 {{- $valid := list "stream" "backupset" "" }}
 {{- if not (has .Values.database.autoRestore.type $valid) }}
-{{- fail "Invalid autorestore type" }}
+{{- fail (printf "Invalid autorestore type: %s" .Values.database.autoRestore.type) }}
 {{- end }}
 {{- with .Values.database.autoRestore.type }}
+{{- . }}
+{{- end -}}
+{{- end -}}
+
+{{- define "autoRestore.source" -}}
+{{- if hasPrefix ":" .Values.database.autoRestore.source }}
+{{- $valid := list ":latest" ":group-latest" "" }}
+{{- if not (has .Values.database.autoRestore.source $valid) }}
+{{- fail (printf "Invalid autorestore source: %s" .Values.database.autoRestore.source) }}
+{{- end }}
+{{- end -}}
+{{- with .Values.database.autoRestore.source }}
 {{- . }}
 {{- end -}}
 {{- end -}}

--- a/stable/database/templates/configmap.yaml
+++ b/stable/database/templates/configmap.yaml
@@ -69,7 +69,7 @@ data:
   NUODB_BACKUP_KEY: {{ default "/nuodb/nuobackup" .Values.nuodb.latestKey }}
   NUODB_AUTO_IMPORT: {{ default "" .Values.database.autoImport.source | quote }}
   NUODB_AUTO_IMPORT_TYPE: {{ default "stream" .Values.database.autoImport.type | quote }}
-  NUODB_AUTO_RESTORE: {{ default "" .Values.database.autoRestore.source | quote }}
+  NUODB_AUTO_RESTORE: {{ include "autoRestore.source" . | default "" | quote }}
   NUODB_AUTO_RESTORE_TYPE: {{ include "autoRestore.type" . | default "stream" | quote }}
   {{- if .Values.admin.tde }}
   NUODB_STORAGE_PASSWORDS_DIR: {{ default "/etc/nuodb/tde" .Values.admin.tde.storagePasswordsDir | quote }}

--- a/stable/restore/templates/_helpers.tpl
+++ b/stable/restore/templates/_helpers.tpl
@@ -152,6 +152,12 @@ Return the restore target.
 Return the restore source.
 */}}
 {{- define "restore.source" -}}
+{{- if hasPrefix ":" .Values.restore.source }}
+{{- $valid := list ":latest" ":group-latest" "" }}
+{{- if not (has .Values.restore.source $valid) }}
+{{- fail (printf "Invalid autorestore source: %s" .Values.restore.source) }}
+{{- end -}}
+{{- end -}}
 {{- default ":latest" .Values.restore.source | trimSuffix "-" -}}
 {{- end -}}
 

--- a/test/integration/template_database_restore_test.go
+++ b/test/integration/template_database_restore_test.go
@@ -1,9 +1,10 @@
 package integration
 
 import (
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"testing"
 
 	"github.com/gruntwork-io/terratest/modules/helm"
 	"github.com/nuodb/nuodb-helm-charts/v3/test/testlib"
@@ -24,14 +25,30 @@ func TestAutoRestoreGarbage(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestAutoRestoreSource(t *testing.T) {
+	// Path to the helm chart we will test
+	helmChartPath := testlib.DATABASE_HELM_CHART_PATH
+
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"database.autoRestore.source": ":garbage",
+		},
+	}
+
+	// There are reserved restore sources starting with ":" which are ":latest"
+	// and ":group-latest"; special sources that are not in allowed fails helm
+	// rendering; we can't really validate other sources as URLs and backup set
+	// names are also allowed
+	_, err := helm.RenderTemplateE(t, options, helmChartPath, "release-name", []string{"templates/configmap.yaml"})
+	require.Error(t, err)
+}
 
 func TestAutoRestoreDefault(t *testing.T) {
 	// Path to the helm chart we will test
 	helmChartPath := testlib.DATABASE_HELM_CHART_PATH
 
 	options := &helm.Options{
-		SetValues: map[string]string{
-		},
+		SetValues: map[string]string{},
 	}
 
 	// Run RenderTemplate to render the template and capture the output.
@@ -74,7 +91,6 @@ func TestAutoRestoreValidValueStream(t *testing.T) {
 
 	require.True(t, found)
 }
-
 
 func TestAutoRestoreValidValueBackupset(t *testing.T) {
 	// Path to the helm chart we will test

--- a/test/integration/template_restore_test.go
+++ b/test/integration/template_restore_test.go
@@ -200,3 +200,21 @@ func TestRestoreRequestStripLevels(t *testing.T) {
 		assert.True(t, testlib.EnvContains(restoreContainer.Env, "NUODB_RESTORE_REQUEST_STRIP_LEVELS", "2"))
 	}
 }
+
+func TestRestoreRequestSource(t *testing.T) {
+	// Path to the helm chart we will test
+	helmChartPath := testlib.RESTORE_HELM_CHART_PATH
+
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"restore.source": ":garbage",
+		},
+	}
+
+	// There are reserved restore sources starting with ":" which are ":latest"
+	// and ":group-latest"; special sources that are not in allowed fails helm
+	// rendering; we can't really validate other sources as URLs and backup set
+	// names are also allowed
+	_, err := helm.RenderTemplateE(t, options, helmChartPath, "release-name", []string{"templates/job.yaml"})
+	require.Error(t, err)
+}


### PR DESCRIPTION
**Changes**

The restore source can be one of the following:
- a backup set name that s available in the backup root directory
- remote URL
- `:latest`
- `:group-latest`

This change validates when a "special" reserved keyword starting with `:` is provided it is one of the valid keywords. A message is logged when automatic archive repair is skipped because the backup set is not available (this is the case in nonHC SMs).

`nuote` has been changed so that `--debug` flag is added if `NUODB_DEBUG` environment variable is set.

**Testing**
- new integration tests
- regression testing