### PR TITLE
Restarting SM fails if an AP is Disconnected

### DIFF
--- a/stable/database/files/nuosm
+++ b/stable/database/files/nuosm
@@ -351,19 +351,6 @@ function isRestoreRequestSupported() {
 }
 
 #=======================================
-# function - ensures that admin layer has an elected leader
-#
-function checkAdminLayer() {
-  local timeout="$1"
-  local status
-  trace "checking Admin layer"
-  status="$(nuocmd check servers --check-leader --timeout "$timeout" 2>&1)"
-  if [ $? -ne 0 ]; then
-    die 1 "Admin layer is inoperative - exiting: ${status}"
-  fi
-}
-
-#=======================================
 # function - completes archive restore request
 #
 function completeRestoreRequest(){
@@ -422,11 +409,11 @@ else
   log "Directory $DB_DIR exists"
 fi
 
-# ensure the admin layer is intact...
-checkAdminLayer 30
-
 trace "retrieving restore request from raft"
-legacy_restore_requested="$( nuocmd get value --key "$restore_req" )"
+legacy_restore_requested="$( nuocmd get value --key "$restore_req" 2>&1 )"
+if [ $? -ne 0 ]; then
+  die 1 "Unable to retrieve legacy restore request: ${legacy_restore_requested}"
+fi
 
 [ -f "$DB_DIR/info.json" ] && myArchive=$(sed -e 's|.*"id":\s*\([0-9]\+\).*|\1|' "$DB_DIR/info.json")
 trace "checking archive raft metadata"

--- a/stable/database/files/nuosm
+++ b/stable/database/files/nuosm
@@ -393,6 +393,15 @@ function resolveLatestSource() {
   return 0
 }
 
+#=======================================
+# function - fetch the legacy restore request from KV store
+#
+function get_legacy_restore_request() {
+  trace "retrieving legacy restore request from KV store"
+  legacy_restore_requested="$( nuocmd get value --key "$restore_req" 2>&1 )"
+  return $?
+}
+
 #=============================
 # main routine
 #=============================
@@ -409,8 +418,9 @@ else
   log "Directory $DB_DIR exists"
 fi
 
-trace "retrieving restore request from raft"
-legacy_restore_requested="$( nuocmd get value --key "$restore_req" 2>&1 )"
+# Retry the first request against the admin layer to make sure that Raft
+# commands can be committed and fail fast on error
+retry 3 get_legacy_restore_request
 if [ $? -ne 0 ]; then
   die 1 "Unable to retrieve legacy restore request: ${legacy_restore_requested}"
 fi

--- a/test/testlib/NuoDBServer.go
+++ b/test/testlib/NuoDBServer.go
@@ -1,0 +1,59 @@
+package testlib
+
+import (
+	"encoding/json"
+	"io"
+	"strings"
+)
+
+type NuoDBServerState struct {
+	State              string `json:"state"`
+	Latency            int64  `json:"latency"`
+	LastAckDeltaMillis int64  `json:"lastAckDeltaMillis"`
+}
+
+type NuoDBServerTermIndexInfo struct {
+	CommitIndex  int64 `json:"commitIndex"`
+	CurrentTerm  int64 `json:"currentTerm"`
+	LogLastIndex int64 `json:"logLastIndex"`
+	LogLastTerm  int64 `json:"logLastTerm"`
+	Valid        bool  `json:"valid"`
+}
+
+type NuoDBServerRoleInfo struct {
+	LeaderServerId         string                   `json:"leaderServerId"`
+	LocalPeerTermIndexInfo NuoDBServerTermIndexInfo `json:"localPeerTermIndexInfo"`
+	Role                   string                   `json:"role"`
+}
+
+type NuoDBServer struct {
+	Address         string              `json:"address"`
+	ConnectedState  NuoDBServerState    `json:"connectedState"`
+	Id              string              `json:"id"`
+	IsEvicted       bool                `json:"isEvicted"`
+	IsLocal         bool                `json:"isLocal"`
+	LocalRoleInfo   NuoDBServerRoleInfo `json:"localRoleInfo"`
+	PeerMemberState string              `json:"peerMemberState"`
+	PeerState       string              `json:"peerState"`
+	Version         string              `json:"version"`
+}
+
+func UnmarshalDomainServers(s string) (err error, servers map[string]NuoDBServer) {
+	dec := json.NewDecoder(strings.NewReader(s))
+	servers = make(map[string]NuoDBServer)
+
+	for {
+		var obj NuoDBServer
+		err = dec.Decode(&obj)
+		if err == io.EOF {
+			// all done
+			return nil, servers
+		}
+
+		if err != nil {
+			return
+		}
+
+		servers[obj.Id] = obj
+	}
+}

--- a/test/testlib/nuodb_admin_utilities.go
+++ b/test/testlib/nuodb_admin_utilities.go
@@ -249,16 +249,13 @@ func GetDomainLeaderE(t *testing.T, namespace string, adminPod string) (string, 
 	return "", errors.New("no leader found")
 }
 
-func AwaitDomainLeader(t *testing.T, namespace string, adminPod string, actionFn func(string),
-	timeout time.Duration) {
+func AwaitDomainLeader(t *testing.T, namespace string, adminPod string, timeout time.Duration) (leader string) {
 	Await(t, func() bool {
-		leader, err := GetDomainLeaderE(t, namespace, adminPod)
-		if err != nil {
-			return false
-		}
-		actionFn(leader)
-		return true
+		var err error
+		leader, err = GetDomainLeaderE(t, namespace, adminPod)
+		return err == nil
 	}, timeout)
+	return
 }
 
 func AwaitServerState(t *testing.T, namespace string, adminPod string,

--- a/test/testlib/nuodb_admin_utilities.go
+++ b/test/testlib/nuodb_admin_utilities.go
@@ -2,6 +2,7 @@ package testlib
 
 import (
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -222,4 +223,54 @@ func ApplyNuoDBLicense(t *testing.T, namespace string, adminPod string) {
 			"nuocmd", "--show-json-fields", "effectiveForDomain", "get", "effective-license")
 		require.True(t, strings.Contains(output, "true"), "NuoDB license key is not effective: %s", output)
 	}
+}
+
+func GetDomainServersE(t *testing.T, namespace string, adminPod string) (map[string]NuoDBServer, error) {
+	options := k8s.NewKubectlOptions("", "", namespace)
+	output, err := k8s.RunKubectlAndGetOutputE(t, options, "exec", adminPod, "--",
+		"nuocmd", "--show-json", "get", "servers")
+	if err == nil {
+		err, servers := UnmarshalDomainServers(output)
+		return servers, err
+	}
+	return nil, err
+}
+
+func GetDomainLeaderE(t *testing.T, namespace string, adminPod string) (string, error) {
+	servers, err := GetDomainServersE(t, namespace, adminPod)
+	if err != nil {
+		return "", err
+	}
+	for _, server := range servers {
+		if server.ConnectedState.State == "Connected" && server.LocalRoleInfo.LeaderServerId != "" {
+			return server.LocalRoleInfo.LeaderServerId, nil
+		}
+	}
+	return "", errors.New("no leader found")
+}
+
+func AwaitDomainLeader(t *testing.T, namespace string, adminPod string, actionFn func(string),
+	timeout time.Duration) {
+	Await(t, func() bool {
+		leader, err := GetDomainLeaderE(t, namespace, adminPod)
+		if err != nil {
+			return false
+		}
+		actionFn(leader)
+		return true
+	}, timeout)
+}
+
+func AwaitServerState(t *testing.T, namespace string, adminPod string,
+	serverId string, expectedState string, timeout time.Duration) {
+	Await(t, func() bool {
+		servers, err := GetDomainServersE(t, namespace, adminPod)
+		if err != nil {
+			return false
+		}
+		if server, ok := servers[serverId]; ok && server.ConnectedState.State == expectedState {
+			return true
+		}
+		return false
+	}, timeout)
 }

--- a/test/testlib/nuodb_database_utilities.go
+++ b/test/testlib/nuodb_database_utilities.go
@@ -412,3 +412,14 @@ func SkipTestOnNuoDBVersionCondition(t *testing.T, condition string) {
 		return c.Check(version)
 	})
 }
+
+func GetDatabaseProcessesE(t *testing.T, namespaceName string, adminPod string, dbName string) (processes []NuoDBProcess, err error) {
+	kubectlOptions := k8s.NewKubectlOptions("", "", namespaceName)
+	output, err := k8s.RunKubectlAndGetOutputE(t, kubectlOptions, "exec", adminPod, "--",
+		"nuocmd", "--show-json", "get", "processes", "--db-name", dbName)
+	if err != nil {
+		return nil, err
+	}
+	err, processes = Unmarshal(output)
+	return
+}


### PR DESCRIPTION
**Issue**
If one of the APs is partitioned from the rest of the domain or shutdown, any SM startup will fail with:

```
2021-04-21T14:57:32.810+0000 ===========================================
2021-04-21T14:57:32.815+0000 logsize=1329; maxlog=5000000
2021-04-21T14:57:32.818+0000 Directory /var/opt/nuodb/archive/nuodb/demo exists
2021-04-21T14:57:32.820+0000 trace: checking Admin layer
2021-04-21T14:58:05.358+0000 Error while checking Admin layer: Admin layer is inoperative - exiting: 'check servers' failed: Health-check failed:
Non-unique LEADER:
  (leader=admin-nuodb-cluster0-2,term=35)->[admin-nuodb-cluster0-2]
  (leader=admin-nuodb-cluster0-1,term=36)->[admin-nuodb-cluster0-0,admin-nuodb-cluster0-1]
```

**Changes**
- remove the admin layer health check as it is too strong for this purpose
- fail the SM fast if the first `nuocmd get value` call fails to indicate a problem with the admin layer

**Testing**
- add E2E test for the scenario above
- regression testing