### PR TITLE
Support for multi-ingress environments

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/otiai10/copy v1.2.0
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/crypto v0.0.0-20200709230013-948cd5f35899 // indirect
+	golang.org/x/sys v0.0.0-20220422013727-9388b58f7150 // indirect
 	golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e // indirect
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.19.0

--- a/go.sum
+++ b/go.sum
@@ -566,6 +566,8 @@ golang.org/x/sys v0.0.0-20200523222454-059865788121/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200622214017-ed371f2e16b4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f h1:+Nyd8tzPX9R7BWHguqsrbFdRx3WQ/1ib8I44HXV5yTA=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20220422013727-9388b58f7150 h1:xHms4gcpe1YE7A3yIllJXP16CMAGuqwO2lX1mTyyRRc=
+golang.org/x/sys v0.0.0-20220422013727-9388b58f7150/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/test/minikube/minikube_external_access_test.go
+++ b/test/minikube/minikube_external_access_test.go
@@ -293,23 +293,25 @@ func TestKubernetesIngress(t *testing.T) {
 	defer testlib.Teardown(testlib.TEARDOWN_DATABASE)
 
 	// install HAProxy Ingress controller
-	haProxyReleaseName := testlib.StartHAProxyIngress(t, &helm.Options{}, namespaceName)
+	haProxyOptions := helm.Options{}
+	haProxyReleaseName := testlib.StartHAProxyIngress(t, &haProxyOptions, namespaceName)
+	ingressClassName := haProxyReleaseName
 	_, ingressPort := findDomainExternalInfo(t, namespaceName, fmt.Sprintf("%s-kubernetes-ingress", haProxyReleaseName), "https")
 
 	options := helm.Options{
 		SetValues: map[string]string{
 			"admin.ingress.enabled":                 "true",
 			"admin.ingress.api.hostname":            testlib.ADMIN_API_INGRESS_HOSTNAME,
-			"admin.ingress.api.className":           "haproxy",
+			"admin.ingress.api.className":           ingressClassName,
 			"admin.ingress.sql.hostname":            testlib.ADMIN_SQL_INGRESS_HOSTNAME,
-			"admin.ingress.sql.className":           "haproxy",
+			"admin.ingress.sql.className":           ingressClassName,
 			"database.sm.resources.requests.cpu":    testlib.MINIMAL_VIABLE_ENGINE_CPU,
 			"database.sm.resources.requests.memory": testlib.MINIMAL_VIABLE_ENGINE_MEMORY,
 			"database.te.resources.requests.cpu":    testlib.MINIMAL_VIABLE_ENGINE_CPU,
 			"database.te.resources.requests.memory": testlib.MINIMAL_VIABLE_ENGINE_MEMORY,
 			"database.te.ingress.enabled":           "true",
 			"database.te.ingress.hostname":          testlib.DATABASE_TE_INGRESS_HOSTNAME,
-			"database.te.ingress.className":         "haproxy",
+			"database.te.ingress.className":         ingressClassName,
 			// The product doesn't support Ingress resource lookup, so define
 			// the port manually; most of the time in production a service of
 			// type=LoadBalancer will be provisioned for the Ingress Controller

--- a/test/testlib/haproxy_utilities.go
+++ b/test/testlib/haproxy_utilities.go
@@ -21,10 +21,12 @@ func StartHAProxyIngress(t *testing.T, options *helm.Options, namespaceName stri
 
 	defaultOptions := helm.Options{
 		SetValues: map[string]string{
-			"controller.replicaCount":     "1",
-			"controller.service.type":     "NodePort",
-			"defaultBackend.enabled":      "true",
-			"defaultBackend.replicaCount": "1",
+			"controller.replicaCount":              "1",
+			"controller.service.type":              "NodePort",
+			"controller.ingressClass":              helmChartReleaseName,
+			"controller.ingressClassResource.name": helmChartReleaseName,
+			"defaultBackend.enabled":               "true",
+			"defaultBackend.replicaCount":          "1",
 		},
 	}
 


### PR DESCRIPTION
**Issue**

If the test job is killed and HAProxy teardown doesn't execute, the `IngressClass` resource (which is cluster-scoped) will be left behind. This will cause all subsequent executions of the test to fail with the following message:

```
Error: INSTALLATION FAILED: rendered manifests contain a resource that already exists. Unable to continue with install: IngressClass "haproxy" in namespace "" exists and cannot be imported into the current release: invalid ownership metadata; annotation validation error: key "meta.helm.sh/release-name" must equal "haproxy-ooimr1": current value is "haproxy-mgyoxp"; annotation validation error: key "meta.helm.sh/release-namespace" must equal "testkubernetesingress-5czgy7": current value is "testkubernetesingress-s0uufa"
```

**Changes**

Added support for multi-ingress environments.

For more information, see https://github.com/haproxytech/helm-charts/tree/main/kubernetes-ingress#installing-in-multi-ingress-environment.