### PR TITLE
Replace deprecated failure-domain.beta.kubernetes.io/zone label in THP

### DIFF
--- a/stable/transparent-hugepage/README.md
+++ b/stable/transparent-hugepage/README.md
@@ -109,7 +109,7 @@ thp:
       requiredDuringSchedulingIgnoredDuringExecution:
         nodeSelectorTerms:
         - matchExpressions:
-          - key: failure-domain.beta.kubernetes.io/zone
+          - key: topology.kubernetes.io/zone
             operator: In
             values:
             {{- range .Values.cloud.zones }}

--- a/stable/transparent-hugepage/values.yaml
+++ b/stable/transparent-hugepage/values.yaml
@@ -42,7 +42,7 @@ thp:
   #     requiredDuringSchedulingIgnoredDuringExecution:
   #       nodeSelectorTerms:
   #       - matchExpressions:
-  #         - key: failure-domain.beta.kubernetes.io/zone
+  #         - key: topology.kubernetes.io/zone
   #           operator: In
   #           values:
   #           {{- range .Values.cloud.zones }}


### PR DESCRIPTION
replace failure-domain.beta.kubernetes.io/zone with
topology.kubernetes.io/zone

This label has been deprecated in Kubernetes 1.17 and newer.