### PR TITLE
Allow database processes to be restarted in helm upgrade tests

### DIFF
--- a/test/minikube/minikube_upgrade_helm_test.go
+++ b/test/minikube/minikube_upgrade_helm_test.go
@@ -110,7 +110,7 @@ func upgradeDatabaseTest(t *testing.T, fromHelmVersion string, upgradeOptions *t
 		testlib.AwaitPodObjectRecreated(t, namespaceName, adminPod, 30*time.Second)
 	}
 
-	testlib.AwaitPodUp(t, namespaceName, admin0, 300*time.Second)
+	testlib.AwaitPodUp(t, namespaceName, admin0, 600*time.Second)
 
 	// TODO: check that 'helm upgrade' did not trigger a restart of database
 	// pods; currently it is possible that the restarted admin does not

--- a/test/minikube/minikube_upgrade_helm_test.go
+++ b/test/minikube/minikube_upgrade_helm_test.go
@@ -110,18 +110,18 @@ func upgradeDatabaseTest(t *testing.T, fromHelmVersion string, upgradeOptions *t
 		testlib.AwaitPodObjectRecreated(t, namespaceName, adminPod, 30*time.Second)
 	}
 
-	testlib.AwaitPodUp(t, namespaceName, admin0, 600*time.Second)
+	testlib.AwaitPodUp(t, namespaceName, admin0, 300*time.Second)
 
 	// TODO: check that 'helm upgrade' did not trigger a restart of database
-	// pods; currently it is possible that the restarted admin does not
-	// receive a reconnection from the database processes either due to DNS
-	// resolution or due to the database process not detecting the loss of
-	// the admin connection
+	// pods and that the database is still running; currently it is possible
+	// that the restarted admin does not receive a reconnection from the
+	// database processes either due to DNS resolution or due to the
+	// database process not detecting the loss of the admin connection
+
+	testlib.UpgradeDatabase(t, namespaceName, databaseReleaseName, admin0, options, upgradeOptions)
 
 	opt := testlib.GetExtractedOptions(options)
 	testlib.AwaitDatabaseUp(t, namespaceName, admin0, opt.DbName, opt.NrSmPods+opt.NrTePods)
-
-	testlib.UpgradeDatabase(t, namespaceName, databaseReleaseName, admin0, options, upgradeOptions)
 }
 
 func TestUpgradeHelm(t *testing.T) {

--- a/test/testlib/nuodb_database_utilities.go
+++ b/test/testlib/nuodb_database_utilities.go
@@ -180,12 +180,13 @@ func StartDatabaseNoWait(t *testing.T, namespace string, adminPod string, option
 	return StartDatabaseTemplate(t, namespace, adminPod, options, InstallDatabase, false)
 }
 
-type UpgradeDatabaseOptions struct {
+type UpgradeOptions struct {
 	TePodShouldGetRecreated bool
 	SmPodShouldGetRecreated bool
+	AdminPodShouldGetRecreated bool
 }
 
-func UpgradeDatabase(t *testing.T, namespaceName string, helmChartReleaseName string, adminPod string, options *helm.Options, upgradeOptions *UpgradeDatabaseOptions) {
+func UpgradeDatabase(t *testing.T, namespaceName string, helmChartReleaseName string, adminPod string, options *helm.Options, upgradeOptions *UpgradeOptions) {
 	opt := GetExtractedOptions(options)
 
 	tePodNameTemplate := fmt.Sprintf("te-%s-nuodb-%s-%s", helmChartReleaseName, opt.ClusterName, opt.DbName)


### PR DESCRIPTION
Currently 'helm upgrade' can cause the database processes to be evicted
in PENDING_RECONNECT state. Remove the check of reconnect behavior so
that we at least have test coverage of helm upgrade.