### PR TITLE
Validate database.sm.hotCopy.enableBackups

### DIFF
--- a/stable/database/templates/_helpers.tpl
+++ b/stable/database/templates/_helpers.tpl
@@ -201,6 +201,10 @@ it by calling typeIs "bool" https://github.com/Masterminds/sprig/issues/111
 {{- if typeIs "bool" . -}}
 {{- . -}}
 {{- else -}}
+{{- $valid := list "true" "false" "" }}
+{{- if not (has . $valid) }}
+{{- fail (printf "Invalid boolean value: %s" .) }}
+{{- end }}
 {{- default true . -}}
 {{- end -}}
 {{- end -}}

--- a/test/integration/template_backup_test.go
+++ b/test/integration/template_backup_test.go
@@ -41,6 +41,22 @@ func TestDatabaseBackupCronJobDisabled(t *testing.T) {
 	assert.Contains(t, err.Error(), "could not find template")
 }
 
+func TestDatabaseBackupCronJobGarbage(t *testing.T) {
+	// Path to the helm chart we will test
+	helmChartPath := testlib.DATABASE_HELM_CHART_PATH
+
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"database.sm.hotCopy.enableBackups": "garbage",
+		},
+	}
+
+	// Garbage value fails helm rendering
+	_, err := helm.RenderTemplateE(t, options, helmChartPath, "release-name", []string{"templates/cronjob.yaml"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Invalid boolean value: garbage")
+}
+
 func TestDatabaseBackupCronJobRestartPolicyDefault(t *testing.T) {
 	// Path to the helm chart we will test
 	helmChartPath := "../../stable/database"


### PR DESCRIPTION
Example pasring error:

```bash
$ helm template stable/database --set database.sm.hotCopy.enableBackups="truee" | grep full-hotcopy-demo-cronjob
Error: template: database/templates/statefulset.yaml:414:84: executing "database/templates/statefulset.yaml" at <include "defaulttrue" .Values.database.sm.hotCopy.enableBackups>: error calling include: template: database/templates/_helpers.tpl:206:4: executing "defaulttrue" at <fail (printf "Invalid boolean value: %s" .)>: error calling fail: Invalid boolean value: truee

Use --debug flag to render out invalid YAML
```