### PR TITLE
Use batch/v1/CronJob if available

### DIFF
--- a/stable/database/templates/_helpers.tpl
+++ b/stable/database/templates/_helpers.tpl
@@ -219,6 +219,17 @@ Return options as $key $value
 {{- end -}}
 
 {{/*
+Return the API version of the CronJob kind
+*/}}
+{{- define "cronjob.apiVersion" -}}
+{{- if .Capabilities.APIVersions.Has "batch/v1/CronJob" -}}
+batch/v1
+{{- else -}}
+batch/v1beta1
+{{- end -}}
+{{- end -}}
+
+{{/*
 Return the hotcopy group prefix
 */}}
 {{- define "hotcopy.groupPrefix" -}}

--- a/stable/database/templates/cronjob.yaml
+++ b/stable/database/templates/cronjob.yaml
@@ -14,7 +14,7 @@
   {{- with $globalScope }}
     {{ $backupGroupLabels := include "hotcopy.group.labels" (merge (dict "backupGroup" $backupGroup) .) }}
 ---
-apiVersion: batch/v1beta1
+apiVersion: {{ include "cronjob.apiVersion" . }}
 kind: CronJob
 metadata:
   name: {{ include "hotcopy.cronjob.name" (merge (dict "backupGroup" $backupGroup "hotCopyType" "full") . ) }}
@@ -115,7 +115,7 @@ spec:
           restartPolicy: {{ .Values.database.sm.hotCopy.restartPolicy }}
 {{- include "nuodb.imagePullSecrets" . | indent 10 }}
 ---
-apiVersion: batch/v1beta1
+apiVersion: {{ include "cronjob.apiVersion" . }}
 kind: CronJob
 metadata:
   name: {{ include "hotcopy.cronjob.name" (merge (dict "backupGroup" $backupGroup "hotCopyType" "incremental") . ) }}
@@ -214,7 +214,7 @@ spec:
 
 {{- if eq (include "defaultfalse" .Values.database.sm.hotCopy.journalBackup.enabled) "true" }}
 ---
-apiVersion: batch/v1beta1
+apiVersion: {{ include "cronjob.apiVersion" . }}
 kind: CronJob
 metadata:
   name: {{ include "hotcopy.cronjob.name" (merge (dict "backupGroup" $backupGroup "hotCopyType" "journal") . ) }}


### PR DESCRIPTION
This change conditionally defines the API version for the backup
cronjobs as batch/v1 if kind batch/v1/CronJob is available, and
otherwise falls back to batch/v1beta1.