### PR TITLE
Increase the timeout for multi-cluster tests

### DIFF
--- a/test/testlib/minikube_utilities.go
+++ b/test/testlib/minikube_utilities.go
@@ -406,7 +406,10 @@ func AwaitTillerUp(t *testing.T) {
 }
 
 func AwaitNrReplicasScheduled(t *testing.T, namespace string, expectedName string, nrReplicas int) {
-	timeout := 60 * time.Second
+	// in multi-cluster tests the Pods won't be scheduled until disks are
+	// provisioned which takes longer than in minikube; adjust the timeout if
+	// needed
+	timeout := AdjustPodTimeout(expectedName, 60*time.Second)
 	if nrReplicas > 1 {
 		timeout *= time.Duration(nrReplicas)
 	}

--- a/test/testlib/multicluster_utilities.go
+++ b/test/testlib/multicluster_utilities.go
@@ -5,8 +5,10 @@ import (
 	"encoding/json"
 	"io"
 	"io/ioutil"
+	"math"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gruntwork-io/terratest/modules/helm"
 	"github.com/gruntwork-io/terratest/modules/k8s"
@@ -230,4 +232,13 @@ func ExecuteInAllClusters(t *testing.T, actionFunc func(context *ClusterDeployme
 	for _, deploymentContext := range clusterDeployments {
 		WithClusterDeployment(t, deploymentContext, actionFunc)
 	}
+}
+
+func AdjustPodTimeout(podName string, timeout time.Duration) time.Duration {
+	if strings.Contains(podName, MULTI_CLUSTER_1.Name) || strings.Contains(podName, MULTI_CLUSTER_2.Name) {
+		// in Azure sometimes it takes 3 to 5 min for the disks to be
+		// provisioned and attached to the nodes
+		return time.Duration(int64(1.5 * math.Max(float64(timeout), float64(300*time.Second))))
+	}
+	return timeout
 }

--- a/test/testlib/nuodb_admin_utilities.go
+++ b/test/testlib/nuodb_admin_utilities.go
@@ -140,7 +140,7 @@ func StartAdminTemplate(t *testing.T, options *helm.Options, replicaCount int, n
 
 	// wait for all admin pods to become ready
 	for i := 0; i < replicaCount; i++ {
-		AwaitPodUp(t, namespaceName, adminNames[i], 300*time.Second)
+		AwaitPodUp(t, namespaceName, adminNames[i], AdjustPodTimeout(adminNames[i], 300*time.Second))
 	}
 
 	// Await num of admin servers only for single cluster deployment; in

--- a/test/testlib/nuodb_database_utilities.go
+++ b/test/testlib/nuodb_database_utilities.go
@@ -152,7 +152,7 @@ func StartDatabaseTemplate(t *testing.T, namespaceName string, adminPod string, 
 				go GetAppLog(t, namespaceName, tePod, "", &v12.PodLogOptions{Follow: true})
 			}
 		})
-		// the TEs will become RUNNING after the SMs as then need an entry node
+		// the TEs will become RUNNING after the SMs as they need an entry node
 		// so use the same ready timeout for both
 		readyTimeout := AdjustPodTimeout(tePodName, 300*time.Second)
 		AwaitPodUp(t, namespaceName, tePodName, readyTimeout)

--- a/test/testlib/nuodb_database_utilities.go
+++ b/test/testlib/nuodb_database_utilities.go
@@ -152,7 +152,10 @@ func StartDatabaseTemplate(t *testing.T, namespaceName string, adminPod string, 
 				go GetAppLog(t, namespaceName, tePod, "", &v12.PodLogOptions{Follow: true})
 			}
 		})
-		AwaitPodUp(t, namespaceName, tePodName, 180*time.Second)
+		// the TEs will become RUNNING after the SMs as then need an entry node
+		// so use the same timeout as the SMs; in Azure sometimes it takes 3 to
+		// 5 min for the disks to be provisioned and attached to the nodes
+		AwaitPodUp(t, namespaceName, tePodName, 300*time.Second)
 
 		// currently we don't render SM pods in the secondary releases
 		if opt.DbPrimaryRelease {

--- a/test/testlib/nuodb_database_utilities.go
+++ b/test/testlib/nuodb_database_utilities.go
@@ -153,9 +153,9 @@ func StartDatabaseTemplate(t *testing.T, namespaceName string, adminPod string, 
 			}
 		})
 		// the TEs will become RUNNING after the SMs as then need an entry node
-		// so use the same timeout as the SMs; in Azure sometimes it takes 3 to
-		// 5 min for the disks to be provisioned and attached to the nodes
-		AwaitPodUp(t, namespaceName, tePodName, 300*time.Second)
+		// so use the same ready timeout for both
+		readyTimeout := AdjustPodTimeout(tePodName, 300*time.Second)
+		AwaitPodUp(t, namespaceName, tePodName, readyTimeout)
 
 		// currently we don't render SM pods in the secondary releases
 		if opt.DbPrimaryRelease {
@@ -166,7 +166,7 @@ func StartDatabaseTemplate(t *testing.T, namespaceName string, adminPod string, 
 					go GetAppLog(t, namespaceName, smPod, "", &v12.PodLogOptions{Follow: true})
 				}
 			})
-			AwaitPodUp(t, namespaceName, smPodName0, 300*time.Second)
+			AwaitPodUp(t, namespaceName, smPodName0, readyTimeout)
 		}
 
 		// Await num of database processes only for single cluster deployments


### PR DESCRIPTION
**Changes**
Sometimes in Azure, it takes 3 to 5 min for the volumes to be provisioned and mounted to the Kubernetes nodes. Bump up the ready and schedule timeouts for multi-cluster tests.

**Testing**
- 15+ [runs](https://app.circleci.com/pipelines/github/nuodb/nuodb-helm-charts/743/workflows/cccf0493-8243-46f5-bf3e-7852f5d5f9f0/jobs/3134) of the `TestKubernetesBasicMultiCluster ` test