### PR TITLE
Upgrade database protocol automatically

### DIFF
--- a/stable/database/README.md
+++ b/stable/database/README.md
@@ -270,6 +270,8 @@ The following tables list the configurable parameters of the `database` chart an
 | `te.otherOptions` | Additional key/value Docker options | `{}` |
 | `sm.otherOptions` | Additional key/value Docker options | `{}` |
 | `te.readinessTimeoutSeconds` | TE readiness probe timeout, sometimes needs adjusting depending on environment and pod resources | `5` |
+| `automaticProtocolUpgrade.enabled` | Enable automatic database protocol upgrade and a Transaction Engine (TE) restart as an upgrade finalization step done by Kubernetes Aware Admin (KAA). Applicable for NuoDB major versions upgrade only | `false` |
+| `automaticProtocolUpgrade.tePreferenceQuery` | LBQuery expression to select the TE that will be restarted after a successful database protocol upgrade. Defaults to random Transaction Engine (TE) in MONITORED state | `""` |
 
 #### database.configFiles.*
 

--- a/stable/database/README.md
+++ b/stable/database/README.md
@@ -270,7 +270,7 @@ The following tables list the configurable parameters of the `database` chart an
 | `te.otherOptions` | Additional key/value Docker options | `{}` |
 | `sm.otherOptions` | Additional key/value Docker options | `{}` |
 | `te.readinessTimeoutSeconds` | TE readiness probe timeout, sometimes needs adjusting depending on environment and pod resources | `5` |
-| `automaticProtocolUpgrade.enabled` | Enable automatic database protocol upgrade and a Transaction Engine (TE) restart as an upgrade finalization step done by Kubernetes Aware Admin (KAA). Applicable for NuoDB major versions upgrade only | `false` |
+| `automaticProtocolUpgrade.enabled` | Enable automatic database protocol upgrade and a Transaction Engine (TE) restart as an upgrade finalization step done by Kubernetes Aware Admin (KAA). Applicable for NuoDB major versions upgrade only. Requires NuoDB 4.2.3+ | `false` |
 | `automaticProtocolUpgrade.tePreferenceQuery` | LBQuery expression to select the TE that will be restarted after a successful database protocol upgrade. Defaults to random Transaction Engine (TE) in MONITORED state | `""` |
 
 #### database.configFiles.*

--- a/stable/database/templates/_helpers.tpl
+++ b/stable/database/templates/_helpers.tpl
@@ -247,6 +247,23 @@ The configuration is imported only in the entrypoint cluster.
 {{- end -}}
 {{- end -}}
 
+{{/*
+Enables automatic database protocol upgrade via annotations.
+The configuration is imported only in the entrypoint cluster.
+*/}}
+{{- define "database.automaticProtocolUpgrade" -}}
+{{- if .Values.database.automaticProtocolUpgrade }}
+{{- if eq (include "defaultfalse" .Values.database.automaticProtocolUpgrade.enabled) "true" -}}
+{{- if (eq (default "cluster0" .Values.cloud.cluster.name) (default "cluster0" .Values.cloud.cluster.entrypointName)) }}
+"nuodb.com/automatic-database-protocol-upgrade": "true"
+{{- with .Values.database.automaticProtocolUpgrade.tePreferenceQuery }}
+"nuodb.com/automatic-database-protocol-upgrade.te-preference-policy": {{ . | quote }}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "autoRestore.type" -}}
 {{- $valid := list "stream" "backupset" "" }}
 {{- if not (has .Values.database.autoRestore.type $valid) }}

--- a/stable/database/templates/_helpers.tpl
+++ b/stable/database/templates/_helpers.tpl
@@ -252,16 +252,16 @@ Enables automatic database protocol upgrade via annotations.
 The configuration is imported only in the entrypoint cluster.
 */}}
 {{- define "database.automaticProtocolUpgrade" -}}
-{{- if .Values.database.automaticProtocolUpgrade }}
-{{- if eq (include "defaultfalse" .Values.database.automaticProtocolUpgrade.enabled) "true" -}}
-{{- if (eq (default "cluster0" .Values.cloud.cluster.name) (default "cluster0" .Values.cloud.cluster.entrypointName)) }}
+  {{- if .Values.database.automaticProtocolUpgrade }}
+    {{- if eq (include "defaultfalse" .Values.database.automaticProtocolUpgrade.enabled) "true" -}}
+      {{- if (eq (default "cluster0" .Values.cloud.cluster.name) (default "cluster0" .Values.cloud.cluster.entrypointName)) }}
 "nuodb.com/automatic-database-protocol-upgrade": "true"
-{{- with .Values.database.automaticProtocolUpgrade.tePreferenceQuery }}
+        {{- with .Values.database.automaticProtocolUpgrade.tePreferenceQuery }}
 "nuodb.com/automatic-database-protocol-upgrade.te-preference-policy": {{ . | quote }}
-{{- end -}}
-{{- end -}}
-{{- end -}}
-{{- end -}}
+        {{- end -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
 {{- end -}}
 
 {{- define "autoRestore.type" -}}

--- a/stable/database/templates/deployment.yaml
+++ b/stable/database/templates/deployment.yaml
@@ -5,6 +5,7 @@ metadata:
     description: |-
       Database deployment resource for NuoDB Transaction Engines (TE).
 {{- include "database.loadBalancerConfig" . | indent 4 }}
+{{- include "database.automaticProtocolUpgrade" . | indent 4 }}
   labels:
     app: {{ template "database.fullname" . }}
     group: nuodb

--- a/stable/database/values.yaml
+++ b/stable/database/values.yaml
@@ -402,22 +402,14 @@ database:
   isManualVolumeProvisioning: false
   isRestore: false
 
-  # NuoDB supports explicit database protocol version upgrade which is performed
-  # after upgrading the NuoDB image for all database processes. To simplify
-  # NuoDB version rollout, Kubernetes Aware Admin (KAA) is used to automatically
-  # upgrade database protocol and restart a Transaction Engine (TE) as an
-  # upgrade finalization step. For more information on how to perform the steps
-  # manually, please check Upgrading the Database Protocol
+  # A new version of NuoDB database software may also introduce a new version of
+  # the database protocol. NuoDB supports explicit database protocol version
+  # upgrade which is performed after upgrading the NuoDB image for all database
+  # processes. To simplify NuoDB version rollout, Kubernetes Aware Admin (KAA)
+  # is used to automatically upgrade database protocol and restart a Transaction
+  # Engine (TE) as an upgrade finalization step. For more information on how to
+  # perform the steps manually, please check Upgrading the Database Protocol
   # (https://doc.nuodb.com/nuodb/latest/deployment-models/physical-or-vmware-environments-with-nuodb-admin/installing-nuodb/upgrading-to-a-new-release/upgrading-the-database-protocol/).
-  #
-  # The database protocol version is eligible for an upgrade to the max possible
-  # version if all of the bellows are true:
-  # - the database is in RUNNING state. This ensures that all SMs/archives are
-  #   RUNNING.
-  # - all database processes are MONITORED
-  # - the automatic upgrade is enabled for this database (disabled by default)
-  # - all database processes are running with the same release binary version
-  # - there are available protocol versions for upgrading to
   #
   # IMPORTANT: After the database protocol version has been upgraded, the NuoDB
   # Archive cannot be used with NuoDB software versions that only support the

--- a/stable/database/values.yaml
+++ b/stable/database/values.yaml
@@ -402,6 +402,22 @@ database:
   isManualVolumeProvisioning: false
   isRestore: false
 
+  # NuoDB supports explicit database protocol version upgrade which is performed
+  # after upgrading the NuoDB image for all database processes. To simplify
+  # NuoDB version rollout, Kubernetes Aware Admin (KAA) is used to automatically
+  # upgrade database protocol and restart a Transaction Engine (TE) as an
+  # upgrade finalization step. For more information on how to perform the steps
+  # manually, please check Upgrading the Database Protocol
+  # (https://doc.nuodb.com/nuodb/latest/deployment-models/physical-or-vmware-environments-with-nuodb-admin/installing-nuodb/upgrading-to-a-new-release/upgrading-the-database-protocol/).
+  automaticProtocolUpgrade:
+    # controls if an automatic protocol upgrade should be done for this database
+    enabled: false
+    # LBQuery expression to select the TE that will be restarted after
+    # successful database protocol upgrade. Defaults to random TE. For more
+    # information, please check LBQuery Expression Syntax
+    # (https://doc.nuodb.com/nuodb/latest/client-development/load-balancer-policies/#_lbquery_expression_syntax).
+    tePreferenceQuery: ""
+
 nuocollector:
   # Enable NuoDB Collector by setting nuocollector.enabled=true
   enabled: false

--- a/stable/database/values.yaml
+++ b/stable/database/values.yaml
@@ -409,6 +409,12 @@ database:
   # upgrade finalization step. For more information on how to perform the steps
   # manually, please check Upgrading the Database Protocol
   # (https://doc.nuodb.com/nuodb/latest/deployment-models/physical-or-vmware-environments-with-nuodb-admin/installing-nuodb/upgrading-to-a-new-release/upgrading-the-database-protocol/).
+  #
+  # IMPORTANT: After the database protocol version has been upgraded, the NuoDB
+  # Archive cannot be used with NuoDB software versions that only support the
+  # previous database protocol version. As a result, downgrading after the
+  # database protocol version has been changed will require restoring a backup
+  # of the database.
   automaticProtocolUpgrade:
     # controls if an automatic protocol upgrade should be done for this database
     enabled: false

--- a/stable/database/values.yaml
+++ b/stable/database/values.yaml
@@ -410,6 +410,15 @@ database:
   # manually, please check Upgrading the Database Protocol
   # (https://doc.nuodb.com/nuodb/latest/deployment-models/physical-or-vmware-environments-with-nuodb-admin/installing-nuodb/upgrading-to-a-new-release/upgrading-the-database-protocol/).
   #
+  # The database protocol version is eligible for an upgrade to the max possible
+  # version if all of the bellows are true:
+  # - the database is in RUNNING state. This ensures that all SMs/archives are
+  #   RUNNING.
+  # - all database processes are MONITORED
+  # - the automatic upgrade is enabled for this database (disabled by default)
+  # - all database processes are running with the same release binary version
+  # - there are available protocol versions for upgrading to
+  #
   # IMPORTANT: After the database protocol version has been upgraded, the NuoDB
   # Archive cannot be used with NuoDB software versions that only support the
   # previous database protocol version. As a result, downgrading after the


### PR DESCRIPTION
**Changes**

Starting from NuoDB 4.2.3, the Kubernetes Aware Admin (KAA) can upgrade the database protocol version automatically (turned off by default). 
Expose this functionality in NuoDB Helm Charts so that NuoDB product upgrade process can be easily automated.

The database protocol version is eligible for an upgrade to the max possible version if all of the bellows are true:

- the database is in `RUNNING` state. This ensures that all SMs/archives are `RUNNING`.
- all database processes are `MONITORED`
- the automatic upgrade is enabled for this database (disabled by default)
- all database processes are running with the same release binary version
- there are available protocol versions for upgrading to

A TE to restart selection preference can be configured if needed.

**Testing**

- Regresion testing
- New integration tests
- Extend `TestKubernetesUpgradeFullDatabase` test and include conditional sub-test. It will run in the internal CI only until the feature is released.