### PR TITLE
Allow Pod security context to be specified

### DIFF
--- a/stable/admin/README.md
+++ b/stable/admin/README.md
@@ -170,8 +170,15 @@ The following tables list the configurable parameters for the `admin` option of 
 | `logPersistence.size` | Amount of disk space allocated for log storage | `60Gi` |
 | `logPersistence.storageClass` | Storage class for volume backing log storage | `-` |
 | `envFrom` | Import ENV vars from one or more configMaps | `[]` |
-| `options` | Set optons to be passed to nuoadmin as arguments | `{}` |
-| `securityContext.capabilities` | add capabilities to the container | `[]` |
+| `options` | Set options to be passed to nuoadmin as arguments | `{}` |
+| `initContainers.runInitDisk` | Whether to run the `init-disk` init container to set volume permissions | `true` |
+| `initContainers.runInitDiskAsRoot` | Whether to run the `init-disk` init container as root | `true` |
+| `securityContext.fsGroupOnly` | Creates a security context for Pods containing only the `securityContext.fsGroup` value | `false` |
+| `securityContext.runAsNonRootGroup` | Creates a security context for Pods containing a non-root user and group (1000:1000) along with the `securityContext.fsGroup` value | `false` |
+| `securityContext.enabled` | Creates a security context for Pods containing the `securityContext.runAsUser` and `securityContext.fsGroup` values | `false` |
+| `securityContext.runAsUser` | The user ID for the Pod security context created if `securityContext.enabled` is `true`. | `1000` |
+| `securityContext.fsGroup` | The `fsGroup` for the Pod security context created if any of `securityContext.fsGroupOnly`, `securityContext.runAsNonRootGroup`, or `securityContext.enabled` are `true`. | `1000` |
+| `securityContext.capabilities` | Capabilities to add to admin container security context | `[]` |
 | `tlsCACert.secret` | TLS CA certificate secret name | `nil` |
 | `tlsCACert.key` | TLS CA certificate secret key | `nil` |
 | `tlsKeyStore.secret` | TLS keystore secret name | `nil` |

--- a/stable/admin/templates/job.yaml
+++ b/stable/admin/templates/job.yaml
@@ -23,6 +23,7 @@ spec:
       name: job-lb-policy-{{ .Values.admin.lbPolicy | lower }}
     spec:
       serviceAccountName: {{ default "nuodb" .Values.nuodb.serviceAccount }}
+      {{- include "securityContext" . | indent 6 }}
       {{- with .Values.admin.nodeSelector }}
       nodeSelector:
 {{ toYaml . | trim | indent 8 }}

--- a/stable/admin/templates/statefulset.yaml
+++ b/stable/admin/templates/statefulset.yaml
@@ -44,6 +44,7 @@ spec:
         group: nuodb
     spec:
       serviceAccountName: {{ default "nuodb" .Values.nuodb.serviceAccount }}
+      {{- include "securityContext" . | indent 6 }}
       {{- with .Values.admin.nodeSelector }}
       nodeSelector:
 {{ toYaml . | trim | indent 8 }}
@@ -57,18 +58,26 @@ spec:
 {{ toYaml .Values.admin.tolerations | trim | indent 8 }}
       {{- end }}
       terminationGracePeriodSeconds: 15
+      {{- if eq (include "defaulttrue" .Values.admin.initContainers.runInitDisk) "true" }}
       initContainers:
       - name: init-disk
         image: {{ template "init.image" . }}
         imagePullPolicy: {{ default "" .Values.busybox.image.pullPolicy }}
-        command: ['sh', '-c', '
-          find /var/opt/nuodb -not -perm 770 -maxdepth 1 -exec chmod -R 770 {} \; &&
-          find /var/log/nuodb -not -perm 770 -maxdepth 1 -exec chmod -R 770 {} \;']
+        command:
+          - sh
+          - -c
+          - find /mnt/* -maxdepth 1 -not \( -perm -0770 -user 1000 \) -exec chmod -R ug+rwx {} \; -exec chown -R 1000 {} \; -exec echo {} \;
         volumeMounts:
         - name: raftlog
-          mountPath: /var/opt/nuodb
+          mountPath: /mnt/vardir
         - name: log-volume
-          mountPath: /var/log/nuodb
+          mountPath: /mnt/logdir
+        {{- if eq (include "defaulttrue" .Values.admin.initContainers.runInitDiskAsRoot) "true" }}
+        securityContext:
+          runAsUser: 0
+          runAsGroup: 0
+        {{- end }}
+      {{- end }}
       containers:
       - name: admin
         image: {{ template "nuodb.image" . }}

--- a/stable/admin/values.yaml
+++ b/stable/admin/values.yaml
@@ -143,11 +143,50 @@ admin:
       - ReadWriteOnce
     # storageClass: "-"
 
-  ## Use a securityContext to specify additional capabilities
-  # For example, if the container needs to configure network setting, then add "NET_ADMIN"
-  # Ex: capabilities: [ "NET_ADMIN" ]
-  ##
+  initContainers:
+    # Whether to run init-disk init container to change permissions of mounted
+    # volumes. This should not be necessary if fsGroup is being specified in
+    # the security context, unless the volumes have a storage class that does
+    # not support fsGroup, such as hostpath.
+    runInitDisk: true
+
+    # Whether to run init-disk as root. If set to false, the user defined by
+    # the Pod security context will be used if one is defined, otherwise the
+    # default user for the init-disk container image (busybox) will be used.
+    runInitDiskAsRoot: true
+
   securityContext:
+    # Whether to create a security context for Pods containing only the fsGroup
+    # value defined below. This is less restrictive than runAsNonRootGroup,
+    # because it allows all containers in the Pod, including init and sidecar
+    # containers to run using the default user (assuming that the containers
+    # does not explicitly specify runAsUser and runAsGroup in their own
+    # security contexts).
+    fsGroupOnly: false
+
+    # Whether to create a security context for Pods restricting the uid and gid
+    # of the runtime "nuodb" user to 1000:1000, which is supported starting
+    # with NuoDB image version 4.3.
+    #
+    # runAsNonRootGroup must be set to false with NuoDB image versions older
+    # than 4.3.
+    runAsNonRootGroup: false
+
+    # Whether to create a security context for Pods containing the runAsUser
+    # and fsGroup values defined below.
+    enabled: false
+
+    # runAsUser must be an integer between 1000 and 65533.
+    runAsUser: 1000
+
+    # Defining fsGroup in a security context causes volumes mounted into the
+    # containers (including those defined by secrets and config maps) to be
+    # owned by the specified group ID, which is also added as a supplementary
+    # group to the runtime user. This allows a non-root user and group to read,
+    # write, and execute files with permissions 440, 660, and 770.
+    fsGroup: 1000
+
+    # Specify additional container capabilities such as "NET_ADMIN"
     capabilities: []
 
   ## Specify one or more configMaps to import Environment Variables from

--- a/stable/database/README.md
+++ b/stable/database/README.md
@@ -189,10 +189,14 @@ The following tables list the configurable parameters of the `database` chart an
 | `name` | Database name | `demo` |
 | `rootUser` | Database root user | `dba` |
 | `rootPassword` | Database root password | `secret` |
-| `securityContext.enabled` | Enable security context | `false` |
-| `securityContext.runAsUser` | User ID for the container | `1000` |
-| `securityContext.fsGroup` | Group ID for the container | `1000` |
-| `securityContext.capabilities` | Enable capabilities for the container - disregards `securityContext.enabled` | `[]` |
+| `initContainers.runInitDisk` | Whether to run the `init-disk` init container to set volume permissions | `true` |
+| `initContainers.runInitDiskAsRoot` | Whether to run the `init-disk` init container as root | `true` |
+| `securityContext.fsGroupOnly` | Creates a security context for Pods containing only the `securityContext.fsGroup` value | `false` |
+| `securityContext.runAsNonRootGroup` | Creates a security context for Pods containing a non-root user and group (1000:1000) along with the `securityContext.fsGroup` value | `false` |
+| `securityContext.enabled` | Creates a security context for Pods containing the `securityContext.runAsUser` and `securityContext.fsGroup` values | `false` |
+| `securityContext.runAsUser` | The user ID for the Pod security context created if `securityContext.enabled` is `true`. | `1000` |
+| `securityContext.fsGroup` | The `fsGroup` for the Pod security context created if any of `securityContext.fsGroupOnly`, `securityContext.runAsNonRootGroup`, or `securityContext.enabled` are `true`. | `1000` |
+| `securityContext.capabilities` | Capabilities to add to engine container security context | `[]` |
 | `env` | Import ENV vars inside containers | `[]` |
 | `envFrom` | Import ENV vars from configMap(s) | `[]` |
 | `lbConfig.prefilter` | Database load balancer prefilter expression | `nil` |

--- a/stable/database/files/nuosm
+++ b/stable/database/files/nuosm
@@ -265,7 +265,7 @@ function perform_restore() {
       return $retval
     fi
 
-    chown -R $(echo "${NUODB_OS_USER:-1000}:${NUODB_OS_GROUP:-0}" | tr -d '"') $download_dir
+    chown -R "$(id -u):$(id -g)" "$download_dir"
 
     # restore data and/or fix the metadata
     log "restoring archive and/or clearing restored archive physical metadata"
@@ -285,7 +285,7 @@ function perform_restore() {
       # consumed during SM shutdown
       log "Moving restored journal content to $JOURNAL_DIR"
       mv "$download_dir/journal/"* "$JOURNAL_DIR"
-      chown -R "$(echo "${NUODB_OS_USER:-1000}:${NUODB_OS_GROUP:-0}" | tr -d '"')" "$JOURNAL_DIR"
+      chown -R "$(id -u):$(id -g)" "$JOURNAL_DIR"
     fi
 
     if [ "$download_dir" != "$DB_DIR" ]; then

--- a/stable/database/templates/configmap.yaml
+++ b/stable/database/templates/configmap.yaml
@@ -84,8 +84,6 @@ data:
   {{- if .Values.admin.tde }}
   NUODB_STORAGE_PASSWORDS_DIR: {{ default "/etc/nuodb/tde" .Values.admin.tde.storagePasswordsDir | quote }}
   {{- end }}
-  NUODB_OS_USER: {{ include "os.user" . | quote }}
-  NUODB_OS_GROUP: {{ include "os.group" . | quote }}
 {{- end }}
 {{- if .Values.database.configFiles }}
 ---

--- a/stable/database/templates/cronjob.yaml
+++ b/stable/database/templates/cronjob.yaml
@@ -19,6 +19,7 @@ spec:
     spec:
       template:
         spec:
+          {{- include "securityContext" . | indent 10 }}
           containers:
           - name: nuodb
             image: {{ template "nuodb.image" . }}
@@ -107,6 +108,7 @@ spec:
     spec:
       template:
         spec:
+          {{- include "securityContext" . | indent 10 }}
           containers:
           - name: nuodb
             image: {{ template "nuodb.image" . }}
@@ -193,6 +195,7 @@ spec:
     spec:
       template:
         spec:
+          {{- include "securityContext" . | indent 10 }}
           containers:
           - name: nuodb
             image: {{ template "nuodb.image" . }}

--- a/stable/database/templates/deployment.yaml
+++ b/stable/database/templates/deployment.yaml
@@ -43,6 +43,7 @@ spec:
         release: {{ .Release.Name | quote }}
     spec:
       serviceAccountName: {{ default "nuodb" .Values.nuodb.serviceAccount }}
+      {{- include "securityContext" . | indent 6 }}
       {{- with .Values.database.te.nodeSelector }}
       nodeSelector:
 {{ toYaml . | trim | indent 8 }}
@@ -54,6 +55,24 @@ spec:
       {{- if .Values.database.te.tolerations }}
       tolerations:
 {{ toYaml .Values.database.te.tolerations | trim | indent 8 }}
+      {{- end }}
+      {{- if eq (include "defaulttrue" .Values.database.initContainers.runInitDisk) "true" }}
+      initContainers:
+      - name: init-disk
+        image: {{ template "init.image" . }}
+        imagePullPolicy: {{ default "" .Values.busybox.image.pullPolicy }}
+        command:
+          - sh
+          - -c
+          - find /mnt/* -maxdepth 1 -not \( -perm -0770 -user 1000 \) -exec chmod -R ug+rwx {} \; -exec chown -R 1000 {} \; -exec echo {} \;
+        volumeMounts:
+        - name: log-volume
+          mountPath: /mnt/logdir
+        {{- if eq (include "defaulttrue" .Values.database.initContainers.runInitDiskAsRoot) "true" }}
+        securityContext:
+          runAsUser: 0
+          runAsGroup: 0
+        {{- end }}
       {{- end }}
       containers:
       - name: engine
@@ -195,5 +214,4 @@ spec:
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler
-      securityContext: {}
       terminationGracePeriodSeconds: 15

--- a/stable/database/templates/statefulset.yaml
+++ b/stable/database/templates/statefulset.yaml
@@ -47,11 +47,7 @@ spec:
     spec:
       serviceAccountName: {{ default "nuodb" .Values.nuodb.serviceAccount }}
       terminationGracePeriodSeconds: 15
-      {{- if eq (include "defaultfalse" .Values.database.securityContext.enabled) "true" }}
-      securityContext:
-        fsGroup: {{ .Values.database.securityContext.fsGroup }}
-        runAsUser: {{ .Values.database.securityContext.runAsUser }}
-      {{- end }}
+      {{- include "securityContext" . | indent 6 }}
       {{- with .Values.database.sm.nodeSelector }}
       nodeSelector:
 {{ toYaml . | trim | indent 8 }}
@@ -64,28 +60,36 @@ spec:
       tolerations:
 {{ toYaml .Values.database.sm.tolerations | trim | indent 8 }}
       {{- end }}
+      {{- if eq (include "defaulttrue" .Values.database.initContainers.runInitDisk) "true" }}
       initContainers:
       - name: init-disk
         image: {{ template "init.image" . }}
         imagePullPolicy: {{ default "" .Values.busybox.image.pullPolicy | quote }}
-        command: ['sh', '-c', '
-          find /var/opt/nuodb -not -perm 770 -maxdepth 2 -exec chmod -R 770 {} \; &&
-          find /var/log/nuodb -not -perm 770 -maxdepth 1 -exec chmod -R 770 {} \;']
+        command:
+          - sh
+          - -c
+          - find /mnt/* -maxdepth 1 -not \( -perm -0770 -user 1000 \) -exec chmod -R ug+rwx {} \; -exec chown -R 1000 {} \; -exec echo {} \;
         volumeMounts:
         - name: archive-volume
-          mountPath: /var/opt/nuodb/archive
+          mountPath: /mnt/archive
         {{- if eq (include "defaultfalse" .Values.database.sm.noHotCopy.journalPath.enabled) "true"}}
         - name: journal-volume
-          mountPath: /var/opt/nuodb/journal
+          mountPath: /mnt/journal
         {{- end }}
         - name: log-volume
-          mountPath: /var/log/nuodb
+          mountPath: /mnt/logdir
+        {{- if eq (include "defaulttrue" .Values.database.initContainers.runInitDiskAsRoot) "true" }}
+        securityContext:
+          runAsUser: 0
+          runAsGroup: 0
+        {{- end }}
+      {{- end }}
       containers:
       - name: engine
         image: {{ template "nuodb.image" . }}
         imagePullPolicy: {{ .Values.nuodb.image.pullPolicy }}
     {{- include "database.capabilities" . | indent 8 }}
-        args: 
+        args:
           - "nuosm"
           - "--servers-ready-timeout"
           - "300"
@@ -94,7 +98,7 @@ spec:
     {{- end }}
           - "--options"
           - "mem {{ .Values.database.sm.resources.requests.memory}} {{ include "opt.key-values" .Values.database.sm.engineOptions }}"
-    {{- with .Values.database.sm.labels }}      
+    {{- with .Values.database.sm.labels }}
           - "--labels"
           - "{{- include "opt.key-values" . }}"
     {{- end }}
@@ -416,11 +420,7 @@ spec:
     spec:
       serviceAccountName: {{ default "nuodb" .Values.nuodb.serviceAccount }}
       terminationGracePeriodSeconds: 15
-      {{- if eq (include "defaultfalse" .Values.database.securityContext.enabled) "true" }}
-      securityContext:
-        fsGroup: {{ .Values.database.securityContext.fsGroup }}
-        runAsUser: {{ .Values.database.securityContext.runAsUser }}
-      {{- end }}
+      {{- include "securityContext" . | indent 6 }}
       {{- with .Values.database.sm.nodeSelector }}
       nodeSelector:
 {{ toYaml . | trim | indent 8 }}
@@ -433,24 +433,30 @@ spec:
       tolerations:
 {{ toYaml .Values.database.sm.tolerations | trim | indent 8 }}
       {{- end }}
+      {{- if eq (include "defaulttrue" .Values.database.initContainers.runInitDisk) "true" }}
       initContainers:
       - name: init-disk
         image: {{ template "init.image" . }}
         imagePullPolicy: {{ default "" .Values.busybox.image.pullPolicy | quote }}
-        command: ['sh', '-c', '
-          find /var/opt/nuodb -not -perm 770 -maxdepth 2 -exec chmod -R 770 {} \; &&
-          find /var/log/nuodb -not -perm 770 -maxdepth 1 -exec chmod -R 770 {} \;']
+        command:
+          - sh
+          - -c
+          - find /mnt/* -maxdepth 1 -not \( -perm -0770 -user 1000 \) -exec chmod -R ug+rwx {} \; -exec chown -R 1000 {} \; -exec echo {} \;
         volumeMounts:
         - name: archive-volume
-          mountPath: /var/opt/nuodb/archive
+          mountPath: /mnt/archive
         {{- if eq (include "defaultfalse" .Values.database.sm.hotCopy.journalPath.enabled) "true"}}
         - name: journal-volume
-          mountPath: /var/opt/nuodb/journal
+          mountPath: /mnt/journal
         {{- end }}
-        - name: backup-volume
-          mountPath: /var/opt/nuodb/backup
         - name: log-volume
-          mountPath: /var/log/nuodb
+          mountPath: /mnt/logdir
+        {{- if eq (include "defaulttrue" .Values.database.initContainers.runInitDiskAsRoot) "true" }}
+        securityContext:
+          runAsUser: 0
+          runAsGroup: 0
+        {{- end }}
+      {{- end }}
       containers:
       - name: engine
         image: {{ template "nuodb.image" . }}

--- a/stable/database/values.yaml
+++ b/stable/database/values.yaml
@@ -138,13 +138,51 @@ database:
   # Database password
   rootPassword: secret
 
-  # Typically set to runAsUser and/or fsGroup to 0 or 1000.
-  # Add container capabilities such as NET_ADMIN. Ex: capabilities: [ "NET_ADMIN" ]
+  initContainers:
+    # Whether to run init-disk init container to change permissions of mounted
+    # volumes. This should not be necessary if fsGroup is being specified in
+    # the security context, unless the volumes have a storage class that does
+    # not support fsGroup, such as hostpath.
+    runInitDisk: true
+
+    # Whether to run init-disk as root. If set to false, the user defined by
+    # the Pod security context will be used if one is defined, otherwise the
+    # default user for the init-disk container image (busybox) will be used.
+    runInitDiskAsRoot: true
+
   securityContext:
-    capabilities: []
+    # Whether to create a security context for Pods containing only the fsGroup
+    # value defined below. This is less restrictive than runAsNonRootGroup,
+    # because it allows all containers in the Pod, including init and sidecar
+    # containers to run using the default user (assuming that the containers
+    # does not explicitly specify runAsUser and runAsGroup in their own
+    # security contexts).
+    fsGroupOnly: false
+
+    # Whether to create a security context for Pods restricting the uid and gid
+    # of the runtime "nuodb" user to 1000:1000, which is supported starting
+    # with NuoDB image version 4.3.
+    #
+    # runAsNonRootGroup must be set to false with NuoDB image versions older
+    # than 4.3.
+    runAsNonRootGroup: false
+
+    # Whether to create a security context for Pods containing the runAsUser
+    # and fsGroup values defined below.
     enabled: false
+
+    # runAsUser must be an integer between 1000 and 65533.
     runAsUser: 1000
-    fsGroup: 0
+
+    # Defining fsGroup in a security context causes volumes mounted into the
+    # containers (including those defined by secrets and config maps) to be
+    # owned by the specified group ID, which is also added as a supplementary
+    # group to the runtime user. This allows a non-root user and group to read,
+    # write, and execute files with permissions 440, 660, and 770.
+    fsGroup: 1000
+
+    # Specify additional container capabilities such as "NET_ADMIN"
+    capabilities: []
 
   ## Import Environment Variables inside containers
   # List of EnvVar v1 core definitions

--- a/stable/restore/README.md
+++ b/stable/restore/README.md
@@ -106,6 +106,11 @@ The following tables list the configurable parameters of the database chart and 
 | Parameter | Description | Default |
 | ----- | ----------- | ------ |
 | `name` | Database name | `demo` |
+| `securityContext.fsGroupOnly` | Creates a security context for Pods containing only the `securityContext.fsGroup` value | `false` |
+| `securityContext.runAsNonRootGroup` | Creates a security context for Pods containing a non-root user and group (1000:1000) along with the `securityContext.fsGroup` value | `false` |
+| `securityContext.enabled` | Creates a security context for Pods containing the `securityContext.runAsUser` and `securityContext.fsGroup` values | `false` |
+| `securityContext.runAsUser` | The user ID for the Pod security context created if `securityContext.enabled` is `true`. | `1000` |
+| `securityContext.fsGroup` | The `fsGroup` for the Pod security context created if any of `securityContext.fsGroupOnly`, `securityContext.runAsNonRootGroup`, or `securityContext.enabled` are `true`. | `1000` |
 
 #### nuodb.*
 

--- a/stable/restore/templates/job.yaml
+++ b/stable/restore/templates/job.yaml
@@ -13,6 +13,7 @@ spec:
   activeDeadlineSeconds: {{ .Values.restore.timeout }}
   template:
     spec:
+      {{- include "securityContext" . | indent 6 }}
 {{- if .Values.restore.affinity }}
       affinity:
 {{ tpl .Values.restore.affinity . | trim | indent 8 }}

--- a/stable/restore/values.yaml
+++ b/stable/restore/values.yaml
@@ -62,6 +62,38 @@ admin:
   #   secret: nuodb-client-pem
   #   key: client.pem
 
+database:
+  securityContext:
+    # Whether to create a security context for Pods containing only the fsGroup
+    # value defined below. This is less restrictive than runAsNonRootGroup,
+    # because it allows all containers in the Pod, including init and sidecar
+    # containers to run using the default user (assuming that the containers
+    # does not explicitly specify runAsUser and runAsGroup in their own
+    # security contexts).
+    fsGroupOnly: false
+
+    # Whether to create a security context for Pods restricting the uid and gid
+    # of the runtime "nuodb" user to 1000:1000, which is supported starting
+    # with NuoDB image version 4.3.
+    #
+    # runAsNonRootGroup must be set to false with NuoDB image versions older
+    # than 4.3.
+    runAsNonRootGroup: false
+
+    # Whether to create a security context for Pods containing the runAsUser
+    # and fsGroup values defined below.
+    enabled: false
+
+    # runAsUser must be an integer between 1000 and 65533.
+    runAsUser: 1000
+
+    # Defining fsGroup in a security context causes volumes mounted into the
+    # containers (including those defined by secrets and config maps) to be
+    # owned by the specified group ID, which is also added as a supplementary
+    # group to the runtime user. This allows a non-root user and group to read,
+    # write, and execute files with permissions 440, 660, and 770.
+    fsGroup: 1000
+
 restore:
 
   ## Provide a name in place of the chart name for `app:` labels

--- a/test/integration/template_database_test.go
+++ b/test/integration/template_database_test.go
@@ -770,3 +770,301 @@ func TestDatabaseSeparateJournal(t *testing.T) {
 	})
 
 }
+
+func TestDatabaseSecurityContext(t *testing.T) {
+	// Path to the helm chart we will test
+	helmChartPath := "../../stable/database"
+
+	t.Run("testDefault", func(t *testing.T) {
+		options := &helm.Options{
+			SetValues: map[string]string{
+				"database.sm.hotCopy.journalPath.enabled": "true",
+				"database.sm.noHotCopy.journalPath.enabled": "true",
+			},
+		}
+
+		// check security context on SM StatefulSets
+		output := helm.RenderTemplate(t, options, helmChartPath, "release-name", []string{"templates/statefulset.yaml"})
+		for _, obj := range testlib.SplitAndRenderStatefulSet(t, output, 2) {
+			securityContext := obj.Spec.Template.Spec.SecurityContext
+			assert.Nil(t, securityContext)
+		}
+
+		// check security context on TE Deployment
+		output = helm.RenderTemplate(t, options, helmChartPath, "release-name", []string{"templates/deployment.yaml"})
+		for _, dep:= range testlib.SplitAndRenderDeployment(t, output, 1) {
+			securityContext := dep.Spec.Template.Spec.SecurityContext
+			assert.Nil(t, securityContext)
+		}
+	})
+
+	t.Run("testEnabled", func(t *testing.T) {
+		options := &helm.Options{
+			SetValues: map[string]string{
+				"database.sm.hotCopy.journalPath.enabled": "true",
+				"database.sm.noHotCopy.journalPath.enabled": "true",
+				"database.securityContext.enabled": "true",
+			},
+		}
+
+		// check security context on SM StatefulSets
+		output := helm.RenderTemplate(t, options, helmChartPath, "release-name", []string{"templates/statefulset.yaml"})
+		for _, obj := range testlib.SplitAndRenderStatefulSet(t, output, 2) {
+			securityContext := obj.Spec.Template.Spec.SecurityContext
+			assert.NotNil(t, securityContext)
+			assert.Equal(t, int64(1000), *securityContext.RunAsUser)
+			assert.Equal(t, int64(0), *securityContext.RunAsGroup)
+			assert.Equal(t, int64(1000), *securityContext.FSGroup)
+		}
+
+		// check security context on TE Deployment
+		output = helm.RenderTemplate(t, options, helmChartPath, "release-name", []string{"templates/deployment.yaml"})
+		for _, dep := range testlib.SplitAndRenderDeployment(t, output, 1) {
+			securityContext := dep.Spec.Template.Spec.SecurityContext
+			assert.NotNil(t, securityContext)
+			assert.Equal(t, int64(1000), *securityContext.RunAsUser)
+			assert.Equal(t, int64(0), *securityContext.RunAsGroup)
+			assert.Equal(t, int64(1000), *securityContext.FSGroup)
+		}
+	})
+
+	t.Run("testRunAsNonRootGroup", func(t *testing.T) {
+		options := &helm.Options{
+			SetValues: map[string]string{
+				"database.sm.hotCopy.journalPath.enabled": "true",
+				"database.sm.noHotCopy.journalPath.enabled": "true",
+				"database.securityContext.runAsNonRootGroup": "true",
+				"database.securityContext.runAsUser": "5555",
+				"database.securityContext.fsGroup": "1234",
+			},
+		}
+
+		// check security context on SM StatefulSets
+		output := helm.RenderTemplate(t, options, helmChartPath, "release-name", []string{"templates/statefulset.yaml"})
+		for _, obj := range testlib.SplitAndRenderStatefulSet(t, output, 2) {
+			securityContext := obj.Spec.Template.Spec.SecurityContext
+			assert.NotNil(t, securityContext)
+			// runAsUser should be disregarded, since we can only use 1000:1000 or <uid>:0
+			assert.Equal(t, int64(1000), *securityContext.RunAsUser)
+			assert.Equal(t, int64(1000), *securityContext.RunAsGroup)
+			assert.Equal(t, int64(1234), *securityContext.FSGroup)
+		}
+
+		// check security context on TE Deployment
+		output = helm.RenderTemplate(t, options, helmChartPath, "release-name", []string{"templates/deployment.yaml"})
+		for _, dep := range testlib.SplitAndRenderDeployment(t, output, 1) {
+			securityContext := dep.Spec.Template.Spec.SecurityContext
+			assert.NotNil(t, securityContext)
+			// runAsUser should be disregarded, since we can only use 1000:1000 or <uid>:0
+			assert.Equal(t, int64(1000), *securityContext.RunAsUser)
+			assert.Equal(t, int64(1000), *securityContext.RunAsGroup)
+			assert.Equal(t, int64(1234), *securityContext.FSGroup)
+		}
+	})
+
+	t.Run("testFsGroupOnly", func(t *testing.T) {
+		options := &helm.Options{
+			SetValues: map[string]string{
+				"database.sm.hotCopy.journalPath.enabled": "true",
+				"database.sm.noHotCopy.journalPath.enabled": "true",
+				"database.securityContext.fsGroupOnly": "true",
+				"database.securityContext.fsGroup": "1234",
+			},
+		}
+
+		// check security context on SM StatefulSets
+		output := helm.RenderTemplate(t, options, helmChartPath, "release-name", []string{"templates/statefulset.yaml"})
+		for _, obj := range testlib.SplitAndRenderStatefulSet(t, output, 2) {
+			securityContext := obj.Spec.Template.Spec.SecurityContext
+			assert.NotNil(t, securityContext)
+			// user and group should be absent
+			assert.Nil(t, securityContext.RunAsUser)
+			assert.Nil(t, securityContext.RunAsGroup)
+			assert.Equal(t, int64(1234), *securityContext.FSGroup)
+		}
+
+		// check security context on TE Deployment
+		output = helm.RenderTemplate(t, options, helmChartPath, "release-name", []string{"templates/deployment.yaml"})
+		for _, dep := range testlib.SplitAndRenderDeployment(t, output, 1) {
+			securityContext := dep.Spec.Template.Spec.SecurityContext
+			assert.NotNil(t, securityContext)
+			// user and group should be absent
+			assert.Nil(t, securityContext.RunAsUser)
+			assert.Nil(t, securityContext.RunAsGroup)
+			assert.Equal(t, int64(1234), *securityContext.FSGroup)
+		}
+	})
+
+	t.Run("testEnabledPrecedence", func(t *testing.T) {
+		options := &helm.Options{
+			SetValues: map[string]string{
+				"database.sm.hotCopy.journalPath.enabled": "true",
+				"database.sm.noHotCopy.journalPath.enabled": "true",
+				"database.securityContext.enabled": "true",
+				"database.securityContext.runAsNonRootGroup": "true",
+				"database.securityContext.runAsUser": "5555",
+				"database.securityContext.fsGroup": "1234",
+			},
+		}
+
+		// check security context on SM StatefulSets
+		output := helm.RenderTemplate(t, options, helmChartPath, "release-name", []string{"templates/statefulset.yaml"})
+		for _, obj := range testlib.SplitAndRenderStatefulSet(t, output, 2) {
+			securityContext := obj.Spec.Template.Spec.SecurityContext
+			assert.NotNil(t, securityContext)
+			assert.Equal(t, int64(5555), *securityContext.RunAsUser)
+			assert.Equal(t, int64(0), *securityContext.RunAsGroup)
+			assert.Equal(t, int64(1234), *securityContext.FSGroup)
+		}
+
+		// check security context on TE Deployment
+		output = helm.RenderTemplate(t, options, helmChartPath, "release-name", []string{"templates/deployment.yaml"})
+		for _, dep := range testlib.SplitAndRenderDeployment(t, output, 1) {
+			securityContext := dep.Spec.Template.Spec.SecurityContext
+			assert.NotNil(t, securityContext)
+			assert.Equal(t, int64(5555), *securityContext.RunAsUser)
+			assert.Equal(t, int64(0), *securityContext.RunAsGroup)
+			assert.Equal(t, int64(1234), *securityContext.FSGroup)
+		}
+	})
+
+	t.Run("testRunAsNonRootGroupPrecedence", func(t *testing.T) {
+		options := &helm.Options{
+			SetValues: map[string]string{
+				"database.sm.hotCopy.journalPath.enabled": "true",
+				"database.sm.noHotCopy.journalPath.enabled": "true",
+				"database.securityContext.runAsNonRootGroup": "true",
+				"database.securityContext.fsGroupOnly": "true",
+				"database.securityContext.runAsUser": "5555",
+				"database.securityContext.fsGroup": "1234",
+			},
+		}
+
+		// check security context on SM StatefulSets
+		output := helm.RenderTemplate(t, options, helmChartPath, "release-name", []string{"templates/statefulset.yaml"})
+		for _, obj := range testlib.SplitAndRenderStatefulSet(t, output, 2) {
+			securityContext := obj.Spec.Template.Spec.SecurityContext
+			assert.NotNil(t, securityContext)
+			// runAsUser should be disregarded, since we can only use 1000:1000 or <uid>:0
+			assert.Equal(t, int64(1000), *securityContext.RunAsUser)
+			assert.Equal(t, int64(1000), *securityContext.RunAsGroup)
+			assert.Equal(t, int64(1234), *securityContext.FSGroup)
+		}
+
+		// check security context on TE Deployment
+		output = helm.RenderTemplate(t, options, helmChartPath, "release-name", []string{"templates/deployment.yaml"})
+		for _, dep := range testlib.SplitAndRenderDeployment(t, output, 1) {
+			securityContext := dep.Spec.Template.Spec.SecurityContext
+			assert.NotNil(t, securityContext)
+			// runAsUser should be disregarded, since we can only use 1000:1000 or <uid>:0
+			assert.Equal(t, int64(1000), *securityContext.RunAsUser)
+			assert.Equal(t, int64(1000), *securityContext.RunAsGroup)
+			assert.Equal(t, int64(1234), *securityContext.FSGroup)
+		}
+	})
+}
+
+func TestDatabaseInitContainers(t *testing.T) {
+	// Path to the helm chart we will test
+	helmChartPath := "../../stable/database"
+
+	t.Run("testDefault", func(t *testing.T) {
+		options := &helm.Options{
+			SetValues: map[string]string{
+				"database.sm.hotCopy.journalPath.enabled": "true",
+				"database.sm.noHotCopy.journalPath.enabled": "true",
+			},
+		}
+
+		// check init containers on SM StatefulSets
+		output := helm.RenderTemplate(t, options, helmChartPath, "release-name", []string{"templates/statefulset.yaml"})
+		for _, obj := range testlib.SplitAndRenderStatefulSet(t, output, 2) {
+			// look for expected init-disk container
+			initContainers := obj.Spec.Template.Spec.InitContainers
+			assert.Equal(t, 1, len(initContainers))
+			container, err := getContainerNamed(initContainers, "init-disk")
+			assert.NoError(t, err)
+			// check that security context for container specifies root user and group
+			securityContext := container.SecurityContext
+			assert.NotNil(t, securityContext)
+			assert.Equal(t, int64(0), *securityContext.RunAsUser)
+			assert.Equal(t, int64(0), *securityContext.RunAsGroup)
+		}
+
+		// check init containers on TE Deployment
+		output = helm.RenderTemplate(t, options, helmChartPath, "release-name", []string{"templates/deployment.yaml"})
+		for _, dep := range testlib.SplitAndRenderDeployment(t, output, 1) {
+			// look for expected init-disk container
+			initContainers := dep.Spec.Template.Spec.InitContainers
+			assert.Equal(t, 1, len(initContainers))
+			container, err := getContainerNamed(initContainers, "init-disk")
+			assert.NoError(t, err)
+			// check that security context for container specifies root user and group
+			securityContext := container.SecurityContext
+			assert.NotNil(t, securityContext)
+			assert.Equal(t, int64(0), *securityContext.RunAsUser)
+			assert.Equal(t, int64(0), *securityContext.RunAsGroup)
+		}
+	})
+
+	t.Run("testRunInitDiskAsNonRoot", func(t *testing.T) {
+		options := &helm.Options{
+			SetValues: map[string]string{
+				"database.sm.hotCopy.journalPath.enabled": "true",
+				"database.sm.noHotCopy.journalPath.enabled": "true",
+				"database.initContainers.runInitDisk": "true",
+				"database.initContainers.runInitDiskAsRoot": "false",
+			},
+		}
+
+		// check init containers on SM StatefulSets
+		output := helm.RenderTemplate(t, options, helmChartPath, "release-name", []string{"templates/statefulset.yaml"})
+		for _, obj := range testlib.SplitAndRenderStatefulSet(t, output, 2) {
+			// look for expected init-disk container
+			initContainers := obj.Spec.Template.Spec.InitContainers
+			assert.Equal(t, 1, len(initContainers))
+			container, err := getContainerNamed(initContainers, "init-disk")
+			assert.NoError(t, err)
+			// check that security context is not defined
+			securityContext := container.SecurityContext
+			assert.Nil(t, securityContext)
+		}
+
+		// check init containers on TE Deployment
+		output = helm.RenderTemplate(t, options, helmChartPath, "release-name", []string{"templates/deployment.yaml"})
+		for _, dep := range testlib.SplitAndRenderDeployment(t, output, 1) {
+			// look for expected init-disk container
+			initContainers := dep.Spec.Template.Spec.InitContainers
+			assert.Equal(t, 1, len(initContainers))
+			container, err := getContainerNamed(initContainers, "init-disk")
+			assert.NoError(t, err)
+			// check that security context is not defined
+			securityContext := container.SecurityContext
+			assert.Nil(t, securityContext)
+		}
+	})
+
+	t.Run("testDisabled", func(t *testing.T) {
+		options := &helm.Options{
+			SetValues: map[string]string{
+				"database.sm.hotCopy.journalPath.enabled": "true",
+				"database.sm.noHotCopy.journalPath.enabled": "true",
+				"database.initContainers.runInitDisk": "false",
+			},
+		}
+
+		// check init containers on SM StatefulSets
+		output := helm.RenderTemplate(t, options, helmChartPath, "release-name", []string{"templates/statefulset.yaml"})
+		for _, obj := range testlib.SplitAndRenderStatefulSet(t, output, 2) {
+			initContainers := obj.Spec.Template.Spec.InitContainers
+			assert.Equal(t, 0, len(initContainers))
+		}
+
+		// check init containers on TE Deployment
+		output = helm.RenderTemplate(t, options, helmChartPath, "release-name", []string{"templates/deployment.yaml"})
+		for _, dep := range testlib.SplitAndRenderDeployment(t, output, 1) {
+			initContainers := dep.Spec.Template.Spec.InitContainers
+			assert.Equal(t, 0, len(initContainers))
+		}
+	})
+}

--- a/test/minikube/minikube_security_context_test.go
+++ b/test/minikube/minikube_security_context_test.go
@@ -1,0 +1,183 @@
+// +build long
+
+package minikube
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/nuodb/nuodb-helm-charts/v3/test/testlib"
+
+	"github.com/gruntwork-io/terratest/modules/helm"
+	"github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/gruntwork-io/terratest/modules/random"
+)
+
+func checkUser(t *testing.T, namespaceName string, podName string, container string, expectedUid int, expectedGid int, expectedSupplementaryGid int) {
+	// check uid
+	options := k8s.NewKubectlOptions("", "", namespaceName)
+	output, err := k8s.RunKubectlAndGetOutputE(t, options, "exec", podName, "-c", container, "--", "id", "-u")
+	require.NoError(t, err)
+	uid, err := strconv.Atoi(strings.TrimSpace(output))
+	require.Equal(t, expectedUid, uid)
+
+	// check gid
+	output, err = k8s.RunKubectlAndGetOutputE(t, options, "exec", podName, "-c", container, "--", "id", "-g")
+	require.NoError(t, err)
+	gid, err := strconv.Atoi(strings.TrimSpace(output))
+	require.Equal(t, expectedGid, gid)
+
+	// check supplementary gids
+	output, err = k8s.RunKubectlAndGetOutputE(t, options, "exec", podName, "-c", container, "--", "id", "-G")
+	require.NoError(t, err)
+	var found bool
+	for _, token := range strings.Split(strings.TrimSpace(output), " ") {
+		gid, err = strconv.Atoi(token)
+		if err == nil && gid == expectedSupplementaryGid {
+			found = true
+		}
+	}
+	require.True(t, found, "gid %d not found: %s", expectedSupplementaryGid, output)
+}
+
+func checkOwnerGid(t *testing.T, namespaceName string, podName string, container string, filename string, expectedGid int) {
+	// check that the specified file is owned by the supplied gid
+	options := k8s.NewKubectlOptions("", "", namespaceName)
+	output, err := k8s.RunKubectlAndGetOutputE(t, options, "exec", podName, "-c", container, "--", "stat", "-c", "%g", filename)
+	require.NoError(t, err)
+	gid, err := strconv.Atoi(strings.TrimSpace(output))
+	require.Equal(t, expectedGid, gid)
+}
+
+func securityContextTest(t *testing.T, adminUid int, adminGid int, adminFsGroup int, databaseUid int, databaseGid, databaseFsGroup int, optionOverrides *map[string]string) {
+	// verify that user can run as the supplied uid and that fsGroup becomes
+	// owner gid for volumes; this test specifically checks secrets because
+	// the hostpath storage-class used by Minikube does not support fsGroup
+
+	testlib.AwaitTillerUp(t)
+	defer testlib.VerifyTeardown(t)
+
+	randomSuffix := strings.ToLower(random.UniqueId())
+	namespaceName := fmt.Sprintf("%skubernetessecuritycontext-%s", testlib.NAMESPACE_NAME_PREFIX, randomSuffix)
+	testlib.CreateNamespace(t, namespaceName)
+
+	defer testlib.Teardown(testlib.TEARDOWN_SECRETS)
+
+	// create the certs and secrets...
+	tlsCommands := []string{
+		"export DEFAULT_PASSWORD='" + testlib.SECRET_PASSWORD + "'",
+		"setup-keys.sh",
+		"nuocmd show certificate --keystore " + testlib.KEYSTORE_FILE + " --store-password \"$DEFAULT_PASSWORD\" > nuoadmin.cert",
+	}
+	testlib.GenerateTLSConfiguration(t, namespaceName, tlsCommands)
+
+	// create a database with TLS enabled
+	options := helm.Options{
+		SetValues: map[string]string{
+			"admin.tlsCACert.secret":                testlib.CA_CERT_SECRET,
+			"admin.tlsCACert.key":                   testlib.CA_CERT_FILE,
+			"admin.tlsKeyStore.secret":              testlib.KEYSTORE_SECRET,
+			"admin.tlsKeyStore.key":                 testlib.KEYSTORE_FILE,
+			"admin.tlsKeyStore.password":            testlib.SECRET_PASSWORD,
+			"admin.tlsTrustStore.secret":            testlib.TRUSTSTORE_SECRET,
+			"admin.tlsTrustStore.key":               testlib.TRUSTSTORE_FILE,
+			"admin.tlsTrustStore.password":          testlib.SECRET_PASSWORD,
+			"admin.tlsClientPEM.secret":             testlib.NUOCMD_SECRET,
+			"admin.tlsClientPEM.key":                testlib.NUOCMD_FILE,
+			"database.sm.resources.requests.cpu":    testlib.MINIMAL_VIABLE_ENGINE_CPU,
+			"database.sm.resources.requests.memory": testlib.MINIMAL_VIABLE_ENGINE_MEMORY,
+			"database.te.resources.requests.cpu":    testlib.MINIMAL_VIABLE_ENGINE_CPU,
+			"database.te.resources.requests.memory": testlib.MINIMAL_VIABLE_ENGINE_MEMORY,
+			"admin.securityContext.runAsUser":       strconv.Itoa(adminUid),
+			"admin.securityContext.fsGroup":         strconv.Itoa(adminFsGroup),
+			"database.securityContext.runAsUser":    strconv.Itoa(databaseUid),
+			"database.securityContext.fsGroup":      strconv.Itoa(databaseFsGroup),
+		},
+	}
+
+	// set overrides
+	for k, v := range *optionOverrides {
+		options.SetValues[k] = v
+	}
+
+	// sometimes the test fails because SMs doesn't go ready due to probe
+	// timeout
+	testlib.OverrideReadinessProbesTimeout(t, &options, "10")
+
+	defer testlib.Teardown(testlib.TEARDOWN_ADMIN)
+	helmChartReleaseName, _ := testlib.StartAdmin(t, &options, 1, namespaceName)
+	adminStatefulSet := fmt.Sprintf("%s-nuodb-cluster0", helmChartReleaseName)
+	admin0 := adminStatefulSet+"-0"
+
+	defer testlib.Teardown(testlib.TEARDOWN_DATABASE)
+	databaseReleaseName := testlib.StartDatabase(t, namespaceName, admin0, &options)
+
+	smPodNameTemplate := fmt.Sprintf("sm-%s", databaseReleaseName)
+	tePodNameTemplate := fmt.Sprintf("te-%s", databaseReleaseName)
+
+	// for all Pods, check that the user has the expected uid:gid and
+	// supplementary gid, and check that TLS secrets mounted into the
+	// container have the expected ownership (owned by gid fsGroup)
+	for _, pod := range testlib.FindAllPodsInSchema(t, namespaceName) {
+		if strings.Contains(pod.Name, adminStatefulSet) {
+			checkUser(t, namespaceName, pod.Name, "admin", adminUid, adminGid, adminFsGroup)
+			checkOwnerGid(t, namespaceName, pod.Name, "admin", "/etc/nuodb/keys/nuocmd.pem", adminFsGroup)
+		} else if strings.Contains(pod.Name, smPodNameTemplate) || strings.Contains(pod.Name, tePodNameTemplate) {
+			checkUser(t, namespaceName, pod.Name, "engine", databaseUid, databaseGid, databaseFsGroup)
+			checkOwnerGid(t, namespaceName, pod.Name, "engine", "/etc/nuodb/keys/nuocmd.pem", databaseFsGroup)
+		}
+	}
+}
+
+func TestSecurityContextEnabled(t *testing.T) {
+	// use arbitary uid and fsGroup, which can be different for both charts
+	adminUid := 1234
+	adminGid := 0
+	adminFsGroup := 2000
+	databaseUid := 5678
+	databaseGid := 0
+	databaseFsGroup := 4000
+	optionOverrides := map[string]string {
+		"admin.securityContext.enabled":    "true",
+		"database.securityContext.enabled": "true",
+	}
+	securityContextTest(t, adminUid, adminGid, adminFsGroup, databaseUid, databaseGid, databaseFsGroup, &optionOverrides)
+}
+
+func TestSecurityContextRunAsNonRootGroup(t *testing.T) {
+	// users with non-0 gid is supported in 4.3
+	testlib.SkipTestOnNuoDBVersionCondition(t, "<4.3")
+
+	// runAsNonRootGroup only supports 1000:1000
+	adminUid := 1000
+	adminGid := 1000
+	adminFsGroup := 1000
+	databaseUid := 1000
+	databaseGid := 1000
+	databaseFsGroup := 1000
+	optionOverrides := map[string]string {
+		"admin.securityContext.runAsNonRootGroup":    "true",
+		"database.securityContext.runAsNonRootGroup": "true",
+	}
+	securityContextTest(t, adminUid, adminGid, adminFsGroup, databaseUid, databaseGid, databaseFsGroup, &optionOverrides)
+}
+
+func TestSecurityContextFsGroupOnly(t *testing.T) {
+	// fsGroup omits runAsUser and runAsGroup, but the we expect the image
+	// to have a default user of 1000:0
+	adminUid := 1000
+	adminGid := 0
+	adminFsGroup := 2000
+	databaseUid := 1000
+	databaseGid := 0
+	databaseFsGroup := 4000
+	optionOverrides := map[string]string {
+		"admin.securityContext.fsGroupOnly":    "true",
+		"database.securityContext.fsGroupOnly": "true",
+	}
+	securityContextTest(t, adminUid, adminGid, adminFsGroup, databaseUid, databaseGid, databaseFsGroup, &optionOverrides)
+}

--- a/test/minikube/minikube_tls_admin_test.go
+++ b/test/minikube/minikube_tls_admin_test.go
@@ -91,7 +91,7 @@ func TestKubernetesTLS(t *testing.T) {
 		localOptions.SetValues["database.te.resources.requests.cpu"] = testlib.MINIMAL_VIABLE_ENGINE_CPU
 		localOptions.SetValues["database.te.resources.requests.memory"] = testlib.MINIMAL_VIABLE_ENGINE_MEMORY
 
-		defer testlib.Teardown("database")
+		defer testlib.Teardown(testlib.TEARDOWN_DATABASE)
 
 		databaseReleaseName := testlib.StartDatabase(t, namespaceName, admin0, &localOptions)
 
@@ -116,7 +116,7 @@ func TestKubernetesTLS(t *testing.T) {
 		localOptions.SetValues["database.te.otherOptions.keystore"] = "/etc/nuodb/keys/nuoadmin.p12"
 		localOptions.SetValues["database.sm.otherOptions.keystore"] = "/etc/nuodb/keys/nuoadmin.p12"
 
-		defer testlib.Teardown("database")
+		defer testlib.Teardown(testlib.TEARDOWN_DATABASE)
 
 		databaseReleaseName := testlib.StartDatabase(t, namespaceName, admin0, &localOptions)
 

--- a/test/minikube/minikube_upgrade_helm_test.go
+++ b/test/minikube/minikube_upgrade_helm_test.go
@@ -4,7 +4,6 @@ package minikube
 
 import (
 	"fmt"
-	"os"
 	"strings"
 	"testing"
 	"time"
@@ -63,10 +62,6 @@ func upgradeAdminTest(t *testing.T, fromHelmVersion string, upgradeOptions *test
 }
 
 func upgradeDatabaseTest(t *testing.T, fromHelmVersion string, upgradeOptions *testlib.UpgradeOptions) {
-	if os.Getenv("NUODB_LICENSE") == "ENTERPRISE" {
-		t.Skip("Can not test helm upgrade in this environment. See DB-33858")
-	}
-
 	testlib.AwaitTillerUp(t)
 	defer testlib.VerifyTeardown(t)
 

--- a/test/testlib/minikube_utilities.go
+++ b/test/testlib/minikube_utilities.go
@@ -327,7 +327,7 @@ func arePodConditionsMet(pod *corev1.Pod, condition corev1.PodConditionType,
 	return false
 }
 
-func findAllPodsInSchema(t *testing.T, namespace string) []corev1.Pod {
+func FindAllPodsInSchema(t *testing.T, namespace string) []corev1.Pod {
 	options := k8s.NewKubectlOptions("", "", namespace)
 	filter := metav1.ListOptions{}
 	pods := k8s.ListPods(t, options, filter)
@@ -337,9 +337,40 @@ func findAllPodsInSchema(t *testing.T, namespace string) []corev1.Pod {
 	return pods
 }
 
-func findAdminOrEngineContainer(containers []corev1.Container) *corev1.Container {
-	for _, container := range containers {
-		if container.Name == "admin" || container.Name == "engine" {
+func doesContainerHaveLogs(container *corev1.Container, containerStatuses []corev1.ContainerStatus) bool {
+	for _, status := range containerStatuses {
+		// check the status of the container; if it is in Waiting state,
+		// then check that it has a non-0 restart count; otherwise the
+		// container has no logs to retrieve
+		if status.Name == container.Name && (status.State.Waiting == nil || status.RestartCount > 0) {
+			return true
+		}
+	}
+	return false
+}
+
+func findAdminOrEngineContainer(pod *corev1.Pod) *corev1.Container {
+	// look for any container named "admin" or "engine" that has logs
+	for _, container := range pod.Spec.Containers {
+		if (container.Name == "admin" || container.Name == "engine") && doesContainerHaveLogs(&container, pod.Status.ContainerStatuses) {
+			return &container
+		}
+	}
+	// look for any container that has logs
+	for _, container := range pod.Spec.Containers {
+		if doesContainerHaveLogs(&container, pod.Status.ContainerStatuses) {
+			return &container
+		}
+	}
+	// look for any init container named "init-disk" that has logs
+	for _, container := range pod.Spec.InitContainers {
+		if container.Name == "init-disk" && doesContainerHaveLogs(&container, pod.Status.InitContainerStatuses) {
+			return &container
+		}
+	}
+	// look for any init container that has logs
+	for _, container := range pod.Spec.InitContainers {
+		if doesContainerHaveLogs(&container, pod.Status.InitContainerStatuses) {
 			return &container
 		}
 	}
@@ -394,7 +425,7 @@ func AwaitTillerUp(t *testing.T) {
 	}
 
 	Await(t, func() bool {
-		for _, pod := range findAllPodsInSchema(t, "kube-system") {
+		for _, pod := range FindAllPodsInSchema(t, "kube-system") {
 			if strings.Contains(pod.Name, "tiller-deploy") {
 				if arePodConditionsMet(&pod, corev1.PodReady, corev1.ConditionTrue) {
 					return true
@@ -414,25 +445,38 @@ func AwaitNrReplicasScheduled(t *testing.T, namespace string, expectedName strin
 		timeout *= time.Duration(nrReplicas)
 	}
 	Await(t, func() bool {
-		var cnt int
-		for _, pod := range findAllPodsInSchema(t, namespace) {
+		var pods []corev1.Pod
+		var podNames string
+		for _, pod := range FindAllPodsInSchema(t, namespace) {
 			if strings.Contains(pod.Name, expectedName) {
 				if arePodConditionsMet(&pod, corev1.PodScheduled, corev1.ConditionTrue) {
-					cnt++
+					// build array of scheduled pods
+					pods = append(pods, pod)
+
+					// build formatted list of pod names
+					if podNames != "" {
+						podNames += ", "
+					}
+					podNames += pod.Name
+
+					// log any pods not in Pending or Running phase
+					if pod.Status.Phase != corev1.PodPending && pod.Status.Phase != corev1.PodRunning {
+						t.Logf("Unexpected phase for pod %s: %s", pod.Name, pod.Status.Phase)
+					}
 				}
 			}
 		}
 
-		t.Logf("%d pods SCHEDULED for name '%s'\n", cnt, expectedName)
+		t.Logf("%d pods SCHEDULED for name '%s': expected=%d, pods=[%s]\n", len(pods), expectedName, nrReplicas, podNames)
 
-		return cnt == nrReplicas
+		return len(pods) == nrReplicas
 	}, timeout)
 }
 
 func AwaitNrReplicasReady(t *testing.T, namespace string, expectedName string, nrReplicas int) {
 	Await(t, func() bool {
 		var cnt int
-		for _, pod := range findAllPodsInSchema(t, namespace) {
+		for _, pod := range FindAllPodsInSchema(t, namespace) {
 			if strings.Contains(pod.Name, expectedName) {
 				if arePodConditionsMet(&pod, corev1.PodReady, corev1.ConditionTrue) {
 					cnt++
@@ -449,7 +493,7 @@ func AwaitNrReplicasReady(t *testing.T, namespace string, expectedName string, n
 func AwaitNoPods(t *testing.T, namespace string, expectedName string) {
 	Await(t, func() bool {
 		var cnt int
-		for _, pod := range findAllPodsInSchema(t, namespace) {
+		for _, pod := range FindAllPodsInSchema(t, namespace) {
 			if strings.Contains(pod.Name, expectedName) {
 				cnt++
 			}
@@ -460,13 +504,13 @@ func AwaitNoPods(t *testing.T, namespace string, expectedName string) {
 }
 
 func findPod(t *testing.T, namespace string, expectedName string) (*corev1.Pod, error) {
-	for _, pod := range findAllPodsInSchema(t, namespace) {
+	for _, pod := range FindAllPodsInSchema(t, namespace) {
 		if strings.Contains(pod.Name, expectedName) {
 			return &pod, nil
 		}
 	}
 
-	for _, pod := range findAllPodsInSchema(t, namespace) {
+	for _, pod := range FindAllPodsInSchema(t, namespace) {
 		t.Logf("Pods %s\n", pod.Name)
 	}
 
@@ -476,7 +520,7 @@ func findPod(t *testing.T, namespace string, expectedName string) (*corev1.Pod, 
 func findPods(t *testing.T, namespace string, expectedName string) ([]corev1.Pod, error) {
 	var pods []corev1.Pod
 
-	for _, pod := range findAllPodsInSchema(t, namespace) {
+	for _, pod := range FindAllPodsInSchema(t, namespace) {
 		if strings.Contains(pod.Name, expectedName) {
 			pods = append(pods, pod)
 		}
@@ -516,7 +560,7 @@ func GetPodNames(t *testing.T, namespaceName string, expectedName string) []stri
 
 func DescribePods(t *testing.T, namespace string, expectedName string) {
 	options := k8s.NewKubectlOptions("", "", namespace)
-	for _, pod := range findAllPodsInSchema(t, namespace) {
+	for _, pod := range FindAllPodsInSchema(t, namespace) {
 		if strings.Contains(pod.Name, expectedName) {
 			k8s.RunKubectl(t, options, "describe", "pod", pod.Name)
 		}
@@ -524,7 +568,7 @@ func DescribePods(t *testing.T, namespace string, expectedName string) {
 }
 
 func DeleteJobPods(t *testing.T, namespace string, jobName string) {
-	for _, pod := range findAllPodsInSchema(t, namespace) {
+	for _, pod := range FindAllPodsInSchema(t, namespace) {
 		if strings.Contains(pod.Name, jobName) {
 			t.Logf("Deleting pod %s for job %s", pod.Name, jobName)
 			DeletePod(t, namespace, pod.Name)
@@ -624,7 +668,7 @@ func AwaitPodHasVersion(t *testing.T, namespace string, podName string, expected
 
 func AwaitBalancerTerminated(t *testing.T, namespace string, expectedName string) {
 	Await(t, func() bool {
-		for _, pod := range findAllPodsInSchema(t, namespace) {
+		for _, pod := range FindAllPodsInSchema(t, namespace) {
 			if strings.Contains(pod.Name, expectedName) {
 				if pod.Status.Phase == "Succeeded" {
 					t.Logf("Pod (%s) TERMINATED\n", expectedName)
@@ -894,9 +938,9 @@ func GetAppLog(t *testing.T, namespace string, podName string, fileNameSuffix st
 	writer := io.Writer(f)
 
 	reader, err := getAppLogStreamE(t, namespace, podName, podLogOptions)
-	// avoid generating test failure just because container has not been started
-	if ctrerr, ok := err.(*ContainerNotStarted); ok {
-		t.Logf("Skipping log collection for pod %s because container %s has not been started", podName, ctrerr.Name)
+	// avoid generating test failure just because container logs are not available
+	if _, ok := err.(*ContainersNotStarted); ok {
+		t.Logf("Skipping log collection for pod %s because no container has been started", podName)
 		return ""
 	}
 	require.NoError(t, err)
@@ -909,12 +953,12 @@ func GetAppLog(t *testing.T, namespace string, podName string, fileNameSuffix st
 	return filePath
 }
 
-type ContainerNotStarted struct {
+type ContainersNotStarted struct {
 	Name string
 }
 
-func (e *ContainerNotStarted) Error() string {
-	return fmt.Sprintf("Container %s not started", e.Name)
+func (e *ContainersNotStarted) Error() string {
+	return "No containers with logs"
 }
 
 func getAppLogStreamE(t *testing.T, namespace string, podName string, podLogOptions *corev1.PodLogOptions) (reader io.ReadCloser, err error) {
@@ -929,22 +973,25 @@ func getAppLogStreamE(t *testing.T, namespace string, podName string, podLogOpti
 			err = e
 			return
 		}
-		if len(pod.Spec.Containers) == 0 {
-			err = errors.New("No containers found")
+		container := findAdminOrEngineContainer(pod)
+		if container == nil {
+			err = &ContainersNotStarted{}
 			return
 		}
-		container := findAdminOrEngineContainer(pod.Spec.Containers)
-		if container == nil {
-			container = &pod.Spec.Containers[0]
-		}
+		podLogOptions.Container = container.Name
 		for _, containerStatus := range pod.Status.ContainerStatuses {
+			// if the container is in Waiting state (e.g. because
+			// the pod is in CrashLoopBackOff state), then get the
+			// logs from the previous invocation of the container
 			if containerStatus.Name == container.Name && containerStatus.State.Waiting != nil {
-				err = &ContainerNotStarted{container.Name}
-				return
+				podLogOptions.Previous = true
 			}
 		}
-		podLogOptions.Container = container.Name
-		t.Logf("Multiple containers found in pod %s. Getting logs from container %s.", podName, podLogOptions.Container)
+		if podLogOptions.Previous {
+			t.Logf("Multiple containers found in pod %s. Getting logs from previous container %s.", podName, podLogOptions.Container)
+		} else {
+			t.Logf("Multiple containers found in pod %s. Getting logs from container %s.", podName, podLogOptions.Container)
+		}
 	}
 
 	reader, err = client.CoreV1().Pods(options.Namespace).GetLogs(podName, podLogOptions).Stream(context.TODO())


### PR DESCRIPTION
- Allow security context to be specified for all Pods created by NuoDB.
  `database.securityContext.enabled` and `admin.securityContext.enabled`
  allow the `runAsUser` and `fsGroup` values to be specified, while
  explicitly supplying a `runAsGroup` value of 0.
  `*.securityContext.runAsNonRootGroup` causes the `runAsUser` and
  `runAsGroup` values for the security context to each be set to 1000.
  This will be supported by the NuoDB image version 4.3. All versions of
  the NuoDB image before 4.3 require the user to have gid 0.
  `*.securityContext.fsGroupOnly` causes a security context to be
  created that only specifies the `fsGroup`.
- Add `admin.initContainers.runInitDisk` and
  `database.initContainers.runInitDisk` values to allow the init
  container that changes permissions and ownership of files within
  storage volumes to be omitted. If a security context is specified,
  this init container is usually redundant, because `fsGroup` implements
  the same behavior natively to Kubernetes. There are some
  storage-classes that do not support this behavior of `fsGroup` such as
  hostpath, which is used by Minikube.  In that case, it makes sense to
  keep the init container enabled even if a security context is
  specified. Since the init container cannot actually change permissions
  and ownership unless it runs as root, it now specifies its own
  security context by default to override the Pod security context. The
  init container security context can be omitted by specifying
  `*.initContainers.runInitDiskAsRoot=false`.
- Make init container compatible with a user with a non-0 gid by
  changing ownership to 1000. Only uid 1000 can have a non-0 gid, and
  the files are also made group-accessible, so that any user with gid 0
  can access them as well. This also fixes the command so that it adds
  the required permissions rather than explicitly setting them to 770,
  which may actually remove permissions, e.g. if the file or directory
  is world-accessible.
- Improve log collection on test failure so that if the default
  container ("admin" or "engine") is not running, we fetch the output of
  its last invocation, and if it does not have a last invocation because
  the Pod failed in the init container, we fetch the output of the init
  container.
- Improve logging of scheduled Pods to show the expected number and the
  names of the scheduled Pods.
- Enable TestUpgradeHelmFullDB in Bamboo, which does not seem to be
  failing anymore after these changes.