### PR TITLE
Increase leaderAssignmentTimeout default value

### DIFF
--- a/stable/admin/values.yaml
+++ b/stable/admin/values.yaml
@@ -175,9 +175,10 @@ admin:
     # force reconnecting processes that are not in the domain state to shut
     # themselves down
     evictUnknownProcesses: true
-    # increase leader assignment timeout to account for maximum scheduling
-    # delay of 5 minutes in K8s
-    leaderAssignmentTimeout: "300000"
+    # increase leader assignment timeout to account for maximum scheduling delay
+    # of 5 minutes in K8s; set the default value to 15 minutes (3x back-off
+    # delay) which should be enough for most databases
+    leaderAssignmentTimeout: "900000"
 
   ## nuodb-admin resource requests and limits
   ## Ref: http://kubernetes.io/docs/user-guide/compute-resources/


### PR DESCRIPTION
**Issue**

In certain cases, databases with 3+ Storage Managers can fail to calculate leader assignment within the configured default timeout due to additional SM Pod startup delays and scheduling deviation between different SM pods.

**Changes**
- Increase the default value for `leaderAssignmentTimeout` to `900000` (15 min.) which should be more than enough for most databases