### PR TITLE
add optional topology spread constraints on TE and SM

### DIFF
--- a/stable/database/templates/deployment.yaml
+++ b/stable/database/templates/deployment.yaml
@@ -37,6 +37,10 @@ spec:
       priorityClassName: {{ default "" .Values.database.priorityClasses.te }}
       {{- end }}
       {{- include "securityContext" . | indent 6 }}
+      {{- if .Values.database.te.topologySpreadConstraints }}
+      topologySpreadConstraints:
+{{ tpl .Values.database.te.topologySpreadConstraints . | trim | indent 8 }}
+      {{- end }}
       {{- with .Values.database.te.nodeSelector }}
       nodeSelector:
 {{ toYaml . | trim | indent 8 }}

--- a/stable/database/templates/statefulset.yaml
+++ b/stable/database/templates/statefulset.yaml
@@ -41,6 +41,10 @@ spec:
       priorityClassName: {{ default "" .Values.database.priorityClasses.sm }}
       {{- end }}
       {{- include "securityContext" . | indent 6 }}
+      {{- if .Values.database.sm.topologySpreadConstraints }}
+      topologySpreadConstraints:
+{{ tpl .Values.database.sm.topologySpreadConstraints . | trim | indent 8 }}
+      {{- end }}
       {{- with .Values.database.sm.nodeSelector }}
       nodeSelector:
 {{ toYaml . | trim | indent 8 }}
@@ -394,6 +398,10 @@ spec:
       priorityClassName: {{ default "" .Values.database.priorityClasses.sm }}
       {{- end }}
       {{- include "securityContext" . | indent 6 }}
+      {{- if .Values.database.sm.topologySpreadConstraints }}
+      topologySpreadConstraints:
+{{ tpl .Values.database.sm.topologySpreadConstraints . | trim | indent 8 }}
+      {{- end }}
       {{- with .Values.database.sm.nodeSelector }}
       nodeSelector:
 {{ toYaml . | trim | indent 8 }}

--- a/stable/database/values.yaml
+++ b/stable/database/values.yaml
@@ -1,4 +1,4 @@
-## Global Docker image parameters
+database/values.yaml## Global Docker image parameters
 ## Please, note that this will override the image parameters, including dependencies, configured to use the global value
 ## Current available global Docker image parameters: imageRegistry and imagePullSecrets
 ##
@@ -414,6 +414,7 @@ database:
     affinity: {}
     # nodeSelector: {}
     # tolerations: []
+    # topologySpreadConstraints: []
     
     ## labels
     # Additional Labels given to the SMs started
@@ -495,6 +496,7 @@ database:
     affinity: {}
     # nodeSelector: {}
     # tolerations: []
+    # topologySpreadConstraints: []
 
     # labels
     # Additional Labels given to the TEs started


### PR DESCRIPTION
added to SM and TE pods the ability to specify topologySpreadConstraints.  This is done similar to affinity where constraints is added as string and then toYaml used.

For example,

    topologySpreadConstraints: |-
      - maxSkew: 1
        topologyKey: topology.kubernetes.io/zone
        whenUnsatisfiable: DoNotSchedule
	labelSelector:
          matchLabels:
            release: {{ .Release.Name | quote }}
            component: sm