### PR TITLE
Delete pods reported as CrashLoopBackOff

### DIFF
--- a/test/testlib/minikube_utilities.go
+++ b/test/testlib/minikube_utilities.go
@@ -1346,3 +1346,46 @@ func RemoveOrphanNamespaces(t *testing.T) {
 		}
 	}
 }
+
+func DeleteCrashLoopBackOffPods(t *testing.T, namespaceName string, collectLog bool) {
+	toDelete := make(map[string]corev1.ContainerStatus)
+	// find all Pods that have containers reported as CrashLoopBackOff
+	for _, pod := range FindAllPodsInSchema(t, namespaceName) {
+		for _, status := range pod.Status.ContainerStatuses {
+			if status.State.Waiting != nil && status.State.Waiting.Reason == "CrashLoopBackOff" {
+				toDelete[pod.Name] = status
+			}
+		}
+	}
+	for podName, previousStatus := range toDelete {
+		if collectLog {
+			GetAppLog(t, namespaceName, podName, "-crashloopbackoff", &corev1.PodLogOptions{})
+		}
+		// verify that the Pod is still having the container with back-off
+		currentPod := GetPod(t, namespaceName, podName)
+		for _, currentStatus := range currentPod.Status.ContainerStatuses {
+			if currentStatus.ContainerID == previousStatus.ContainerID {
+				t.Logf("Deleting CrashLoopBackOff pod=%s, container=%s, containerId=%s",
+					podName, previousStatus.Name, previousStatus.ContainerID)
+				DeletePod(t, namespaceName, "pod/"+podName)
+				break
+			}
+		}
+	}
+}
+
+func StartBackgroundTask(teardownName string, task func()) {
+	stopCh := make(chan bool)
+	AddTeardown(teardownName, func() { stopCh <- true })
+	go func() {
+		for {
+			select {
+			case <-stopCh:
+				return
+			default:
+				task()
+				time.Sleep(1 * time.Second)
+			}
+		}
+	}()
+}


### PR DESCRIPTION
The `TestKubernetesRestoreMultipleBackupGroups` test is doing multiple restore
operations in a sequence which increases the possibility for a container to be
reported as `CrashLoopBackOff`. This increases the testing time due to
container restart back-off and can fail the test. Monitor for such pods and
restart them to reset the back-off timer.

Database processes that are not selected for restore may experience schedule
delay and start after the restore coordinator SM already restored the database.
In that case _"Waiting for database restore to complete"_ message won't be see
in their log.