### PR TITLE
Resurrect archive only if it will be reused

### DIFF
--- a/stable/database/files/nuosm
+++ b/stable/database/files/nuosm
@@ -145,12 +145,15 @@ function isRestoreSourceAvailable() {
 #
 function resurrectRemovedArchive() {
   trace "resurrecting removed archive metadata"
-  # Find archiveId associated with process which address is the same as this pod hostname
-  # It assumes that there is only one archive object associated with the current host
-  removed_archive=$( nuocmd show archives --db-name $DB_NAME --removed --removed-archive-format "archive-id: {id}" | sed -En "/^archive-id: / {N; /$HOSTNAME/ s/^archive-id: ([0-9]+).*$/\1/; T; p}" | head -n 1 )
-  if [ -n "$removed_archive" ]; then
-    log "Resurrecting removed archiveId=${removed_archive}"
-    nuocmd create archive --db-name $DB_NAME --archive-path $DB_DIR --is-external --restored --archive-id $removed_archive
+  # Resurrect the archiveId associated which this pod if the previously fetched
+  # archiveId is removed
+  if [ -n "$myArchive" ] && \
+    nuocmd show archives \
+      --db-name $DB_NAME \
+      --removed \
+      --removed-archive-format "archive-id: {id}" | grep -q "archive-id: ${myArchive}$"; then
+    log "Resurrecting removed archiveId=${myArchive}"
+    nuocmd create archive --db-name $DB_NAME --archive-path $DB_DIR --is-external --restored --archive-id "$myArchive"
   fi
 }
 

--- a/stable/database/files/nuosm
+++ b/stable/database/files/nuosm
@@ -145,8 +145,8 @@ function isRestoreSourceAvailable() {
 #
 function resurrectRemovedArchive() {
   trace "resurrecting removed archive metadata"
-  # Resurrect the archiveId associated which this pod if the previously fetched
-  # archiveId is removed
+  # Resurrect the previously fetched archiveId associated which this Pod it is
+  # removed
   if [ -n "$myArchive" ] && \
     nuocmd show archives \
       --db-name $DB_NAME \

--- a/stable/database/files/nuosm
+++ b/stable/database/files/nuosm
@@ -761,9 +761,10 @@ else
 
   wotIdid=""
 
-  # resurrect my archive if it is removed
-  # this will likely never execute but is kept to be sure
-  resurrectRemovedArchive
+  # resurrect my archive only if info.json file is available, otherwise
+  # nuodocker will create a new one; this is needed because KAA will remove
+  # archives for scaled down SM statefulsets
+  [ -f "$DB_DIR/info.json" ] && resurrectRemovedArchive
 
   # if a RESTORE_SOURCE is defined, and the archive dir is empty, then import/restore from the URL
   if [ -n "$restore_source" -a -z "$restore_requested" -a $atomCount -lt 20 -a $catalogCount -lt 2 ]; then


### PR DESCRIPTION
**Issue**

In rare cases, a database running NuoDB 4.1.x can have `AWAITING_ARCHIVE_HISTORIES_INC` state if the PVC for some of the SMs needs to be recreated. For example:

- scale down SM StatefulSet to 0
- delete and recreate the archive PVC which creates a new PV (change in the storage class for example)
- scale up SM StatefulSet to the previous replica count

**Changes**

Resurrect the archive metadata which was previously bound to an SM Pod only if it will be reused. Use the previously fetched `archiveId` when resurrecting it. 

**Testing**

- `TestChangingJournalLocationWithMultipleSMs` was flaky because of this issue
- `TestDomainResync` exercise the archive metadata reuse after SM scale down and then up
- regression testing
