### PR TITLE
Driveby test fixes to SplitAndRender

### DIFF
--- a/test/integration/template_collector_test.go
+++ b/test/integration/template_collector_test.go
@@ -138,7 +138,7 @@ func executeSidecarTests(t *testing.T, options *helm.Options) {
 		helmChartPath := testlib.DATABASE_HELM_CHART_PATH
 		output := helm.RenderTemplate(t, options, testlib.DATABASE_HELM_CHART_PATH, "release-name", []string{"templates/statefulset.yaml"})
 
-		for _, obj := range testlib.SplitAndRenderStatefulSet(t, output, 1) {
+		for _, obj := range testlib.SplitAndRenderStatefulSet(t, output, 2) {
 			t.Logf("Inspecting database statefulset: %s", obj.Name)
 			checkSpecVolumes(t, obj.Spec.Template.Spec.Volumes, options, helmChartPath)
 			checkSidecarContainers(t, obj.Spec.Template.Spec.Containers, options, helmChartPath)

--- a/test/integration/template_database_test.go
+++ b/test/integration/template_database_test.go
@@ -636,41 +636,7 @@ func TestDatabasePodAnnotationsRender(t *testing.T) {
 		// Run RenderTemplate to render the template and capture the output.
 		output := helm.RenderTemplate(t, options, helmChartPath, "release-name", []string{"templates/statefulset.yaml"})
 
-		for _, obj := range testlib.SplitAndRenderStatefulSet(t, output, 1) {
-			assert.Equal(t, options.SetValues["database.podAnnotations.key1"], obj.Spec.Template.ObjectMeta.Annotations["key1"])
-			assert.Equal(t, options.SetValues["database.podAnnotations.key2"], obj.Spec.Template.ObjectMeta.Annotations["key2"])
-			assert.Equal(t, options.SetValues["database.podAnnotations.key3\\.key3"], obj.Spec.Template.ObjectMeta.Annotations["key3.key3"])
-			assert.Equal(t, options.SetValues["database.podAnnotations.key4\\.key4/key4"], obj.Spec.Template.ObjectMeta.Annotations["key4.key4/key4"])
-			assert.Equal(t, options.SetValues["database.podAnnotations.key5\\.key5/key5"], obj.Spec.Template.ObjectMeta.Annotations["key5.key5/key5"])
-			assert.Equal(t, options.SetValues["database.podAnnotations.vault\\.hashicorp\\.com/agent-inject"], obj.Spec.Template.ObjectMeta.Annotations["vault.hashicorp.com/agent-inject"])
-			assert.Equal(t, options.SetValues["database.podAnnotations.vault\\.hashicorp\\.com/agent-inject-template-ca\\.cert"], obj.Spec.Template.ObjectMeta.Annotations["vault.hashicorp.com/agent-inject-template-ca.cert"])
-		}
-	})
-
-	t.Run("testStatefulSet", func(t *testing.T) {
-		// Run RenderTemplate to render the template and capture the output.
-		output := helm.RenderTemplate(t, options, helmChartPath, "release-name", []string{"templates/statefulset.yaml"})
-
 		for _, obj := range testlib.SplitAndRenderStatefulSet(t, output, 2) {
-			assert.Equal(t, options.SetValues["database.podAnnotations.key1"], obj.Spec.Template.ObjectMeta.Annotations["key1"])
-			assert.Equal(t, options.SetValues["database.podAnnotations.key2"], obj.Spec.Template.ObjectMeta.Annotations["key2"])
-			assert.Equal(t, options.SetValues["database.podAnnotations.key3\\.key3"], obj.Spec.Template.ObjectMeta.Annotations["key3.key3"])
-			assert.Equal(t, options.SetValues["database.podAnnotations.key4\\.key4/key4"], obj.Spec.Template.ObjectMeta.Annotations["key4.key4/key4"])
-			assert.Equal(t, options.SetValues["database.podAnnotations.key5\\.key5/key5"], obj.Spec.Template.ObjectMeta.Annotations["key5.key5/key5"])
-			assert.Equal(t, options.SetValues["database.podAnnotations.vault\\.hashicorp\\.com/agent-inject"], obj.Spec.Template.ObjectMeta.Annotations["vault.hashicorp.com/agent-inject"])
-			assert.Equal(t, options.SetValues["database.podAnnotations.vault\\.hashicorp\\.com/agent-inject-template-ca\\.cert"], obj.Spec.Template.ObjectMeta.Annotations["vault.hashicorp.com/agent-inject-template-ca.cert"])
-		}
-	})
-
-	t.Run("testDaemonSet", func(t *testing.T) {
-		// make a copy
-		localOptions := *options
-		localOptions.SetValues["database.enableDaemonSet"] = "true"
-
-		// Run RenderTemplate to render the template and capture the output.
-		output := helm.RenderTemplate(t, &localOptions, helmChartPath, "release-name", []string{"templates/daemonset.yaml"})
-
-		for _, obj := range testlib.SplitAndRenderDaemonSet(t, output, 1) {
 			assert.Equal(t, options.SetValues["database.podAnnotations.key1"], obj.Spec.Template.ObjectMeta.Annotations["key1"])
 			assert.Equal(t, options.SetValues["database.podAnnotations.key2"], obj.Spec.Template.ObjectMeta.Annotations["key2"])
 			assert.Equal(t, options.SetValues["database.podAnnotations.key3\\.key3"], obj.Spec.Template.ObjectMeta.Annotations["key3.key3"])
@@ -716,24 +682,7 @@ func TestDatabaseStoragePasswordsRender(t *testing.T) {
 		// Run RenderTemplate to render the template and capture the output.
 		output := helm.RenderTemplate(t, options, helmChartPath, "release-name", []string{"templates/statefulset.yaml"})
 
-		for _, obj := range testlib.SplitAndRenderStatefulSet(t, output, 1) {
-			database := "demo"
-			container := obj.Spec.Template.Spec.Containers[0]
-			mount, ok := testlib.GetMount(container.VolumeMounts, "tde-volume-"+database)
-			assert.True(t, ok, "mount tde-volume-%s not found", database)
-			assert.True(t, mount.ReadOnly)
-			assert.Equal(t, options.SetValues["admin.tde.storagePasswordsDir"]+"/"+database, mount.MountPath)
-			volume, ok := testlib.GetVolume(obj.Spec.Template.Spec.Volumes, "tde-volume-"+database)
-			assert.True(t, ok, "volume tde-volume-%s not found", database)
-			assert.Equal(t, options.SetValues["admin.tde.secrets."+database], volume.VolumeSource.Secret.SecretName)
-		}
-	})
-
-	t.Run("testStatefulSet", func(t *testing.T) {
-		// Run RenderTemplate to render the template and capture the output.
-		output := helm.RenderTemplate(t, options, helmChartPath, "release-name", []string{"templates/statefulset.yaml"})
-
-		for _, obj := range testlib.SplitAndRenderStatefulSet(t, output, 1) {
+		for _, obj := range testlib.SplitAndRenderStatefulSet(t, output, 2) {
 			database := "demo"
 			container := obj.Spec.Template.Spec.Containers[0]
 			mount, ok := testlib.GetMount(container.VolumeMounts, "tde-volume-"+database)
@@ -754,7 +703,7 @@ func TestDatabaseStoragePasswordsRender(t *testing.T) {
 		// Run RenderTemplate to render the template and capture the output.
 		output := helm.RenderTemplate(t, &localOptions, helmChartPath, "release-name", []string{"templates/daemonset.yaml"})
 
-		for _, obj := range testlib.SplitAndRenderDaemonSet(t, output, 1) {
+		for _, obj := range testlib.SplitAndRenderDaemonSet(t, output, 2) {
 			database := "demo"
 			container := obj.Spec.Template.Spec.Containers[0]
 			mount, ok := testlib.GetMount(container.VolumeMounts, "tde-volume-"+database)
@@ -766,5 +715,4 @@ func TestDatabaseStoragePasswordsRender(t *testing.T) {
 			assert.Equal(t, options.SetValues["admin.tde.secrets."+database], volume.VolumeSource.Secret.SecretName)
 		}
 	})
-
 }

--- a/test/integration/template_resources_test.go
+++ b/test/integration/template_resources_test.go
@@ -86,7 +86,7 @@ func TestResourcesDatabaseDefaults(t *testing.T) {
 	foundBackupEnabled := false
 	foundBackupDisabled := false
 
-	for _, obj := range testlib.SplitAndRenderStatefulSet(t, output, 1) {
+	for _, obj := range testlib.SplitAndRenderStatefulSet(t, output, 2) {
 		containers := &obj.Spec.Template.Spec.Containers
 
 		assert.NotEmpty(t, containers)
@@ -139,7 +139,7 @@ func TestResourcesDatabaseOverridden(t *testing.T) {
 	foundBackupEnabled := false
 	foundBackupDisabled := false
 
-	for _, obj := range testlib.SplitAndRenderStatefulSet(t, output, 1) {
+	for _, obj := range testlib.SplitAndRenderStatefulSet(t, output, 2) {
 		containers := &obj.Spec.Template.Spec.Containers
 
 		assert.NotEmpty(t, containers)


### PR DESCRIPTION
- when using SplitAndRenderStatefulSet with the DB SS, the test should make sure that both backup and non-backup SMs get tested. This is done by setting the expectedNrObjects to 2.
-remove code duplication
