### PR TITLE
Disable Helm Upgrade Tests without license

### DIFF
--- a/test/minikube/minikube_domain_resync_test.go
+++ b/test/minikube/minikube_domain_resync_test.go
@@ -274,7 +274,7 @@ func TestAdminScaleDown(t *testing.T) {
 }
 
 func TestDomainResync(t *testing.T) {
-	if os.Getenv("NUODB_LICENSE") != "ENTERPRISE" && os.Getenv("NUODB_LICENSE_CONTENT") == "" {
+	if os.Getenv("NUODB_LICENSE") != "ENTERPRISE" || os.Getenv("NUODB_LICENSE_CONTENT") == "" {
 		t.Skip("Cannot test resync without the Enterprise Edition")
 	}
 

--- a/test/minikube/minikube_domain_resync_test.go
+++ b/test/minikube/minikube_domain_resync_test.go
@@ -274,7 +274,7 @@ func TestAdminScaleDown(t *testing.T) {
 }
 
 func TestDomainResync(t *testing.T) {
-	if os.Getenv("NUODB_LICENSE") != "ENTERPRISE" || os.Getenv("NUODB_LICENSE_CONTENT") == "" {
+	if os.Getenv("NUODB_LICENSE") != "ENTERPRISE" && os.Getenv("NUODB_LICENSE_CONTENT") == "" {
 		t.Skip("Cannot test resync without the Enterprise Edition")
 	}
 

--- a/test/minikube/minikube_upgrade_helm_test.go
+++ b/test/minikube/minikube_upgrade_helm_test.go
@@ -4,6 +4,7 @@ package minikube
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -62,6 +63,10 @@ func upgradeAdminTest(t *testing.T, fromHelmVersion string, upgradeOptions *test
 }
 
 func upgradeDatabaseTest(t *testing.T, fromHelmVersion string, upgradeOptions *testlib.UpgradeOptions) {
+	if os.Getenv("NUODB_LICENSE") != "ENTERPRISE" || os.Getenv("NUODB_LICENSE_CONTENT") == "" {
+		t.Skip("Can not test helm upgrade in this environment")
+	}
+
 	testlib.AwaitTillerUp(t)
 	defer testlib.VerifyTeardown(t)
 

--- a/test/minikube/minikube_upgrade_helm_test.go
+++ b/test/minikube/minikube_upgrade_helm_test.go
@@ -63,7 +63,7 @@ func upgradeAdminTest(t *testing.T, fromHelmVersion string, upgradeOptions *test
 }
 
 func upgradeDatabaseTest(t *testing.T, fromHelmVersion string, upgradeOptions *testlib.UpgradeOptions) {
-	if os.Getenv("NUODB_LICENSE") != "ENTERPRISE" || os.Getenv("NUODB_LICENSE_CONTENT") == "" {
+	if os.Getenv("NUODB_LICENSE") != "ENTERPRISE" && os.Getenv("NUODB_LICENSE_CONTENT") == "" {
 		t.Skip("Can not test helm upgrade in this environment")
 	}
 

--- a/test/minikube/minikube_upgrade_helm_test.go
+++ b/test/minikube/minikube_upgrade_helm_test.go
@@ -63,7 +63,7 @@ func upgradeAdminTest(t *testing.T, fromHelmVersion string, upgradeOptions *test
 }
 
 func upgradeDatabaseTest(t *testing.T, fromHelmVersion string, upgradeOptions *testlib.UpgradeOptions) {
-	if os.Getenv("NUODB_LICENSE") != "ENTERPRISE" && os.Getenv("NUODB_LICENSE_CONTENT") == "" {
+	if os.Getenv("NUODB_LICENSE") == "ENTERPRISE" {
 		t.Skip("Can not test helm upgrade in this environment")
 	}
 

--- a/test/minikube/minikube_upgrade_helm_test.go
+++ b/test/minikube/minikube_upgrade_helm_test.go
@@ -64,7 +64,7 @@ func upgradeAdminTest(t *testing.T, fromHelmVersion string, upgradeOptions *test
 
 func upgradeDatabaseTest(t *testing.T, fromHelmVersion string, upgradeOptions *testlib.UpgradeOptions) {
 	if os.Getenv("NUODB_LICENSE") == "ENTERPRISE" {
-		t.Skip("Can not test helm upgrade in this environment")
+		t.Skip("Can not test helm upgrade in this environment. See DB-33858")
 	}
 
 	testlib.AwaitTillerUp(t)


### PR DESCRIPTION
NuoDB infrastructure (bamboo) does not use the license and license content. Disable the full DB helm upgrade tests in those cases.