### PR TITLE
Use most recent 4.2.x release as default

### DIFF
--- a/stable/admin/values.yaml
+++ b/stable/admin/values.yaml
@@ -49,7 +49,7 @@ nuodb:
   image:
     registry: docker.io
     repository: nuodb/nuodb-ce
-    tag: 4.2.1
+    tag: '4.2'
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/stable/database/values.yaml
+++ b/stable/database/values.yaml
@@ -42,7 +42,7 @@ nuodb:
   image:
     registry: docker.io
     repository: nuodb/nuodb-ce
-    tag: 4.2.1
+    tag: '4.2'
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/stable/restore/values.yaml
+++ b/stable/restore/values.yaml
@@ -32,7 +32,7 @@ nuodb:
   image:
     registry: docker.io
     repository: nuodb/nuodb-ce
-    tag: 4.2.1
+    tag: '4.2'
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
Drop last component of the default version so that the most recent
maintenance release of 4.2 gets pulled.