### PR TITLE
Remove port 48005 from AP service used for external access

### DIFF
--- a/stable/admin/templates/service.yaml
+++ b/stable/admin/templates/service.yaml
@@ -16,7 +16,6 @@ spec:
   ports:
   - { name: 8888-tcp,   port: 8888,   protocol: TCP,  targetPort: 8888  }
   - { name: 48004-tcp,  port: 48004,  protocol: TCP,  targetPort: 48004 }
-  - { name: 48005-tcp,  port: 48005,  protocol: TCP,  targetPort: 48005 }
   selector:
     app: {{ template "admin.fullname" . }}
   sessionAffinity: None


### PR DESCRIPTION
This change removes port 48005 from the service created by
admin.externalAccess.enabled=true.

Port 48005 is used for internal communication among APs and not by
external clients. When this port is exposed to external access using
Network Load Balancer in AWS, stacktraces are generated by the Thrift
server that listens on that port due to the load balancer pinging the AP
on that port, even though there is no reason for the port to be exposed
through a load balancer.