### PR TITLE
Set publishNotReadyAddresses to true for TE services

### DIFF
--- a/stable/database/templates/service-clusterip.yaml
+++ b/stable/database/templates/service-clusterip.yaml
@@ -33,6 +33,7 @@ metadata:
   annotations:
     description: |
       Cluster IP service targeting specific Helm release permitting us to load balance within the cluster.
+    "service.alpha.kubernetes.io/tolerate-unready-endpoints": "true"
   labels:
     app: {{ template "database.fullname" . }}
     group: nuodb

--- a/stable/database/templates/service-clusterip.yaml
+++ b/stable/database/templates/service-clusterip.yaml
@@ -42,6 +42,7 @@ metadata:
     release: {{ .Release.Name | quote }}
   name: {{ template "database.fullname" . }}-{{ default .Values.admin.serviceSuffix.clusterip .Values.database.serviceSuffix.clusterip }}
 spec:
+  publishNotReadyAddresses: true
   ports:
   - { name: 48006-tcp,  port: 48006,  protocol: TCP,  targetPort: 48006 }
   selector:

--- a/stable/database/templates/service.yaml
+++ b/stable/database/templates/service.yaml
@@ -14,6 +14,7 @@ metadata:
     release: {{ .Release.Name | quote }}
   name: {{ template "database.externalServiceName" . }}
 spec:
+  publishNotReadyAddresses: true
   ports:
   - { name: 48006-tcp,  port: 48006,  protocol: TCP,  targetPort: 48006 }
   selector:

--- a/stable/database/templates/service.yaml
+++ b/stable/database/templates/service.yaml
@@ -4,6 +4,7 @@ kind: Service
 metadata:
   annotations:
     description: "Service (and load-balancer) for TE pods."
+    "service.alpha.kubernetes.io/tolerate-unready-endpoints": "true"
 {{- include "database.externalAccessAnnotations" . | indent 4 }}
   labels:
     app: {{ template "database.fullname" . }}

--- a/test/integration/template_database_test.go
+++ b/test/integration/template_database_test.go
@@ -85,6 +85,7 @@ func TestDatabaseClusterServiceRenders(t *testing.T) {
 			// This is the cluster IP targeting only TEs in this TE group
 			assert.Equal(t, "te", obj.Spec.Selector["component"])
 			assert.Equal(t, "release-name-nuodb-cluster0-demo-database", obj.Spec.Selector["app"])
+			assert.True(t, obj.Spec.PublishNotReadyAddresses)
 		}
 	}
 }
@@ -126,6 +127,7 @@ func TestDatabaseServiceRenders(t *testing.T) {
 	for _, obj := range testlib.SplitAndRenderService(t, output, 1) {
 		assert.Equal(t, "release-name-nuodb-cluster0-demo-database-balancer", obj.Name)
 		assert.Equal(t, v1.ServiceTypeLoadBalancer, obj.Spec.Type)
+		assert.True(t, obj.Spec.PublishNotReadyAddresses)
 		assert.Equal(t, "release-name-nuodb-cluster0-demo-database", obj.Spec.Selector["app"])
 		assert.Equal(t, "te", obj.Spec.Selector["component"])
 		assert.Contains(t, obj.Annotations, "service.beta.kubernetes.io/aws-load-balancer-internal")


### PR DESCRIPTION
**Issue**

A SQL application will fail to connect to a TE group that doesn't have _ready_ TE pods with the following error message:

```
Connection failed: connection failed: 6: connection to 10.97.49.14:48006 failed: Connection refused (61)
```

This issue affects external database access in scenarios where multiple TE groups are running in different availability zones or Kubernetes clusters. Normally the SQL application will be configured with Load balancer policies that prefer the TE group in the local AZ or cluster. 

The switch to the remote TE group happens instantly if the local one fails or is unavailable, however, the problem is seen when the previously failed TE group is brought up again. The AP will return a local TE external address (the `LoadBalancer` service external address) as the TE will be in `RUNNING` state, however, the service will not route the traffic to unready endpoints preventing the connection to a TE. Until at least one TE pod in the local TE group becomes ready, the SQL app won't be able to obtain a new database connection (typically around 30sec).

**Change**

Set `publishNotReadyAddresses=true` on TE group services so that incoming connections can be sent to unready endpoints. This should be safe because the AP won't advertise a TE that is not `RUNNING`.


