### PR TITLE
[HELM-281] Recursively change permissions in init container

### DIFF
--- a/stable/admin/templates/statefulset.yaml
+++ b/stable/admin/templates/statefulset.yaml
@@ -59,7 +59,7 @@ spec:
       - name: init-disk
         image: {{ template "init.image" . }}
         imagePullPolicy: {{ default "" .Values.busybox.image.pullPolicy }}
-        command: ['chmod' , '770', '/var/opt/nuodb', '/var/log/nuodb']
+        command: ['chmod', '-R', '770', '/var/opt/nuodb', '/var/log/nuodb']
         volumeMounts:
         - name: raftlog
           mountPath: /var/opt/nuodb


### PR DESCRIPTION
Recursively change permissions in init container so that any files that
happen to be in the persistent volume are made accessible to the nuodb
user (the nuodb user is in the root group and is given access to files
by making them group-readable and -writable).