### PR TITLE
B&R guide content re-order

### DIFF
--- a/docs/BackupAndRestore.md
+++ b/docs/BackupAndRestore.md
@@ -6,14 +6,14 @@ NuoDB provides several automated mechanisms for backing up and restoring a datab
 
 After database installation, the available backup and restore mechanisms are: 
 
-1. [Automatic archive initial import](#automatic-archive-initial-import)
-2. [Scheduled online database backups](#scheduled-online-database-backups)
-3. [Automatic archive restore](#automatic-archive-restore)
-4. [Archive seed restore](#archive-seed-restore)
-5. [Distributed database in-place restore](#distributed-database-in-place-restore)
-6. [Fine-grained archive selection](#fine-grained-archive-selection)
-7. [Distributed Database restore with storage groups](#distributed-database-restore-with-storage-groups)
-8. [Manual database restore](#manual-database-restore)
+1. [Scheduled online database backups](#scheduled-online-database-backups)
+2. [Fine-grained archive selection](#fine-grained-archive-selection)
+3. [Distributed database restore from source](#distributed-database-restore-from-source)
+4. [Distributed database restore with storage groups](#distributed-database-restore-with-storage-groups)
+5. [Manual database restore](#manual-database-restore)
+6. [Automatic archive initial import](#automatic-archive-initial-import)
+7. [Automatic archive restore](#automatic-archive-restore)
+8. [Archive seed restore](#archive-seed-restore)
 
 Several of these mechanisms require additional configuration before using.
 
@@ -51,13 +51,13 @@ The table below shows the compatibility matrix for different backup and restore 
 |                                       | NuoDB 4.0.x+ Helm Charts 2.x.x | NuoDB 4.0.x+ Helm Charts 3.0.x | NuoDB 4.0.x+ Helm Charts 3.1.x | NuoDB 4.2.x+ Helm Charts 3.2.x+ |
 |---------------------------------------|--------------------------------|--------------------------------|---------------------------------|---------------------------------|
 | Scheduled online database backups     | ✓<sup>[1]</sup>                | ✓<sup>[1]</sup>                | ✓                               | ✓                               |
-| Distributed database in-place restore | ✓<sup>[2]</sup><sup>[3]</sup>  | ✓<sup>[2]</sup><sup>[3]</sup>  | ✓<sup>[3]</sup>                 | ✓<sup>[3]</sup>                 |
-| Archive seed restore                  | ✓<sup>[4]</sup>                | ✓<sup>[4]</sup>                | ✓<sup>[4]</sup>                 | ✓                               |
+| Fine-grained archive selection        | -                              | -                              | -                               | ✓                               |
+| Distributed database restore from source | ✓<sup>[2]</sup><sup>[3]</sup>  | ✓<sup>[2]</sup><sup>[3]</sup>  | ✓<sup>[3]</sup>                 | ✓<sup>[3]</sup>                 |
+| Distributed database restore with storage groups  | -                              | -                              | -                               | ✓                               |
+| Manual database restore               | -                              | -                              | -                               | ✓                               |
 | Automatic archive initial import      | ✓                              | ✓                              | ✓                               | ✓                               |
 | Automatic archive restore             | ✓                              | ✓                              | ✓                               | ✓                               |
-| Fine-grained archive selection        | -                              | -                              | -                               | ✓                               |
-| Database restore with storage groups  | -                              | -                              | -                               | ✓                               |
-| Manual database restore               | -                              | -                              | -                               | ✓                               |
+| Archive seed restore                  | ✓<sup>[4]</sup>                | ✓<sup>[4]</sup>                | ✓<sup>[4]</sup>                 | ✓                               |
 
 [1] - Scheduled online backups workflow is supported by _initial_ database backup job and _post-restore_ cron job.
 Additional capability was added into the `nuobackup` script allowing the removal of these jobs in [Helm Charts v3.1.0](https://github.com/nuodb/nuodb-helm-charts/releases/tag/v3.1.0).
@@ -72,7 +72,7 @@ For detailed information about features, enhancements, and fixed problems, pleas
 
 > **NOTE**: The examples and the sample output shown in this document are specific to NuoDB 4.2.x+ and Helm Charts 3.2.x+.
 
-## Backup and Restore Mechanisms
+## Backup
 
 ### Scheduled online database backups
 
@@ -98,40 +98,6 @@ The `nuobackup` script is made available as a configMap and is used by all backu
 The _Full_ hot copy result is recorded into the NuoDB Admin domain key-value (KV) store upon successful finish.
 Use `nuobackup --type report-latest --db-name <db> --group <backup group>` to show the latest successful _full_ hot copy backup set for a specific backup group.
 
-The backup jobs execution should be monitored on a regular basis to ensure that they complete successfully.
-By default, each backup job execution will be retried on failure which can be configured by the  `database.hotCopy.restartPolicy` setting.
-The number of pods kept for failed backup jobs is defined by the `database.hotCopy.failureHistory` setting.
-This setting is useful when debugging failed backup job execution.
-The logs of the pod executing the job should be checked for errors.
-
-For example, the output below shows a failed full hot copy job:
-
-```bash
-kubectl get pods --selector job-name
-NAME                                                READY   STATUS             RESTARTS   AGE
-full-hotcopy-demo-cronjob-1613661840-rgpxv          0/1     Completed          0          32m
-full-hotcopy-demo-cronjob-1613663760-r8lm8          0/1     Error              1          14s
-```
-
-The logs from the pod indicate that there are no running SMs that match the provided labels.
-
-```bash
-kubectl logs full-hotcopy-demo-cronjob-1613663760-r8lm8
-Starting full backup for database demo on processes with labels 'backup cluster0 ' ...
-'backup database' failed: No SMs found matching the provided labels backup cluster0
-Error running hotcopy 1
-```
-
-Further investigation shows that the HC SMs statefulset has been scaled down to 0 replicas.
-
-```bash
-kubectl get statefulsets.apps
-NAME                                      READY   AGE
-admin-nuodb-cluster0                      1/1     3h41m
-sm-database-nuodb-cluster0-demo           2/2     3h41m
-sm-database-nuodb-cluster0-demo-hotcopy   0/0     3h41m
-```
-
 > **IMPORTANT**: It is important to take periodic journal hot copies when journal hot copy is enabled. Otherwise, the journal will keep growing which can lead to filling the archive volume space.
 
 It is possible to disable backup jobs creation by setting `hotcopy.enableBackups` to `false`.
@@ -142,6 +108,8 @@ Custom backup jobs that use the `nuobackup` script can be configured to support 
 There are no backup retention policies currently available.
 The admin user is responsible to make sure that there is enough space in the backup volume of each SM for new hot copies to be created.
 Customer provided `ReadWriteMany` backup volumes, such as Elastic Block Store (EBS) and Azure Files, can be used  to enable retention management using cloud tooling.
+
+## Restore
 
 ### Restore/Import source and type
 
@@ -168,7 +136,29 @@ A remote _stream_ source is downloaded and extracted directly into the archive d
 - _backupset_ - Hot copy backup set which is either fetched from a remote source or available in the backup directory.
 A remote _backupset_ requires additional space as it is downloaded and extracted temporarily in the archive volume to be used during archive restore operation.
 
-### Distributed database in-place restore
+### Fine-grained archive selection
+
+NuoDB _restore_ chart provides several ways to select which archives should be restored during the [distributed database restore](#distributed-database-restore-from-source) or [archive seed restore](#archive-seed-restore).
+
+- explicitly selecting specific archive IDs - `restore.archiveIds` variable can be set to specific archive IDs in the domain state for the target database.
+To list all archives for a database, the `nuocmd show archives --db-name <db>` is used.
+The process for each archive can be seen under the archive info which makes it easier for the user to mark the archives for restore.
+- selecting archives served by database processes with specific labels - `restore.labels` can be used to configure process labels, which then define the archives which will be selected for a restore.
+Any configured label and value that matches an SM process will add its archive to the list of selected archives for a restore.
+For instance, this can be used to easily select all SMs in a specific backup group - `--set restore.labels.backup="<backup group>"`.
+
+NuoDB will automatically assign the following process labels:
+
+- archive-pvc - the name of the archive PVC associated to this pod (available only for SMs)
+- container-id - the ID of the container
+- pod-name - Kubernetes pod name
+- pod-uid - Kubernetes pod UID
+- backup - The name of the backup group (available only for HC SMs)
+- host - Kubernetes node hostname on which the pod is running (available only for TEs)
+
+### Distributed restore
+
+#### Distributed database restore from source
 
 Database in-place restore can recover from a complete loss or data corruption of all database archives by reverting the database state to a previous restore point.
 NuoDB _restore_ chart is used to **overwrite** the existing database state using a configured restore source.
@@ -280,91 +270,103 @@ To perform a database restore in multi-cluster deployment, proceed with one of t
 3. Configure HC SMs in all clusters to be part of a single backup group and leave one set of backup jobs enabled in only one of the clusters to control this backup group.
 This will ensure that all HC SMs backups will be coordinated during hot copy requests.
 
-### Fine-grained archive selection
+#### Distributed database restore with storage groups
 
-NuoDB _restore_ chart provides several ways to select which archives should be restored during [distributed database in-place restore](#distributed-database-in-place-restore) or [archive seed restore](#archive-seed-restore).
+Database restore using user-defined storage groups is a special case of a database restore operation.
+The process is documented in the [Distributed database restore from source](#distributed-database-restore-from-source) section. Several considerations need to be taken into account:
 
-- explicitly selecting specific archive IDs - `restore.archiveIds` variable can be set to specific archive IDs in the domain state for the target database.
-To list all archives for a database, the `nuocmd show archives --db-name <db>` is used.
-The process for each archive can be seen under the archive info which makes it easier for the user to mark the archives for restore.
-- selecting archives served by database processes with specific labels - `restore.labels` can be used to configure process labels, which then define the archives which will be selected for a restore.
-Any configured label and value that matches an SM process will add its archive to the list of selected archives for a restore.
-For instance, this can be used to easily select all SMs in a specific backup group - `--set restore.labels.backup="<backup group>"`.
+- a complete set of archives serving all storage groups must be restored when performing database in-place restore
+- to ensure that backup coverage is complete, each storage group must be served by at least one HC SM
 
-NuoDB will automatically assign the following process labels:
+A complete set of archives can be selected using several of the methods described in [Fine-grained archive selection](#fine-grained-archive-selection) section. NuoDB won't perform any special checks during database restore to ensure that the archives selected for a restore are a complete set of archives.
+If some of the storage groups are missing from the selection, their state won't be restored.
 
-- archive-pvc - the name of the archive PVC associated to this pod (available only for SMs)
-- container-id - the ID of the container
-- pod-name - Kubernetes pod name
-- pod-uid - Kubernetes pod UID
-- backup - The name of the backup group (available only for HC SMs)
-- host - Kubernetes node hostname on which the pod is running (available only for TEs)
+> **NOTE**: For more information about storage groups, check [Using Table Partitions and Storage Groups](https://doc.nuodb.com/nuodb/latest/database-administration/using-table-partitions-and-storage-groups/)
 
-### Archive seed restore
+#### Manual database restore
 
-The _archive seed restore_ operation restores a corrupted or lost archive while the database is running.
-This operation will reset the existing archive state, and once it joins the database, the new SM will sync to the current state of the running database.
-For this reason, you cannot restore the entire database by restoring a single SM in a running database.
-The _seed restore_ has the potential to reduce the _SYNCing_ time from other running SMs as only the changed atoms will be transferred.
-The database will remain running throughout this operation.
+_Manual database restore_ is a special case of database restore operation and allows complex restore operations to be executed easier in Kubernetes deployments.
+The _Manual database restore_ operation is initiated by installing the _restore_ chart with `restore.manual="true"` which creates a manual restore request.
+This mode blocks all database pods before allowing them to form a database, in order to give the user access to the persistent volumes used by an SM.
+After the archive restore is marked as completed, NuoDB will unblock the processes, a restore coordinator will be selected and the restore process will continue as documented in the [Distributed database restore from source](#distributed-database-restore-from-source) section.
 
-The high-level steps to perform _archive seed restore_ are the following:
+As an example, a point-in-time (PiT) restore in a new environment will be demonstrated to fix a "fat-finger" error in production.
+Currently, the automatic initial archive restore doesn't support restore to a specific point in time, hence an _Manual database restore_ is used.
 
-1. Identify which archives will be restored.
-2. Ensure that the restore source is available either locally in the backup volume or as a remote URL.
-3. Ensure that there is enough free disk space in the archive volume of each SM selected for restore so that it can accommodate a backup of the existing archive contents and the restored archive.
-If a backup set using URL is selected as a restore source, it will be downloaded temporarily in the archive directory.
-4. Invoke the database restore request by installing the NuoDB _restore_ chart and selecting archives for restore.
-5. Start or restart the selected SM
+> **NOTE**: For more information on PiT restore and `nuoarchive`, please check [here](https://doc.nuodb.com/nuodb/latest/reference-information/command-line-tools/nuodb-archive/nuodb-archive---restoring/).
 
-In this example, there is an SM exited because it experienced archive data corruption.
-One way to fix the issue is to completely delete the corrupted archive and let the SM sync the whole archive from one of the running processes in the database.
-To reduce the sync time, we can upload one of the recent online database backups to a remote location and restore the corrupted archive.
+We have selected to restore from a backup set that has several journal backup elements which can be seen using `nuoarchive restore --report-backups <backup set>`:
 
-> **NOTE**: A copy of an archive or backup set from another database can't be used to perform _archive seed restore_. Otherwise the Storage Manager process will fail to start with error _Archive "/var/opt/nuodb/archive/nuodb/demo" doesn't match database.  Expected UUID \*\*\*, got \*\*\*._
+```xml
+<BackupSet id="323ba60e-f8ff-6040-438c-c16e397f52ff" database="demo" databaseId="84a3b51b-3a17-444c-f188-e4836769c12a" collectionId="772d059c-7fba-40f9-8f1c-2ec4c820a152" archiveId="b18a0698-c630-3e4a-e59c-739d86752ecd">
+    <BackupElements>
+        <BackupElement id="b3e78c2b-45a7-4a4c-841f-fca454d324e5" type="journal" startDate="2021-02-19 17:01:05" endDate="2021-02-19 17:01:05"/>
+        <BackupElement id="7733fdd4-0a00-416b-a819-1dbfe442481d" type="journal" startDate="2021-02-19 17:00:06" endDate="2021-02-19 17:00:06"/>
+        <BackupElement id="cba2d8ae-8553-49f6-8d4b-6cedddf4b18a" type="incremental" startDate="2021-02-19 17:00:08" endDate="2021-02-19 17:00:08"/>
+        <BackupElement id="772d059c-7fba-40f9-8f1c-2ec4c820a152" type="full" startDate="2021-02-19 17:00:05" endDate="2021-02-19 17:00:05"/>
+    </BackupElements>
+</BackupSet>
+```
 
-Select the archive for restore by specifying either `restore.archiveIds` or `restore.labels` and install the _restore_ chart with `restore.type="archive"`.
-We are using the `pod-name` process label to select the desired SM.
+The target for the restore will be a pre-production database that is already running.
+Since the backup set used here is taken from a different environment, all database archives will need to be restored.
+We are using a database with two SMs for simplicity and request both database archives for a restore.
 
 ```bash
-helm install restore nuodb/restore \
+helm install -n nuodb restore nuodb/restore \
   --namespace nuodb \
   --set cloud.cluster.name="cluster0" \
   --set admin.domain="nuodb" \
   --set restore.target=demo \
-  --set restore.type=archive \
-  --set restore.source="http://nginx.web.svc.cluster.local/20210219T160002.tar.gz" \
-  --set restore.labels.pod-name="sm-database-nuodb-cluster0-demo-1"
+  --set restore.type=database \
+  --set restore.source="http://nginx.web.svc.cluster.local/20210219T170005.tar.gz" \
+  --set restore.archiveIds="{0,1}" \
+  --set restore.manual=true
 ```
 
-By default the database process selected for a restore will be restarted if it is running which can be seen from the logs of the restore pod.
+The SM process serving archive IDs 0 and 1 will block and wait for their archives to be restored which is visible in the log below.
+All TEs will wait for the database restore to complete before they attempt to start.
 
 ```
-2021-03-02T11:25:44.199+0000 restore_type=archive; restore_source=http://nginx.web.svc.cluster.local/20210219T160002.tar.gz; arguments= --labels pod-name sm-database-nuodb-cluster0-demo-1
-2021-03-02T11:25:46.838+0000 restore.autoRestart=true - initiating process startId=0 restart
-2021-03-02T11:25:47.509+0000 Restore job completed
-```
-
-The SM will download the remote source and perform the requested restore while the rest of the database is running.
-A successful restore should be seen in the log of the SM pod:
-
-```
-2021-02-19T16:25:43.586+0000 Archive with archiveId=1 has been requested for a restore
-2021-02-19T16:25:43.591+0000 Archive restore will be performed for archiveId=1, source=http://nginx.web.svc.cluster.local/20210219T160002.tar.gz, type=backupset, strip=1
-2021-02-19T16:25:43.600+0000 Restoring http://nginx.web.svc.cluster.local/20210219T160002.tar.gz; existing archive directores: total 8
-drwxr-xr-x 33 nuodb root 4096 Feb 19 16:25 demo
-drwxr-xr-x  2 nuodb root 4096 Feb 19 10:32 demo-save-20210219T103236
-2021-02-19T16:25:43.682+0000 (restore) recreated /var/opt/nuodb/archive/nuodb/demo; atoms=0
-2021-02-19T16:25:43.693+0000 curl -k  http://nginx.web.svc.cluster.local/20210219T160002.tar.gz | tar xzf - --strip-components 1 -C /var/opt/nuodb/archive/nuodb/20210219T160002-downloaded
-  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
-                                 Dload  Upload   Total   Spent    Left  Speed
-100  100k  100  100k    0     0  9164k      0 --:--:-- --:--:-- --:--:-- 9164k
-2021-02-19T16:25:44.285+0000 restoring archive and/or clearing restored archive physical metadata
-2021-02-19T16:25:45.876+0000 Finished restoring /var/opt/nuodb/archive/nuodb/20210219T160002-downloaded to /var/opt/nuodb/archive/nuodb/demo. Created archive with archive ID 8
-2021-02-19T16:25:45.879+0000 removing /var/opt/nuodb/archive/nuodb/20210219T160002-downloaded
-2021-02-19T16:25:48.585+0000 Restore request for archiveId=1 marked as completed
 ...
+2021-02-19T17:10:13.019+0000 INFO  root Manual restore has been requested for archiveId=0, database=demo. Waiting for archive restore to complete ...
 ```
+
+Once connected to the corresponding SM pod, the archive restore is done manually by using `nuoarchive restore --report-timestamps` and `nuoarchive restore --restore-snapshot` commands.
+The first command will report timestamp and transaction ID mappings available for PiT restore, and the second command will restore the snapshot identified by a transaction ID.
+
+```
+2021-02-19T17:00:30 4484
+2021-02-19T17:00:31 4868
+```
+
+In this example, transaction ID 4484 will be used during the restore.
+
+```bash
+cd /var/opt/nuodb/archive/nuodb
+mv demo demo-save-20210219T183055
+mkdir download && cd download
+curl -k  http://nginx.web.svc.cluster.local/20210219T170005.tar.gz | tar xzf - -C .
+
+nuoarchive restore --report-timestamps $PWD/20210219T170005
+
+nuoarchive restore --restore-snapshot 4484 --restore-dir ../demo $PWD/20210219T170005
+```
+
+After successful archive restore, its original archive ID should be marked as complete.
+This will delete the archive metadata from the NuoDB Admin tier and will cause the SM to proceed with its startup operations.
+
+```
+nuodocker complete restore --db-name demo --archive-ids 0
+```
+
+Repeat the above steps for archive ID 1.
+
+> **NOTE**: If the database has only one archive, you will need to delete the database by using `nuocmd delete database --db-name <db>` before the last archive can be removed.
+`nuodocker start sm` will automatically recreate the database and the archive once the archive restore is marked complete.
+
+The database restore request will be cleared after a successful database in-place restore and can be viewed using `nuodocker get restore-requests --db-name <db>`.
+The database state should be manually verified by `nuocmd show domain` and using SQL queries to ensure that it's in the desired state after a successful restore.
 
 ### Automatic archive initial import
 
@@ -522,100 +524,124 @@ drwxr-xr-x  2 nuodb root 4096 Feb 19 10:32 demo-save-20210219T103238
 ...
 ```
 
-### Distributed database restore with storage groups
+### Archive seed restore
 
-Database restore using user-defined storage groups is a special case of a database restore operation.
-The process is documented in the [Distributed database in-place restore](#distributed-database-in-place-restore) section. Several considerations need to be taken into account:
+The _archive seed restore_ operation restores a corrupted or lost archive while the database is running.
+This operation will reset the existing archive state, and once it joins the database, the new SM will sync to the current state of the running database.
+For this reason, you cannot restore the entire database by restoring a single SM in a running database.
+The _seed restore_ has the potential to reduce the _SYNCing_ time from other running SMs as only the changed atoms will be transferred.
+The database will remain running throughout this operation.
 
-- a complete set of archives serving all storage groups must be restored when performing database in-place restore
-- to ensure that backup coverage is complete, each storage group must be served by at least one HC SM
+The high-level steps to perform _archive seed restore_ are the following:
 
-A complete set of archives can be selected using several of the methods described in [Fine-grained archive selection](#fine-grained-archive-selection) section. NuoDB won't perform any special checks during database restore to ensure that the archives selected for a restore are a complete set of archives.
-If some of the storage groups are missing from the selection, their state won't be restored.
+1. Identify which archives will be restored.
+2. Ensure that the restore source is available either locally in the backup volume or as a remote URL.
+3. Ensure that there is enough free disk space in the archive volume of each SM selected for restore so that it can accommodate a backup of the existing archive contents and the restored archive.
+If a backup set using URL is selected as a restore source, it will be downloaded temporarily in the archive directory.
+4. Invoke the database restore request by installing the NuoDB _restore_ chart and selecting archives for restore.
+5. Start or restart the selected SM
 
-> **NOTE**: For more information about storage groups, check [Using Table Partitions and Storage Groups](https://doc.nuodb.com/nuodb/latest/database-administration/using-table-partitions-and-storage-groups/)
+In this example, there is an SM exited because it experienced archive data corruption.
+One way to fix the issue is to completely delete the corrupted archive and let the SM sync the whole archive from one of the running processes in the database.
+To reduce the sync time, we can upload one of the recent online database backups to a remote location and restore the corrupted archive.
 
-### Manual database restore
+> **NOTE**: A copy of an archive or backup set from another database can't be used to perform _archive seed restore_. Otherwise the Storage Manager process will fail to start with error _Archive "/var/opt/nuodb/archive/nuodb/demo" doesn't match database.  Expected UUID \*\*\*, got \*\*\*._
 
-_Manual database restore_ is a special case of database restore operation and allows complex restore operations to be executed easier in Kubernetes deployments.
-The _Manual database restore_ operation is initiated by installing the _restore_ chart with `restore.manual="true"` which creates a manual restore request.
-This mode blocks all database pods before allowing them to form a database, in order to give the user access to the persistent volumes used by an SM.
-After the archive restore is marked as completed, NuoDB will unblock the processes, a restore coordinator will be selected and the restore process will continue as documented in the [Distributed database in-place restore](#distributed-database-in-place-restore) section.
-
-As an example, a point-in-time (PiT) restore in a new environment will be demonstrated to fix a "fat-finger" error in production.
-Currently, the automatic initial archive restore doesn't support restore to a specific point in time, hence an _Manual database restore_ is used.
-
-> **NOTE**: For more information on PiT restore and `nuoarchive`, please check [here](https://doc.nuodb.com/nuodb/latest/reference-information/command-line-tools/nuodb-archive/nuodb-archive---restoring/).
-
-We have selected to restore from a backup set that has several journal backup elements which can be seen using `nuoarchive restore --report-backups <backup set>`:
-
-```xml
-<BackupSet id="323ba60e-f8ff-6040-438c-c16e397f52ff" database="demo" databaseId="84a3b51b-3a17-444c-f188-e4836769c12a" collectionId="772d059c-7fba-40f9-8f1c-2ec4c820a152" archiveId="b18a0698-c630-3e4a-e59c-739d86752ecd">
-    <BackupElements>
-        <BackupElement id="b3e78c2b-45a7-4a4c-841f-fca454d324e5" type="journal" startDate="2021-02-19 17:01:05" endDate="2021-02-19 17:01:05"/>
-        <BackupElement id="7733fdd4-0a00-416b-a819-1dbfe442481d" type="journal" startDate="2021-02-19 17:00:06" endDate="2021-02-19 17:00:06"/>
-        <BackupElement id="cba2d8ae-8553-49f6-8d4b-6cedddf4b18a" type="incremental" startDate="2021-02-19 17:00:08" endDate="2021-02-19 17:00:08"/>
-        <BackupElement id="772d059c-7fba-40f9-8f1c-2ec4c820a152" type="full" startDate="2021-02-19 17:00:05" endDate="2021-02-19 17:00:05"/>
-    </BackupElements>
-</BackupSet>
-```
-
-The target for the restore will be a pre-production database that is already running.
-Since the backup set used here is taken from a different environment, all database archives will need to be restored.
-We are using a database with two SMs for simplicity and request both database archives for a restore.
+Select the archive for restore by specifying either `restore.archiveIds` or `restore.labels` and install the _restore_ chart with `restore.type="archive"`.
+We are using the `pod-name` process label to select the desired SM.
 
 ```bash
-helm install -n nuodb restore nuodb/restore \
+helm install restore nuodb/restore \
   --namespace nuodb \
   --set cloud.cluster.name="cluster0" \
   --set admin.domain="nuodb" \
   --set restore.target=demo \
-  --set restore.type=database \
-  --set restore.source="http://nginx.web.svc.cluster.local/20210219T170005.tar.gz" \
-  --set restore.archiveIds="{0,1}" \
-  --set restore.manual=true
+  --set restore.type=archive \
+  --set restore.source="http://nginx.web.svc.cluster.local/20210219T160002.tar.gz" \
+  --set restore.labels.pod-name="sm-database-nuodb-cluster0-demo-1"
 ```
 
-The SM process serving archive IDs 0 and 1 will block and wait for their archives to be restored which is visible in the log below.
-All TEs will wait for the database restore to complete before they attempt to start.
+By default the database process selected for a restore will be restarted if it is running which can be seen from the logs of the restore pod.
 
 ```
+2021-03-02T11:25:44.199+0000 restore_type=archive; restore_source=http://nginx.web.svc.cluster.local/20210219T160002.tar.gz; arguments= --labels pod-name sm-database-nuodb-cluster0-demo-1
+2021-03-02T11:25:46.838+0000 restore.autoRestart=true - initiating process startId=0 restart
+2021-03-02T11:25:47.509+0000 Restore job completed
+```
+
+The SM will download the remote source and perform the requested restore while the rest of the database is running.
+A successful restore should be seen in the log of the SM pod:
+
+```
+2021-02-19T16:25:43.586+0000 Archive with archiveId=1 has been requested for a restore
+2021-02-19T16:25:43.591+0000 Archive restore will be performed for archiveId=1, source=http://nginx.web.svc.cluster.local/20210219T160002.tar.gz, type=backupset, strip=1
+2021-02-19T16:25:43.600+0000 Restoring http://nginx.web.svc.cluster.local/20210219T160002.tar.gz; existing archive directores: total 8
+drwxr-xr-x 33 nuodb root 4096 Feb 19 16:25 demo
+drwxr-xr-x  2 nuodb root 4096 Feb 19 10:32 demo-save-20210219T103236
+2021-02-19T16:25:43.682+0000 (restore) recreated /var/opt/nuodb/archive/nuodb/demo; atoms=0
+2021-02-19T16:25:43.693+0000 curl -k  http://nginx.web.svc.cluster.local/20210219T160002.tar.gz | tar xzf - --strip-components 1 -C /var/opt/nuodb/archive/nuodb/20210219T160002-downloaded
+  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
+                                 Dload  Upload   Total   Spent    Left  Speed
+100  100k  100  100k    0     0  9164k      0 --:--:-- --:--:-- --:--:-- 9164k
+2021-02-19T16:25:44.285+0000 restoring archive and/or clearing restored archive physical metadata
+2021-02-19T16:25:45.876+0000 Finished restoring /var/opt/nuodb/archive/nuodb/20210219T160002-downloaded to /var/opt/nuodb/archive/nuodb/demo. Created archive with archive ID 8
+2021-02-19T16:25:45.879+0000 removing /var/opt/nuodb/archive/nuodb/20210219T160002-downloaded
+2021-02-19T16:25:48.585+0000 Restore request for archiveId=1 marked as completed
 ...
-2021-02-19T17:10:13.019+0000 INFO  root Manual restore has been requested for archiveId=0, database=demo. Waiting for archive restore to complete ...
 ```
 
-Once connected to the corresponding SM pod, the archive restore is done manually by using `nuoarchive restore --report-timestamps` and `nuoarchive restore --restore-snapshot` commands.
-The first command will report timestamp and transaction ID mappings available for PiT restore, and the second command will restore the snapshot identified by a transaction ID.
+## Troubleshooting
 
-```
-2021-02-19T17:00:30 4484
-2021-02-19T17:00:31 4868
-```
+### Backup failure
 
-In this example, transaction ID 4484 will be used during the restore.
+The backup jobs execution should be monitored on a regular basis to ensure that they complete successfully.
+By default, each backup job execution will be retried on failure which can be configured by the  `database.hotCopy.restartPolicy` setting.
+The number of pods kept for failed backup jobs is defined by the `database.hotCopy.failureHistory` setting.
+This setting is useful when debugging failed backup job execution.
+The logs of the pod executing the job should be checked for errors.
+
+#### No SM matching backup labels
+
+For example, the output below shows a failed full hot copy job:
 
 ```bash
-cd /var/opt/nuodb/archive/nuodb
-mv demo demo-save-20210219T183055
-mkdir download && cd download
-curl -k  http://nginx.web.svc.cluster.local/20210219T170005.tar.gz | tar xzf - -C .
-
-nuoarchive restore --report-timestamps $PWD/20210219T170005
-
-nuoarchive restore --restore-snapshot 4484 --restore-dir ../demo $PWD/20210219T170005
+kubectl get pods --selector job-name
+NAME                                                READY   STATUS             RESTARTS   AGE
+full-hotcopy-demo-cronjob-1613661840-rgpxv          0/1     Completed          0          32m
+full-hotcopy-demo-cronjob-1613663760-r8lm8          0/1     Error              1          14s
 ```
 
-After successful archive restore, its original archive ID should be marked as complete.
-This will delete the archive metadata from the NuoDB Admin tier and will cause the SM to proceed with its startup operations.
+The logs from the pod indicate that there are no running SMs that match the provided labels.
 
+```bash
+kubectl logs full-hotcopy-demo-cronjob-1613663760-r8lm8
+Starting full backup for database demo on processes with labels 'backup cluster0 ' ...
+'backup database' failed: No SMs found matching the provided labels backup cluster0
+Error running hotcopy 1
 ```
-nuodocker complete restore --db-name demo --archive-ids 0
+
+Further investigation shows that the HC SMs statefulset has been scaled down to 0 replicas.
+
+```bash
+kubectl get statefulsets.apps
+NAME                                      READY   AGE
+admin-nuodb-cluster0                      1/1     3h41m
+sm-database-nuodb-cluster0-demo           2/2     3h41m
+sm-database-nuodb-cluster0-demo-hotcopy   0/0     3h41m
 ```
 
-Repeat the above steps for archive ID 1.
+#### Overlapping backups
 
-> **NOTE**: If the database has only one archive, you will need to delete the database by using `nuocmd delete database --db-name <db>` before the last archive can be removed.
-`nuodocker start sm` will automatically recreate the database and the archive once the archive restore is marked complete.
+TBD
 
-The database restore request will be cleared after a successful database in-place restore and can be viewed using `nuodocker get restore-requests --db-name <db>`.
-The database state should be manually verified by `nuocmd show domain` and using SQL queries to ensure that it's in the desired state after a successful restore.
+#### Backup storage full
+
+TBD
+
+### Restore failure
+
+TBD
+
+#### Invalid restore source
+
+TBD


### PR DESCRIPTION
**Changes**
Re-orders the B&R document content as suggested by QA for better readability.
New table of contents:
```
Introduction
- Terminology
- Compatibility Matrix
Backup
- Scheduled online database backups
-- Backup retention management
Restore
- Restore/Import source and type
- Fine-grained archive selection
- Distributed restore
-- Distributed database restore from source
-- Distributed database restore with storage groups
-- Manual database restore
- Automatic archive initial import
- Automatic archive restore
- Archive seed restore
Troubleshooting
- Backup failure
-- ...
- Restore failure
-- ...
```

Note: No major changes to the actual content has been done in this PR. 
I'll open another PR for the new content so that it's easier to review.