### PR TITLE
Increase leaderAssignmentTimeout to account for CrashLoopBackOff

### DIFF
--- a/stable/admin/values.yaml
+++ b/stable/admin/values.yaml
@@ -174,6 +174,9 @@ admin:
     # force reconnecting processes that are not in the domain state to shut
     # themselves down
     evictUnknownProcesses: true
+    # increase leader assignment timeout to account for maximum scheduling
+    # delay of 5 minutes in K8s
+    leaderAssignmentTimeout: "300000"
 
   ## nuodb-admin resource requests and limits
   ## Ref: http://kubernetes.io/docs/user-guide/compute-resources/

--- a/test/minikube/minikube_upgrade_helm_test.go
+++ b/test/minikube/minikube_upgrade_helm_test.go
@@ -175,6 +175,7 @@ func TestUpgradeHelm(t *testing.T) {
 
 	t.Run("NuoDB_From330_ToLocal", func(t *testing.T) {
 		upgradeAdminTest(t, "3.3.0", &testlib.UpgradeOptions{
+			AdminPodShouldGetRecreated: true,
 		})
 	})
 }
@@ -194,6 +195,7 @@ func TestUpgradeHelmFullDB(t *testing.T) {
 
 	t.Run("NuoDB_From330_ToLocal", func(t *testing.T) {
 		upgradeDatabaseTest(t, "3.3.0", &testlib.UpgradeOptions{
+			AdminPodShouldGetRecreated: true,
 		})
 	})
 }

--- a/test/testlib/nuodb_database_utilities.go
+++ b/test/testlib/nuodb_database_utilities.go
@@ -154,7 +154,7 @@ func StartDatabaseTemplate(t *testing.T, namespaceName string, adminPod string, 
 				go GetAppLog(t, namespaceName, smPod, "", &v12.PodLogOptions{Follow: true})
 			}
 		})
-		AwaitPodUp(t, namespaceName, smPodName0, 300*time.Second)
+		AwaitPodUp(t, namespaceName, smPodName0, 600*time.Second)
 
 		// Await num of database processes only for single cluster deployment;
 		// in multi-clusters the await logic should be called once all clusters

--- a/test/testlib/nuodb_database_utilities.go
+++ b/test/testlib/nuodb_database_utilities.go
@@ -154,7 +154,7 @@ func StartDatabaseTemplate(t *testing.T, namespaceName string, adminPod string, 
 				go GetAppLog(t, namespaceName, smPod, "", &v12.PodLogOptions{Follow: true})
 			}
 		})
-		AwaitPodUp(t, namespaceName, smPodName0, 600*time.Second)
+		AwaitPodUp(t, namespaceName, smPodName0, 300*time.Second)
 
 		// Await num of database processes only for single cluster deployment;
 		// in multi-clusters the await logic should be called once all clusters


### PR DESCRIPTION
If SMs fail to start due to leaderAssignmentTimeout because some SM is not being scheduled (e.g. because the volume the archive is on is unavailable), then eventually the SMs will enter CrashLoopBackOff state and Kubernetes will begin scheduling them with a 5-minute delay. This would cause the leaderAssignmentTimeout problems to persist even after all SMs become schedulable, because now the SMs are more staggered in when they get scheduled, and we will be lucky for all of them to be scheduled within the same 60-second window as required by the current leaderAssignmentTimeout setting of 60000 milliseconds.

This change bumps the leaderAssignmentTimeout to 300000 milliseconds (5 minutes) to account for the maximum scheduling delay in Kubernetes.