### PR TITLE
Fix database restore with cold backup and external journal

### DIFF
--- a/stable/database/files/nuosm
+++ b/stable/database/files/nuosm
@@ -275,12 +275,7 @@ function perform_restore() {
     retval=$?
     log "$status"
 
-    if [ "$download_dir" != "$DB_DIR" ]; then
-      log "removing $download_dir"
-      rm -rf $download_dir
-    fi
-
-    if [ "$SEPARATE_JOURNAL" == "true" ] && [ "$restore_type" == "stream" ]; then
+    if [ "$SEPARATE_JOURNAL" == "true" ] && [ -f "$download_dir/1.atm" ]; then
       # `nuodocker restore archive` doesn't invoke `nuoarchive` on cold archive
       # (stream) restore type. Move the content of the internal journal
       # directory to the external journal path manually as the journal is not
@@ -288,6 +283,11 @@ function perform_restore() {
       log "Moving restored journal content to $JOURNAL_DIR"
       mv "$download_dir/journal/"* "$JOURNAL_DIR"
       chown -R "$(echo "${NUODB_OS_USER:-1000}:${NUODB_OS_GROUP:-0}" | tr -d '"')" "$JOURNAL_DIR"
+    fi
+
+    if [ "$download_dir" != "$DB_DIR" ]; then
+      log "removing $download_dir"
+      rm -rf $download_dir
     fi
 
   else

--- a/test/minikube/minikube_base_restore_test.go
+++ b/test/minikube/minikube_base_restore_test.go
@@ -47,6 +47,28 @@ func verifyBackup(t *testing.T, namespaceName string, podName string, databaseNa
 	require.True(t, backupset != "")
 }
 
+func verifyExternalJournal(t *testing.T, namespaceName string, adminPod string,
+	databaseReleaseName string, databaseOptions *helm.Options) {
+	opt := testlib.GetExtractedOptions(databaseOptions)
+	if source, ok := databaseOptions.SetValues["database.autoImport.source"]; ok && source == testlib.IMPORT_ARCHIVE_URL {
+		// verify that the journal content is moved to the external journal dir
+		smPodNameTemplate := fmt.Sprintf("sm-%s-nuodb-%s-%s", databaseReleaseName, opt.ClusterName, opt.DbName)
+		smPodName0 := fmt.Sprintf("%s-hotcopy-0", smPodNameTemplate)
+		require.GreaterOrEqual(t, testlib.GetStringOccurrenceInLog(t, namespaceName, smPodName0,
+			fmt.Sprintf("Moving restored journal content to /var/opt/nuodb/journal/nuodb/%s", opt.DbName),
+			&corev1.PodLogOptions{}), 1)
+		// verify that the database contains the restored data
+		tables, err := testlib.RunSQL(t, namespaceName, adminPod, "demo", "show schema User")
+		require.NoError(t, err, "error running SQL: show schema User")
+		require.True(t, strings.Contains(tables, "HOCKEY"))
+	}
+	// check that archives are created with external journal directory
+	archives, _ := testlib.CheckArchives(t, namespaceName, adminPod, opt.DbName, opt.NrSmPods, 0)
+	for _, archive := range archives {
+		require.Equal(t, fmt.Sprintf("/var/opt/nuodb/journal/nuodb/%s", opt.DbName), archive.JournalPath)
+	}
+}
+
 func TestKubernetesBackupDatabase(t *testing.T) {
 	testlib.AwaitTillerUp(t)
 	defer testlib.VerifyTeardown(t)
@@ -347,7 +369,7 @@ func TestKubernetesImportDatabaseSeparateJournal(t *testing.T) {
 
 	verifyPacketFetch(t, namespaceName, admin0)
 
-	t.Run("startDatabaseStatefulSet", func(t *testing.T) {
+	t.Run("autoImportStream", func(t *testing.T) {
 		defer testlib.Teardown(testlib.TEARDOWN_DATABASE)
 
 		databaseOptions := &helm.Options{
@@ -364,15 +386,27 @@ func TestKubernetesImportDatabaseSeparateJournal(t *testing.T) {
 		// Install database and check that the journal content of the cold
 		// backup is moved to the target journal location
 		databaseReleaseName := testlib.StartDatabase(t, namespaceName, admin0, databaseOptions)
-		opt := testlib.GetExtractedOptions(databaseOptions)
-		smPodNameTemplate := fmt.Sprintf("sm-%s-nuodb-%s-%s", databaseReleaseName, opt.ClusterName, opt.DbName)
-		smPodName0 := fmt.Sprintf("%s-hotcopy-0", smPodNameTemplate)
-		require.GreaterOrEqual(t, testlib.GetStringOccurrenceInLog(t, namespaceName, smPodName0,
-			"Moving restored journal content to /var/opt/nuodb/journal/nuodb/demo", &corev1.PodLogOptions{}), 1)
+		verifyExternalJournal(t, namespaceName, admin0, databaseReleaseName, databaseOptions)
+	})
 
-		// verify that the database contains the restored data
-		tables, err := testlib.RunSQL(t, namespaceName, admin0, "demo", "show schema User")
-		require.NoError(t, err, "error running SQL: show schema User")
-		require.True(t, strings.Contains(tables, "HOCKEY"))
+	t.Run("autoImportBackupset", func(t *testing.T) {
+		defer testlib.Teardown(testlib.TEARDOWN_DATABASE)
+
+		databaseOptions := &helm.Options{
+			SetValues: map[string]string{
+				"database.autoImport.source":              testlib.IMPORT_ARCHIVE_URL,
+				"database.autoImport.type":                "backupset",
+				"database.sm.resources.requests.cpu":      testlib.MINIMAL_VIABLE_ENGINE_CPU,
+				"database.sm.resources.requests.memory":   testlib.MINIMAL_VIABLE_ENGINE_MEMORY,
+				"database.te.resources.requests.cpu":      testlib.MINIMAL_VIABLE_ENGINE_CPU,
+				"database.te.resources.requests.memory":   testlib.MINIMAL_VIABLE_ENGINE_MEMORY,
+				"database.sm.hotCopy.journalPath.enabled": "true",
+			},
+		}
+
+		// Install database and check that the journal content of the cold
+		// backup is moved to the target journal location
+		databaseReleaseName := testlib.StartDatabase(t, namespaceName, admin0, databaseOptions)
+		verifyExternalJournal(t, namespaceName, admin0, databaseReleaseName, databaseOptions)
 	})
 }

--- a/test/minikube/minikube_base_restore_test.go
+++ b/test/minikube/minikube_base_restore_test.go
@@ -404,8 +404,9 @@ func TestKubernetesImportDatabaseSeparateJournal(t *testing.T) {
 			},
 		}
 
-		// Install database and check that the journal content of the cold
-		// backup is moved to the target journal location
+		// Regardless of the specified backup type the journal content should be
+		// moved to the target journal location in case a cold backup is
+		// downloaded
 		databaseReleaseName := testlib.StartDatabase(t, namespaceName, admin0, databaseOptions)
 		verifyExternalJournal(t, namespaceName, admin0, databaseReleaseName, databaseOptions)
 	})

--- a/test/minikube/minikube_long_restore_test.go
+++ b/test/minikube/minikube_long_restore_test.go
@@ -20,6 +20,28 @@ import (
 	"github.com/gruntwork-io/terratest/modules/k8s"
 )
 
+func verifyExternalJournal(t *testing.T, namespaceName string, adminPod string,
+	databaseReleaseName string, databaseOptions *helm.Options) {
+	opt := testlib.GetExtractedOptions(databaseOptions)
+	if source, ok := databaseOptions.SetValues["database.autoImport.source"]; ok && source == testlib.IMPORT_ARCHIVE_URL {
+		// verify that the journal content is moved to the external journal dir
+		smPodNameTemplate := fmt.Sprintf("sm-%s-nuodb-%s-%s", databaseReleaseName, opt.ClusterName, opt.DbName)
+		smPodName0 := fmt.Sprintf("%s-hotcopy-0", smPodNameTemplate)
+		require.GreaterOrEqual(t, testlib.GetStringOccurrenceInLog(t, namespaceName, smPodName0,
+			fmt.Sprintf("Moving restored journal content to /var/opt/nuodb/journal/nuodb/%s", opt.DbName),
+			&corev1.PodLogOptions{}), 1)
+		// verify that the database contains the restored data
+		tables, err := testlib.RunSQL(t, namespaceName, adminPod, "demo", "show schema User")
+		require.NoError(t, err, "error running SQL: show schema User")
+		require.True(t, strings.Contains(tables, "HOCKEY"))
+	}
+	// check that archives are created with external journal directory
+	archives, _ := testlib.CheckArchives(t, namespaceName, adminPod, opt.DbName, opt.NrSmPods, 0)
+	for _, archive := range archives {
+		require.Equal(t, fmt.Sprintf("/var/opt/nuodb/journal/nuodb/%s", opt.DbName), archive.JournalPath)
+	}
+}
+
 func TestKubernetesRestoreMultipleSMs(t *testing.T) {
 	if os.Getenv("NUODB_LICENSE") != "ENTERPRISE" && os.Getenv("NUODB_LICENSE_CONTENT") == "" {
 		t.Skip("Cannot test multiple SMs without the Enterprise Edition")
@@ -314,4 +336,131 @@ func TestKubernetesRestoreDatabaseWithURL(t *testing.T) {
 	require.NoError(t, err, "error running SQL: show schema User")
 	require.Contains(t, tables, "No tables found in schema ", "Show schema returned: ", tables)
 	testlib.CheckRestoreRequests(t, namespaceName, admin0, opt.DbName, "", "")
+}
+
+func TestKubernetesImportDatabaseSeparateJournal(t *testing.T) {
+	testlib.AwaitTillerUp(t)
+	defer testlib.VerifyTeardown(t)
+
+	defer testlib.Teardown(testlib.TEARDOWN_ADMIN)
+
+	helmChartReleaseName, namespaceName := testlib.StartAdmin(t, &helm.Options{}, 1, "")
+	admin0 := fmt.Sprintf("%s-nuodb-cluster0-0", helmChartReleaseName)
+
+	t.Run("autoImportStream", func(t *testing.T) {
+		defer testlib.Teardown(testlib.TEARDOWN_DATABASE)
+
+		databaseOptions := &helm.Options{
+			SetValues: map[string]string{
+				"database.autoImport.source":              testlib.IMPORT_ARCHIVE_URL,
+				"database.sm.resources.requests.cpu":      testlib.MINIMAL_VIABLE_ENGINE_CPU,
+				"database.sm.resources.requests.memory":   testlib.MINIMAL_VIABLE_ENGINE_MEMORY,
+				"database.te.resources.requests.cpu":      testlib.MINIMAL_VIABLE_ENGINE_CPU,
+				"database.te.resources.requests.memory":   testlib.MINIMAL_VIABLE_ENGINE_MEMORY,
+				"database.sm.hotCopy.journalPath.enabled": "true",
+			},
+		}
+
+		// Install database and check that the journal content of the cold
+		// backup is moved to the target journal location
+		databaseReleaseName := testlib.StartDatabase(t, namespaceName, admin0, databaseOptions)
+		verifyExternalJournal(t, namespaceName, admin0, databaseReleaseName, databaseOptions)
+	})
+
+	t.Run("autoImportBackupset", func(t *testing.T) {
+		defer testlib.Teardown(testlib.TEARDOWN_DATABASE)
+
+		databaseOptions := &helm.Options{
+			SetValues: map[string]string{
+				"database.autoImport.source":              testlib.IMPORT_ARCHIVE_URL,
+				"database.autoImport.type":                "backupset",
+				"database.sm.resources.requests.cpu":      testlib.MINIMAL_VIABLE_ENGINE_CPU,
+				"database.sm.resources.requests.memory":   testlib.MINIMAL_VIABLE_ENGINE_MEMORY,
+				"database.te.resources.requests.cpu":      testlib.MINIMAL_VIABLE_ENGINE_CPU,
+				"database.te.resources.requests.memory":   testlib.MINIMAL_VIABLE_ENGINE_MEMORY,
+				"database.sm.hotCopy.journalPath.enabled": "true",
+			},
+		}
+
+		// Regardless of the specified backup type the journal content should be
+		// moved to the target journal location in case a cold backup is
+		// downloaded
+		databaseReleaseName := testlib.StartDatabase(t, namespaceName, admin0, databaseOptions)
+		verifyExternalJournal(t, namespaceName, admin0, databaseReleaseName, databaseOptions)
+	})
+}
+
+func TestKubernetesRestoreDatabaseSeparateJournal(t *testing.T) {
+	testlib.AwaitTillerUp(t)
+	defer testlib.VerifyTeardown(t)
+
+	defer testlib.Teardown(testlib.TEARDOWN_ADMIN)
+
+	helmChartReleaseName, namespaceName := testlib.StartAdmin(t, &helm.Options{}, 1, "")
+
+	admin0 := fmt.Sprintf("%s-nuodb-cluster0-0", helmChartReleaseName)
+
+	t.Run("databaseRestoreStream", func(t *testing.T) {
+		databaseOptions := &helm.Options{
+			SetValues: map[string]string{
+				"database.name":                           "demo",
+				"database.sm.resources.requests.cpu":      testlib.MINIMAL_VIABLE_ENGINE_CPU,
+				"database.sm.resources.requests.memory":   testlib.MINIMAL_VIABLE_ENGINE_MEMORY,
+				"database.te.resources.requests.cpu":      testlib.MINIMAL_VIABLE_ENGINE_CPU,
+				"database.te.resources.requests.memory":   testlib.MINIMAL_VIABLE_ENGINE_MEMORY,
+				"database.sm.hotCopy.journalPath.enabled": "true",
+				"restore.source":                          testlib.IMPORT_ARCHIVE_URL,
+			},
+		}
+
+		defer testlib.Teardown(testlib.TEARDOWN_DATABASE)
+
+		databaseReleaseName := testlib.StartDatabase(t, namespaceName, admin0, databaseOptions)
+
+		defer testlib.Teardown(testlib.TEARDOWN_RESTORE)
+		testlib.RestoreDatabase(t, namespaceName, admin0, databaseOptions)
+
+		verifyExternalJournal(t, namespaceName, admin0, databaseReleaseName, databaseOptions)
+		testlib.CheckRestoreRequests(t, namespaceName, admin0, "demo", "", "")
+	})
+
+	t.Run("databaseRestoreBackupset", func(t *testing.T) {
+		databaseOptions := &helm.Options{
+			SetValues: map[string]string{
+				"database.name":                           "demo",
+				"database.sm.resources.requests.cpu":      testlib.MINIMAL_VIABLE_ENGINE_CPU,
+				"database.sm.resources.requests.memory":   testlib.MINIMAL_VIABLE_ENGINE_MEMORY,
+				"database.te.resources.requests.cpu":      testlib.MINIMAL_VIABLE_ENGINE_CPU,
+				"database.te.resources.requests.memory":   testlib.MINIMAL_VIABLE_ENGINE_MEMORY,
+				"database.sm.hotCopy.journalPath.enabled": "true",
+			},
+		}
+
+		defer testlib.Teardown(testlib.TEARDOWN_DATABASE)
+
+		databaseReleaseName := testlib.StartDatabase(t, namespaceName, admin0, databaseOptions)
+
+		opt := testlib.GetExtractedOptions(databaseOptions)
+		smPodNameTemplate := fmt.Sprintf("sm-%s-nuodb-%s-%s", databaseReleaseName, opt.ClusterName, opt.DbName)
+		smPodName0 := testlib.GetPodName(t, namespaceName, smPodNameTemplate)
+
+		// Execute initial backup
+		backupset := testlib.BackupDatabase(t, namespaceName, smPodName0, opt.DbName, "full", opt.ClusterName)
+
+		testlib.CreateQuickstartSchema(t, namespaceName, admin0)
+
+		// set restore source to the initial backupset
+		databaseOptions.SetValues["restore.source"] = backupset
+
+		defer testlib.Teardown(testlib.TEARDOWN_RESTORE)
+		testlib.RestoreDatabase(t, namespaceName, admin0, databaseOptions)
+
+		verifyExternalJournal(t, namespaceName, admin0, databaseReleaseName, databaseOptions)
+
+		// verify that the database does NOT contain the data from AFTER the backup
+		tables, err := testlib.RunSQL(t, namespaceName, admin0, "demo", "show schema User")
+		require.NoError(t, err, "error running SQL: show schema User")
+		require.Contains(t, tables, "No tables found in schema ", "Show schema returned: ", tables)
+		testlib.CheckRestoreRequests(t, namespaceName, admin0, opt.DbName, "", "")
+	})
 }


### PR DESCRIPTION
**Issue**

There are two cases where an archive restore won't work if an external journal directory is enabled:
- `autoImport` with a cold archive but `backupset` selected as a backup type
- database restore with cold archive

**Changes**

- Check if a cold archive is downloaded as a restore source by testing the existence of `1.atm`. Previously this was relying on `restore_type` which is not exposed when doing database restore or it might be incorrectly specified by the user in case of `autoImport` or `autoRestore`.

**Testing**

- `TestKubernetesImportDatabaseSeparateJournal` test case has been extended and moved to the `long_restore` test suite.
- Added restore database tests with separate journal location.
- Purge all database archives as part of the database teardown function. This allows running several database tests that check archives with a single admin setup.