### PR TITLE
Collect logging from all TEs and SMs

### DIFF
--- a/test/testlib/minikube_utilities.go
+++ b/test/testlib/minikube_utilities.go
@@ -435,6 +435,23 @@ func findPod(t *testing.T, namespace string, expectedName string) (*corev1.Pod, 
 	return nil, errors.New("did not find any pod matching name")
 }
 
+func findPods(t *testing.T, namespace string, expectedName string) ([]corev1.Pod, error) {
+	var pods []corev1.Pod
+
+	for _, pod := range findAllPodsInSchema(t, namespace) {
+		if strings.Contains(pod.Name, expectedName) {
+			pods = append(pods, pod)
+		}
+	}
+
+	if len(pods) == 0 {
+		return nil, errors.New("did not find any pod matching name")
+	} else {
+		return pods, nil
+	}
+
+}
+
 func GetPod(t *testing.T, namespace string, podName string) *corev1.Pod {
 	options := k8s.NewKubectlOptions("", "", namespace)
 
@@ -446,6 +463,17 @@ func GetPodName(t *testing.T, namespaceName string, expectedName string) string 
 	require.NoError(t, err, "No pod found with name ", expectedName)
 
 	return tePod.Name
+}
+
+func GetPodNames(t *testing.T, namespaceName string, expectedName string) []string {
+	var names []string
+	pods, err := findPods(t, namespaceName, expectedName)
+	require.NoError(t, err, "No pods found with name ", expectedName)
+	for _, pod := range pods {
+		names = append(names, pod.Name)
+	}
+
+	return names
 }
 
 func DescribePods(t *testing.T, namespace string, expectedName string) {

--- a/test/testlib/nuodb_admin_utilities.go
+++ b/test/testlib/nuodb_admin_utilities.go
@@ -41,7 +41,7 @@ func CreateNamespace(t *testing.T, namespaceName string) {
 	}
 
 	// this method is async
-	//go GetK8sEventLog(t, namespaceName)
+	go GetK8sEventLog(t, namespaceName)
 
 	AddTeardown(TEARDOWN_ADMIN, func() {
 		k8s.DeleteNamespace(t, kubectlOptions, namespaceName)

--- a/test/testlib/nuodb_admin_utilities.go
+++ b/test/testlib/nuodb_admin_utilities.go
@@ -41,7 +41,7 @@ func CreateNamespace(t *testing.T, namespaceName string) {
 	}
 
 	// this method is async
-	go GetK8sEventLog(t, namespaceName)
+	//go GetK8sEventLog(t, namespaceName)
 
 	AddTeardown(TEARDOWN_ADMIN, func() {
 		k8s.DeleteNamespace(t, kubectlOptions, namespaceName)


### PR DESCRIPTION
- TestChangingJournalLocationWithMultipleSMs was not collecting pre-restart data.
- DB teardown would only collect 1 SM log. If the test uses the ENTERPRISE license there can be many SMs running. Fix the code so that it collects all currently running SMs.
- DB teardown would only collect 1 TE log. There can be many TEs running. Fix the code so that it collects all currently running TEs.