### PR TITLE
Rewrite upgrade database tests

### DIFF
--- a/stable/admin/values.yaml
+++ b/stable/admin/values.yaml
@@ -171,6 +171,9 @@ admin:
     # entire Raft state into one message; set maximum message size to 1GB to
     # allow Raft state to grow to 1GB
     thrift.message.max: "1073741824"
+    # force reconnecting processes that are not in the domain state to shut
+    # themselves down
+    evictUnknownProcesses: true
 
   ## nuodb-admin resource requests and limits
   ## Ref: http://kubernetes.io/docs/user-guide/compute-resources/

--- a/test/minikube/minikube_upgrade_helm_test.go
+++ b/test/minikube/minikube_upgrade_helm_test.go
@@ -120,9 +120,9 @@ func upgradeDatabaseTest(t *testing.T, fromHelmVersion string, updateOptions *Up
 	// make sure the DB is properly reconnected before restarting
 	testlib.AwaitDatabaseUp(t, namespaceName, admin0, opt.DbName, opt.NrSmPods+opt.NrTePods)
 
-	helm.Upgrade(t, options, testlib.DATABASE_HELM_CHART_PATH, databaseReleaseName)
-
-	testlib.AwaitDatabaseUp(t, namespaceName, admin0, opt.DbName, opt.NrSmPods+opt.NrTePods)
+	testlib.UpgradeDatabase(t, namespaceName, databaseReleaseName, admin0, options, &testlib.UpgradeDatabaseOptions{
+		TePodShouldGetRecreated: true,
+	})
 }
 
 func TestUpgradeHelm(t *testing.T) {

--- a/test/minikube/minikube_upgrade_helm_test.go
+++ b/test/minikube/minikube_upgrade_helm_test.go
@@ -120,9 +120,7 @@ func upgradeDatabaseTest(t *testing.T, fromHelmVersion string, updateOptions *Up
 	// make sure the DB is properly reconnected before restarting
 	testlib.AwaitDatabaseUp(t, namespaceName, admin0, opt.DbName, opt.NrSmPods+opt.NrTePods)
 
-	testlib.UpgradeDatabase(t, namespaceName, databaseReleaseName, admin0, options, &testlib.UpgradeDatabaseOptions{
-		TePodShouldGetRecreated: true,
-	})
+	testlib.UpgradeDatabase(t, namespaceName, databaseReleaseName, admin0, options, &testlib.UpgradeDatabaseOptions{})
 }
 
 func TestUpgradeHelm(t *testing.T) {


### PR DESCRIPTION
These tests were failing silently. Rewrite them so that we can identify problems in the future.

Also, pick up a change to admin options that fixes upgrade from 3.1.0.