### PR TITLE
Update AWS annotations for the LoadBalancer service

### DIFF
--- a/stable/admin/README.md
+++ b/stable/admin/README.md
@@ -153,6 +153,7 @@ The following tables list the configurable parameters for the `admin` option of 
 | `externalAccess.enabled` | Whether to deploy a Layer 4 cloud load balancer service for the admin layer | `false` |
 | `externalAccess.internalIP` | Whether to use an internal (to the cloud) or external (public) IP address for the load balancer | `nil` |
 | `externalAccess.type` | The service type used to enable external access for NuoDB Admin. The supported types are `NodePort` and `LoadBalancer` (defaults to `LoadBalancer`) | `nil` |
+| `externalAccess.annotations` | Annotations to pass through to the Service of type `LoadBalancer` | `{}` |
 | `resources` | Labels to apply to all resources | `{}` |
 | `affinity` | Affinity rules for NuoDB Admin | `{}` |
 | `nodeSelector` | Node selector rules for NuoDB Admin | `{}` |

--- a/stable/admin/templates/_helpers.tpl
+++ b/stable/admin/templates/_helpers.tpl
@@ -266,3 +266,36 @@ Renders the admin service name for external access based on the service type
 {{ .Values.admin.domain }}
   {{- end }}
 {{- end }}
+
+{{/*
+Renders the annotations for the LoadBalancer admin service
+*/}}
+{{- define "admin.externalAccessAnnotations" -}}
+  {{- if eq (default "LoadBalancer" .Values.admin.externalAccess.type) "LoadBalancer" }}
+    {{- if .Values.admin.externalAccess.annotations }}
+{{ toYaml .Values.admin.externalAccess.annotations | trim }}
+    {{- else -}}
+      {{- if .Values.cloud.provider }}
+        {{- if eq .Values.cloud.provider "amazon" }}
+          {{- if .Values.admin.externalAccess.internalIP }}
+service.beta.kubernetes.io/aws-load-balancer-internal: "true"
+service.beta.kubernetes.io/aws-load-balancer-scheme: "internal"
+          {{- else }}
+service.beta.kubernetes.io/aws-load-balancer-type: "external"
+service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: "ip"
+service.beta.kubernetes.io/aws-load-balancer-scheme: "internet-facing"
+          {{- end }}
+        {{- else if eq .Values.cloud.provider "azure" }}
+          {{- if .Values.admin.externalAccess.internalIP }}
+service.beta.kubernetes.io/azure-load-balancer-internal: "true"
+          {{- end }}
+        {{- else if eq .Values.cloud.provider "google" }}
+          {{- if .Values.admin.externalAccess.internalIP }}
+cloud.google.com/load-balancer-type: "Internal"
+networking.gke.io/load-balancer-type: "Internal"
+          {{- end -}}
+        {{- end -}}
+      {{- end -}}
+    {{- end }}
+  {{- end }}
+{{- end -}}

--- a/stable/admin/templates/service.yaml
+++ b/stable/admin/templates/service.yaml
@@ -4,17 +4,7 @@ kind: Service
 metadata:
   annotations:
     description: "Service (and load-balancer) for Admin pods."
-    {{- if and .Values.admin.externalAccess.internalIP .Values.cloud.provider}}
-    {{- if eq (default "LoadBalancer" .Values.admin.externalAccess.type) "LoadBalancer" }}
-    {{- if eq .Values.cloud.provider "amazon" }}
-    service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0
-    {{- else if eq .Values.cloud.provider "azure" }}
-    service.beta.kubernetes.io/azure-load-balancer-internal: "true"
-    {{- else if eq .Values.cloud.provider "google" }}
-    cloud.google.com/load-balancer-type: "Internal"
-    {{- end}}
-    {{- end}}
-    {{- end}}
+{{- include "admin.externalAccessAnnotations" . | indent 4 }}
   labels:
     app: {{ template "admin.fullname" . }}
     group: nuodb

--- a/stable/admin/values.yaml
+++ b/stable/admin/values.yaml
@@ -121,6 +121,7 @@ admin:
   #   enabled: false
   #   internalIP: true
   #   type: LoadBalancer
+  #   annotations: {}
 
   persistence:
     size: 1Gi

--- a/stable/database/README.md
+++ b/stable/database/README.md
@@ -256,6 +256,7 @@ The following tables list the configurable parameters of the `database` chart an
 | `te.externalAccess.enabled` | Whether to deploy a Layer 4 service for the database | `false` |
 | `te.externalAccess.internalIP` | Whether to use an internal (to the cloud) or external (public) IP address for the load balancer. Only applies to external access of type `LoadBalancer` | `nil` |
 | `te.externalAccess.type` | The service type used to enable external database access. The supported types are `NodePort` and `LoadBalancer` (defaults to `LoadBalancer`) | `nil` |
+| `te.externalAccess.annotations` | Annotations to pass through to the Service of type `LoadBalancer` | `{}` |
 | `te.dbServices.enabled` | Whether to deploy clusterip and headless services for direct TE connections (defaults true) | `nil` |
 | `te.logPersistence.enabled` | Whether to enable persistent storage for logs | `false` |
 | `te.logPersistence.overwriteBackoff.copies` | How many copies of the crash directory to keep within windowMinutes | `3` |

--- a/stable/database/templates/service.yaml
+++ b/stable/database/templates/service.yaml
@@ -4,18 +4,7 @@ kind: Service
 metadata:
   annotations:
     description: "Service (and load-balancer) for TE pods."
-    {{- if and .Values.database.te.externalAccess.internalIP .Values.cloud.provider }}
-    {{- if eq (default "LoadBalancer" .Values.database.te.externalAccess.type) "LoadBalancer" }}
-    {{- if eq .Values.cloud.provider "amazon" }}
-    service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0
-    {{- else if eq .Values.cloud.provider "azure" }}
-    service.beta.kubernetes.io/azure-load-balancer-internal: "true"
-    {{- else if eq .Values.cloud.provider "google" }}
-    cloud.google.com/load-balancer-type: "Internal"
-    networking.gke.io/load-balancer-type: "Internal"
-    {{- end}}
-    {{- end}}
-    {{- end}}
+{{- include "database.externalAccessAnnotations" . | indent 4 }}
   labels:
     app: {{ template "database.fullname" . }}
     group: nuodb

--- a/stable/database/values.yaml
+++ b/stable/database/values.yaml
@@ -361,6 +361,7 @@ database:
       # enabled: false
       # internalIP: true
       # type: LoadBalancer
+      # annotations: {}
     
     ## By default, database clusterip and headless services for direct TE connections are enabled,
     ## but can be optionally disabled here

--- a/test/integration/template_admin_test.go
+++ b/test/integration/template_admin_test.go
@@ -204,6 +204,30 @@ func TestAdminServiceRenders(t *testing.T) {
 		assert.Equal(t, v1.ServiceTypeLoadBalancer, obj.Spec.Type)
 		assert.Empty(t, obj.Spec.ClusterIP)
 		assert.Contains(t, obj.Annotations, "service.beta.kubernetes.io/aws-load-balancer-internal")
+		assert.Contains(t, obj.Annotations, "service.beta.kubernetes.io/aws-load-balancer-scheme")
+	}
+
+	// render external AWS NLB annotations
+	options.SetValues["admin.externalAccess.internalIP"] = "false"
+	output = helm.RenderTemplate(t, options, helmChartPath, "release-name", []string{"templates/service.yaml"})
+
+	for _, obj := range testlib.SplitAndRenderService(t, output, 1) {
+		assert.Equal(t, "nuodb-balancer", obj.Name)
+		assert.Equal(t, v1.ServiceTypeLoadBalancer, obj.Spec.Type)
+		assert.Empty(t, obj.Spec.ClusterIP)
+		assert.Equal(t, obj.Annotations["service.beta.kubernetes.io/aws-load-balancer-type"], "external")
+		assert.Equal(t, obj.Annotations["service.beta.kubernetes.io/aws-load-balancer-nlb-target-type"], "ip")
+		assert.Equal(t, obj.Annotations["service.beta.kubernetes.io/aws-load-balancer-scheme"], "internet-facing")
+	}
+
+	// render custom annotations for the external service
+	options.SetValues["admin.externalAccess.annotations.service\\.beta\\.kubernetes\\.io/aws-load-balancer-name"] = "nuodb-admin-nlb"
+	output = helm.RenderTemplate(t, options, helmChartPath, "release-name", []string{"templates/service.yaml"})
+	for _, obj := range testlib.SplitAndRenderService(t, output, 1) {
+		assert.Equal(t, "nuodb-balancer", obj.Name)
+		assert.Equal(t, v1.ServiceTypeLoadBalancer, obj.Spec.Type)
+		assert.Equal(t, obj.Annotations["service.beta.kubernetes.io/aws-load-balancer-name"], "nuodb-admin-nlb")
+		assert.NotContains(t, obj.Annotations, "service.beta.kubernetes.io/aws-load-balancer-scheme")
 	}
 }
 


### PR DESCRIPTION
**Issue**

Starting from aws-load-balancer-controller v2.2.0, the `service.beta.kubernetes.io/aws-load-balancer-internal` LoadBalancer service annotation is deprecated. The new `service.beta.kubernetes.io/aws-load-balancer-scheme` annotation should instead. The v2.2.0+ controller creates NLB with "internal" scheme by default which allows traffic from the VPC only. 

This prevents external access to the NuoDB domain when `admin.externalAccess.internalIP` and `database.te.externalAccess.internalIP` are set to `false`.

**Changes**

- added the needed new [AWS annotations](https://docs.aws.amazon.com/eks/latest/userguide/network-load-balancing.html#network-load-balancer) for external access to the `admin` and `database` _LoadBalancer_ services
- refactored the external service annotations rendering in named template
- added `admin.externalAccess.annotations` and `database.te.externalAccess.annotations` support for user-defined annotations. This is to allow custom configuration based on the load balancer controller version if needed.

**Testing**

- added more integration tests
- regression testing
- @bkelly-ndb could you please give it another run in EKS whenever possible? Thanks!

