### PR TITLE
Add admin helm upgrade workaround to upgrade tests

### DIFF
--- a/test/minikube/minikube_upgrade_helm_test.go
+++ b/test/minikube/minikube_upgrade_helm_test.go
@@ -15,11 +15,7 @@ import (
 	v12 "k8s.io/api/core/v1"
 )
 
-type UpdateOptions struct {
-	adminPodShouldGetRecreated            bool
-}
-
-func upgradeAdminTest(t *testing.T, fromHelmVersion string, updateOptions *UpdateOptions) {
+func upgradeAdminTest(t *testing.T, fromHelmVersion string, upgradeOptions *testlib.UpgradeOptions) {
 	testlib.AwaitTillerUp(t)
 	defer testlib.VerifyTeardown(t)
 
@@ -58,16 +54,14 @@ func upgradeAdminTest(t *testing.T, fromHelmVersion string, updateOptions *Updat
 
 	helm.Upgrade(t, options, testlib.ADMIN_HELM_CHART_PATH, helmChartReleaseName)
 
-	if updateOptions.adminPodShouldGetRecreated {
+	if upgradeOptions.AdminPodShouldGetRecreated {
 		testlib.AwaitPodObjectRecreated(t, namespaceName, adminPod, 30*time.Second)
 	}
 
 	testlib.AwaitPodUp(t, namespaceName, admin0, 300*time.Second)
 }
 
-func upgradeDatabaseTest(t *testing.T, fromHelmVersion string, updateOptions *UpdateOptions) {
-	t.Skip("Test is flaky in minikube")
-
+func upgradeDatabaseTest(t *testing.T, fromHelmVersion string, upgradeOptions *testlib.UpgradeOptions) {
 	testlib.AwaitTillerUp(t)
 	defer testlib.VerifyTeardown(t)
 
@@ -114,7 +108,7 @@ func upgradeDatabaseTest(t *testing.T, fromHelmVersion string, updateOptions *Up
 
 	helm.Upgrade(t, options, testlib.ADMIN_HELM_CHART_PATH, helmChartReleaseName)
 
-	if updateOptions.adminPodShouldGetRecreated {
+	if upgradeOptions.AdminPodShouldGetRecreated {
 		testlib.AwaitPodObjectRecreated(t, namespaceName, adminPod, 30*time.Second)
 	}
 
@@ -123,38 +117,68 @@ func upgradeDatabaseTest(t *testing.T, fromHelmVersion string, updateOptions *Up
 	opt := testlib.GetExtractedOptions(options)
 
 	// make sure the DB is properly reconnected before restarting
-	testlib.Await(t, func() bool {
-		return testlib.GetStringOccurrenceInLog(t, namespaceName, admin0, "Reconnected with process with connectKey", &v12.PodLogOptions{}) == 2
+	err := testlib.AwaitWithError(t, func() bool {
+		return testlib.GetStringOccurrenceInLog(t, namespaceName, admin0,
+			"Reconnected with process with connectKey",
+			&v12.PodLogOptions{
+				Container: "admin",
+			}) == 2
 	}, 120*time.Second)
+
+	if err != nil {
+		// in some environments, the engine does not manage to reconnect to an admin after the admin pod was restarted
+		// the only way to proceed is to restart the engine
+		// see https://github.com/nuodb/nuodb-helm-charts/issues/238
+		t.Log(err)
+		t.Logf("WARNING: engine did not reconnect with admin. Killing all engines to make upgrade proceed!")
+
+		opt := testlib.GetExtractedOptions(options)
+		tePodNameTemplate := fmt.Sprintf("te-%s-nuodb-%s-%s", databaseReleaseName, opt.ClusterName, opt.DbName)
+		smPodNameTemplate := fmt.Sprintf("sm-%s-nuodb-%s-%s", databaseReleaseName, opt.ClusterName, opt.DbName)
+
+		tePodName := testlib.GetPodName(t, namespaceName, tePodNameTemplate)
+		smPodName := testlib.GetPodName(t, namespaceName, smPodNameTemplate)
+
+		go testlib.GetAppLog(t, namespaceName, tePodName, "-pre-kill", &v12.PodLogOptions{Follow: true})
+		go testlib.GetAppLog(t, namespaceName, smPodName, "-pre-kill", &v12.PodLogOptions{Follow: true})
+
+		testlib.KillProcess(t, namespaceName, tePodName)
+		testlib.KillProcess(t, namespaceName, smPodName)
+
+		testlib.AwaitPodUp(t, namespaceName, tePodName, 300*time.Second)
+		testlib.AwaitPodUp(t, namespaceName, smPodName, 300*time.Second)
+
+	}
+	// make sure the environment is stable before proceeding
 	testlib.AwaitDatabaseUp(t, namespaceName, admin0, opt.DbName, opt.NrSmPods+opt.NrTePods)
 
-	testlib.UpgradeDatabase(t, namespaceName, databaseReleaseName, admin0, options, &testlib.UpgradeDatabaseOptions{})
+	testlib.UpgradeDatabase(t, namespaceName, databaseReleaseName, admin0, options, upgradeOptions)
 }
 
 func TestUpgradeHelm(t *testing.T) {
 	t.Run("NuoDB_From310_ToLocal", func(t *testing.T) {
-		upgradeAdminTest(t, "3.1.0", &UpdateOptions{
-			adminPodShouldGetRecreated: true,
+		upgradeAdminTest(t, "3.1.0", &testlib.UpgradeOptions{
+			AdminPodShouldGetRecreated: true,
 		})
 	})
 
 	t.Run("NuoDB_From320_ToLocal", func(t *testing.T) {
-		upgradeAdminTest(t, "3.2.0", &UpdateOptions{
-			adminPodShouldGetRecreated: true,
+		upgradeAdminTest(t, "3.2.0", &testlib.UpgradeOptions{
+			AdminPodShouldGetRecreated: true,
 		})
 	})
 }
 
 func TestUpgradeHelmFullDB(t *testing.T) {
 	t.Run("NuoDB_From310_ToLocal", func(t *testing.T) {
-		upgradeDatabaseTest(t, "3.1.0", &UpdateOptions{
-			adminPodShouldGetRecreated: true,
+		upgradeDatabaseTest(t, "3.1.0", &testlib.UpgradeOptions{
+			AdminPodShouldGetRecreated: true,
 		})
 	})
 
 	t.Run("NuoDB_From320_ToLocal", func(t *testing.T) {
-		upgradeDatabaseTest(t, "3.2.0", &UpdateOptions{
-			adminPodShouldGetRecreated: true,
+		upgradeDatabaseTest(t, "3.2.0", &testlib.UpgradeOptions{
+			AdminPodShouldGetRecreated: true,
 		})
 	})
 }

--- a/test/minikube/minikube_upgrade_helm_test.go
+++ b/test/minikube/minikube_upgrade_helm_test.go
@@ -117,7 +117,7 @@ func upgradeDatabaseTest(t *testing.T, fromHelmVersion string, upgradeOptions *t
 	opt := testlib.GetExtractedOptions(options)
 
 	// make sure the DB is properly reconnected before restarting
-	err := testlib.AwaitWithError(t, func() bool {
+	err := testlib.AwaitE(t, func() bool {
 		return testlib.GetStringOccurrenceInLog(t, namespaceName, admin0,
 			"Reconnected with process with connectKey",
 			&v12.PodLogOptions{

--- a/test/testlib/minikube_utilities.go
+++ b/test/testlib/minikube_utilities.go
@@ -357,7 +357,7 @@ func Await(t *testing.T, lmbd func() bool, timeout time.Duration) {
 	}
 }
 
-func AwaitWithError(t *testing.T, lmbd func() bool, timeout time.Duration) error {
+func AwaitE(t *testing.T, lmbd func() bool, timeout time.Duration) error {
 	now := time.Now()
 	for timeExpired := time.After(timeout); ; {
 		select {

--- a/test/testlib/nuodb_database_utilities.go
+++ b/test/testlib/nuodb_database_utilities.go
@@ -180,12 +180,7 @@ func StartDatabaseNoWait(t *testing.T, namespace string, adminPod string, option
 	return StartDatabaseTemplate(t, namespace, adminPod, options, InstallDatabase, false)
 }
 
-type UpgradeDatabaseOptions struct {
-	TePodShouldGetRecreated bool
-	SmPodShouldGetRecreated bool
-}
-
-func UpgradeDatabase(t *testing.T, namespaceName string, helmChartReleaseName string, adminPod string, options *helm.Options, upgradeOptions *UpgradeDatabaseOptions) {
+func UpgradeDatabase(t *testing.T, namespaceName string, helmChartReleaseName string, adminPod string, options *helm.Options, upgradeOptions *UpgradeOptions) {
 	opt := GetExtractedOptions(options)
 
 	tePodNameTemplate := fmt.Sprintf("te-%s-nuodb-%s-%s", helmChartReleaseName, opt.ClusterName, opt.DbName)
@@ -208,6 +203,8 @@ func UpgradeDatabase(t *testing.T, namespaceName string, helmChartReleaseName st
 		_ = k8s.RunKubectlE(t, kubectlOptions, "exec", adminPod, "--", "nuocmd", "show", "archives")
 		_ = k8s.RunKubectlE(t, kubectlOptions, "exec", adminPod, "--", "nuocmd", "show", "database", "--db-name", "demo", "--all-incarnations")
 	})
+
+	SetDeploymentUpgradeStrategyToRecreate(t, namespaceName, fmt.Sprintf("te-%s-nuodb-cluster0-demo", helmChartReleaseName))
 
 	helm.Upgrade(t, options, DATABASE_HELM_CHART_PATH, helmChartReleaseName)
 

--- a/test/testlib/upgrade_utilities.go
+++ b/test/testlib/upgrade_utilities.go
@@ -1,0 +1,7 @@
+package testlib
+
+type UpgradeOptions struct {
+	AdminPodShouldGetRecreated bool
+	TePodShouldGetRecreated    bool
+	SmPodShouldGetRecreated bool
+}


### PR DESCRIPTION
When the admin pod gets recreated, the engines do not always reconnect. This is worse in newer versions of K8s.

This is a known issue: https://github.com/nuodb/nuodb-helm-charts/issues/238

Re-enable the tests and add a workaround:
If the engine does not reconnect in time, kill the engine process. This is better than deleting the deployment pod since it won't give the pod a new SHA. This causes at least 2 restarts. 1 restart after the process exits and another restart when the new process gets evicted. There can be as many as 4 restarts before the system stabilizes.

Also refactor the UpgradeOptions as proposed in an earlier PR.