### PR TITLE
Fix TE preference query annotation key

### DIFF
--- a/stable/database/templates/_helpers.tpl
+++ b/stable/database/templates/_helpers.tpl
@@ -260,7 +260,7 @@ The configuration is imported only in the entrypoint cluster.
         {{- if (eq (default "cluster0" .Values.cloud.cluster.name) (default "cluster0" .Values.cloud.cluster.entrypointName)) }}
 "nuodb.com/automatic-database-protocol-upgrade": "true"
           {{- with .Values.database.automaticProtocolUpgrade.tePreferenceQuery }}
-"nuodb.com/automatic-database-protocol-upgrade.te-preference-policy": {{ . | quote }}
+"nuodb.com/automatic-database-protocol-upgrade.te-preference-query": {{ . | quote }}
           {{- end -}}
         {{- end -}}
       {{- end -}}

--- a/test/integration/process_marshall_test.go
+++ b/test/integration/process_marshall_test.go
@@ -2,6 +2,7 @@ package integration
 
 import (
 	"encoding/json"
+
 	"github.com/nuodb/nuodb-helm-charts/v3/test/testlib"
 	"github.com/stretchr/testify/assert"
 
@@ -9,8 +10,7 @@ import (
 )
 
 func TestUnmarshall(t *testing.T) {
-	s := (
-		`{
+	s := (`{
   "address": "172.17.0.6", 
   "dbName": "demo", 
   "durableState": "MONITORED", 
@@ -64,6 +64,7 @@ func TestUnmarshall(t *testing.T) {
 	assert.True(t, obj.Hostname == "te-database-rggfj1-nuodb-demo-57f984dcd5-s7nhr")
 	assert.True(t, obj.Host == "admin-kljkzo-nuodb-0")
 	assert.True(t, obj.DbName == "demo")
+	assert.True(t, obj.StartId == "1")
 
 	_, ok := obj.Labels["cloud"]
 	assert.True(t, ok)
@@ -79,8 +80,7 @@ func TestUnmarshall(t *testing.T) {
 }
 
 func TestUnmarshallMany(t *testing.T) {
-	s := (
-		`{
+	s := (`{
   "address": "172.17.0.7", 
   "archiveDir": "/var/opt/nuodb/archive/nuodb/demo", 
   "archiveId": 0, 
@@ -136,18 +136,19 @@ func TestUnmarshallMany(t *testing.T) {
 
 func TestMarshall(t *testing.T) {
 
-	labels := map[string]string {
-		"cloud": "minikube",
+	labels := map[string]string{
+		"cloud":  "minikube",
 		"region": "local",
-		"zone": "local-b",
+		"zone":   "local-b",
 	}
 
-	obj := testlib.NuoDBProcess {
-		Address: "172.17.0.6",
-		DbName: "demo",
-		Host: "admin-kljkzo-nuodb-0",
+	obj := testlib.NuoDBProcess{
+		Address:  "172.17.0.6",
+		DbName:   "demo",
+		Host:     "admin-kljkzo-nuodb-0",
 		Hostname: "te-database-rggfj1-nuodb-demo-57f984dcd5-s7nhr",
-		Labels: labels,
+		Labels:   labels,
+		StartId:  "0",
 	}
 	b, err := json.Marshal(&obj)
 

--- a/test/integration/template_database_test.go
+++ b/test/integration/template_database_test.go
@@ -600,7 +600,7 @@ func TestAutomaticDatabaseProtocolUpgrade(t *testing.T) {
 			assert.Equal(t, "true", obj.Annotations["nuodb.com/automatic-database-protocol-upgrade"])
 			assert.Equal(t,
 				options.SetValues["database.automaticProtocolUpgrade.tePreferenceQuery"],
-				obj.Annotations["nuodb.com/automatic-database-protocol-upgrade.te-preference-policy"])
+				obj.Annotations["nuodb.com/automatic-database-protocol-upgrade.te-preference-query"])
 		}
 	})
 }

--- a/test/testlib/NuoDBProcess.go
+++ b/test/testlib/NuoDBProcess.go
@@ -16,6 +16,7 @@ type NuoDBProcess struct {
 	IpAddress string            `json:"ipAddress"`
 	Options   map[string]string `json:"options"`
 	NodeId    int32             `json:"nodeId"`
+	StartId   int32             `json:"startId"`
 }
 
 func Unmarshal(s string) (err error, processes []NuoDBProcess) {

--- a/test/testlib/NuoDBProcess.go
+++ b/test/testlib/NuoDBProcess.go
@@ -16,7 +16,7 @@ type NuoDBProcess struct {
 	IpAddress string            `json:"ipAddress"`
 	Options   map[string]string `json:"options"`
 	NodeId    int32             `json:"nodeId"`
-	StartId   int32             `json:"startId"`
+	StartId   string            `json:"startId"`
 }
 
 func Unmarshal(s string) (err error, processes []NuoDBProcess) {


### PR DESCRIPTION
**Issue**

Previously setting `database.automaticProtocolUpgrade.tePreferenceQuery` option had no effect.

**Changes**

Fixed the TE preference query annotation key to be the one expected by the admin.

**Testing**

- modified the rolling upgrade test to use the option
- regression testing