### PR TITLE
Override thrift.message.max to enable catching up admins

### DIFF
--- a/stable/admin/values.yaml
+++ b/stable/admin/values.yaml
@@ -166,6 +166,11 @@ admin:
     # packet to close the admin connection, leaving a database process entry
     # in the domain state that has no running Pod associated with it
     processLivenessCheckSec: 30
+    # increase maximum message size that can be sent between admin processes;
+    # if catching up a server using a snapshot, we may have to serialize our
+    # entire Raft state into one message; set maximum message size to 1GB to
+    # allow Raft state to grow to 1GB
+    thrift.message.max: "1073741824"
 
   ## nuodb-admin resource requests and limits
   ## Ref: http://kubernetes.io/docs/user-guide/compute-resources/

--- a/test/minikube/minikube_upgrade_helm_test.go
+++ b/test/minikube/minikube_upgrade_helm_test.go
@@ -197,11 +197,15 @@ func TestUpgradeHelm(t *testing.T) {
 
 	t.Run("NuoDB_From310_ToLocal", func(t *testing.T) {
 		upgradeAdminTest(t, "3.1.0", &UpdateOptions{
+			adminPodShouldGetRecreated: true,
+			adminJobWasCreated:         true,
 		})
 	})
 
 	t.Run("NuoDB_From320_ToLocal", func(t *testing.T) {
 		upgradeAdminTest(t, "3.2.0", &UpdateOptions{
+			adminPodShouldGetRecreated: true,
+			adminJobWasCreated:         true,
 		})
 	})
 }
@@ -244,11 +248,15 @@ func TestUpgradeHelmFullDB(t *testing.T) {
 
 	t.Run("NuoDB_From310_ToLocal", func(t *testing.T) {
 		upgradeDatabaseTest(t, "3.1.0", &UpdateOptions{
+			adminPodShouldGetRecreated: true,
+			adminJobWasCreated:         true,
 		})
 	})
 
 	t.Run("NuoDB_From320_ToLocal", func(t *testing.T) {
 		upgradeDatabaseTest(t, "3.2.0", &UpdateOptions{
+			adminPodShouldGetRecreated: true,
+			adminJobWasCreated:         true,
 		})
 	})
 }

--- a/test/minikube/minikube_upgrade_helm_test.go
+++ b/test/minikube/minikube_upgrade_helm_test.go
@@ -198,14 +198,12 @@ func TestUpgradeHelm(t *testing.T) {
 	t.Run("NuoDB_From310_ToLocal", func(t *testing.T) {
 		upgradeAdminTest(t, "3.1.0", &UpdateOptions{
 			adminPodShouldGetRecreated: true,
-			adminJobWasCreated:         true,
 		})
 	})
 
 	t.Run("NuoDB_From320_ToLocal", func(t *testing.T) {
 		upgradeAdminTest(t, "3.2.0", &UpdateOptions{
 			adminPodShouldGetRecreated: true,
-			adminJobWasCreated:         true,
 		})
 	})
 }
@@ -249,14 +247,12 @@ func TestUpgradeHelmFullDB(t *testing.T) {
 	t.Run("NuoDB_From310_ToLocal", func(t *testing.T) {
 		upgradeDatabaseTest(t, "3.1.0", &UpdateOptions{
 			adminPodShouldGetRecreated: true,
-			adminJobWasCreated:         true,
 		})
 	})
 
 	t.Run("NuoDB_From320_ToLocal", func(t *testing.T) {
 		upgradeDatabaseTest(t, "3.2.0", &UpdateOptions{
 			adminPodShouldGetRecreated: true,
-			adminJobWasCreated:         true,
 		})
 	})
 }


### PR DESCRIPTION
Currently we cannot catch up admins with a snapshot if the Raft state is
larger than 10MB, because that is the current default value of
thrift.message.max. Override this to allow Raft state to grow up to 1GB.