### PR TITLE
Avoid recursive chmod if all directories already have 770

### DIFF
--- a/stable/admin/templates/statefulset.yaml
+++ b/stable/admin/templates/statefulset.yaml
@@ -61,7 +61,9 @@ spec:
       - name: init-disk
         image: {{ template "init.image" . }}
         imagePullPolicy: {{ default "" .Values.busybox.image.pullPolicy }}
-        command: ['chmod', '-R', '770', '/var/opt/nuodb', '/var/log/nuodb']
+        command: ['sh', '-c', '
+          find /var/opt/nuodb -not -perm 770 -maxdepth 1 -exec chmod -R 770 {} \; &&
+          find /var/log/nuodb -not -perm 770 -maxdepth 1 -exec chmod -R 770 {} \;']
         volumeMounts:
         - name: raftlog
           mountPath: /var/opt/nuodb

--- a/stable/database/templates/statefulset.yaml
+++ b/stable/database/templates/statefulset.yaml
@@ -437,16 +437,9 @@ spec:
       - name: init-disk
         image: {{ template "init.image" . }}
         imagePullPolicy: {{ default "" .Values.busybox.image.pullPolicy | quote }}
-        command:
-          - 'chmod'
-          - '-R'
-          - '770'
-          - '/var/opt/nuodb/archive'
-          - '/var/opt/nuodb/backup'
-          - '/var/log/nuodb'
-{{- if eq (include "defaultfalse" .Values.database.sm.hotCopy.journalPath.enabled) "true"}}
-          - '/var/opt/nuodb/journal'
-{{- end }}
+        command: ['sh', '-c', '
+          find /var/opt/nuodb -not -perm 770 -maxdepth 2 -exec chmod -R 770 {} \; &&
+          find /var/log/nuodb -not -perm 770 -maxdepth 1 -exec chmod -R 770 {} \;']
         volumeMounts:
         - name: archive-volume
           mountPath: /var/opt/nuodb/archive

--- a/stable/database/templates/statefulset.yaml
+++ b/stable/database/templates/statefulset.yaml
@@ -68,15 +68,9 @@ spec:
       - name: init-disk
         image: {{ template "init.image" . }}
         imagePullPolicy: {{ default "" .Values.busybox.image.pullPolicy | quote }}
-        command:
-          - 'chmod'
-          - '-R'
-          - '770'
-          - '/var/opt/nuodb/archive'
-          - '/var/log/nuodb'
-  {{- if eq (include "defaultfalse" .Values.database.sm.noHotCopy.journalPath.enabled) "true"}}
-          - '/var/opt/nuodb/journal'
-  {{- end }}
+        command: ['sh', '-c', '
+          find /var/opt/nuodb -not -perm 770 -maxdepth 2 -exec chmod -R 770 {} \; &&
+          find /var/log/nuodb -not -perm 770 -maxdepth 1 -exec chmod -R 770 {} \;']
         volumeMounts:
         - name: archive-volume
           mountPath: /var/opt/nuodb/archive

--- a/test/integration/template_database_test.go
+++ b/test/integration/template_database_test.go
@@ -708,9 +708,6 @@ func TestDatabaseSeparateJournal(t *testing.T) {
 			assert.True(t, ok, "mount journal-volume not found")
 			assert.EqualValues(t, "/var/opt/nuodb/journal", mount.MountPath)
 
-			initContainer := obj.Spec.Template.Spec.InitContainers[0]
-			assert.Contains(t, initContainer.Command, "/var/opt/nuodb/journal")
-
 			claim, ok := testlib.GetVolumeClaim(obj.Spec.VolumeClaimTemplates, "journal-volume")
 			assert.True(t, ok, "volume journal-volume not found")
 			assert.Equal(t, v1.ReadWriteOnce, claim.Spec.AccessModes[0])
@@ -742,9 +739,6 @@ func TestDatabaseSeparateJournal(t *testing.T) {
 			assert.True(t, ok, "mount journal-volume not found")
 			assert.EqualValues(t, "/var/opt/nuodb/journal", mount.MountPath)
 
-			initContainer := obj.Spec.Template.Spec.InitContainers[0]
-			assert.Contains(t, initContainer.Command, "/var/opt/nuodb/journal")
-
 			claim, ok := testlib.GetVolumeClaim(obj.Spec.VolumeClaimTemplates, "journal-volume")
 			assert.True(t, ok, "volume journal-volume not found")
 			assert.Equal(t, v1.ReadWriteMany, claim.Spec.AccessModes[0])
@@ -769,9 +763,6 @@ func TestDatabaseSeparateJournal(t *testing.T) {
 
 			_, ok := testlib.GetMount(container.VolumeMounts, "journal-volume")
 			assert.False(t, ok, "mount journal-volume not found")
-
-			initContainer := obj.Spec.Template.Spec.InitContainers[0]
-			assert.NotContains(t, initContainer.Command, "/var/opt/nuodb/journal")
 
 			_, ok = testlib.GetVolumeClaim(obj.Spec.VolumeClaimTemplates, "journal-volume")
 			assert.False(t, ok, "volume journal-volume not found")


### PR DESCRIPTION
Avoid performing recursive on `/var/opt/nuodb` and `/var/log/nuodb` if all files and subdirectories one level deep already have mode 770. For SMs, descend two levels to ensure that all files `/var/opt/nuodb/archive` and `/var/opt/nuodb/journal` have mode 770 (this is to account for the fact that previously we did not perform recursive chmod at all, so it is possible for those directories to contain files that are not writeable by the nuodb user).