### PR TITLE
Dump stacktraces before collecting logs

### DIFF
--- a/stable/admin/templates/statefulset.yaml
+++ b/stable/admin/templates/statefulset.yaml
@@ -4,6 +4,8 @@ metadata:
   annotations:
     description: |-
       NuoAdmin statefulset resource for NuoDB Admin layer.
+    kubectl.kubernetes.io/default-container: admin
+    kubectl.kubernetes.io/default-logs-container: admin
 {{- include "admin.loadBalancerConfig" . | indent 4 }}
     {{- if (eq (default "cluster0" .Values.cloud.cluster.name) (default "cluster0" .Values.cloud.cluster.entrypointName)) }}
     nuodb.com/bootstrap-servers: {{ default 0 .Values.admin.bootstrapServers | quote }}

--- a/stable/database/templates/deployment.yaml
+++ b/stable/database/templates/deployment.yaml
@@ -4,6 +4,8 @@ metadata:
   annotations:
     description: |-
       Database deployment resource for NuoDB Transaction Engines (TE).
+    kubectl.kubernetes.io/default-container: engine
+    kubectl.kubernetes.io/default-logs-container: engine
 {{- include "database.loadBalancerConfig" . | indent 4 }}
 {{- include "database.automaticProtocolUpgrade" . | indent 4 }}
   labels:

--- a/stable/database/templates/statefulset.yaml
+++ b/stable/database/templates/statefulset.yaml
@@ -6,6 +6,8 @@ metadata:
   annotations:
     description: |-
       Database deployment resource for NuoDB Storage Engines (SM).
+    kubectl.kubernetes.io/default-container: engine
+    kubectl.kubernetes.io/default-logs-container: engine
   labels:
     app: {{ template "database.fullname" . }}
     group: nuodb


### PR DESCRIPTION
This has two changes:
- On test failure, dump stacktraces to stdout so that they appear in the collected logs. This is helpful for diagnosing issues involving admin processes.
- Use annotations to specify the default container.