### PR TITLE
add checksum to configmap entries that are mapped to volumes in order…

### DIFF
--- a/stable/admin/templates/statefulset.yaml
+++ b/stable/admin/templates/statefulset.yaml
@@ -27,8 +27,15 @@ spec:
   template:
     metadata:
       name: {{ template "admin.fullname" . }}
-      {{- if .Values.admin.podAnnotations }}
       annotations:
+      {{- if .Values.admin.configFiles }}
+        {{- with .Values.admin.configFiles }}
+        checksum/config: {{ toYaml . | sha256sum }}
+        {{- end }}
+      {{- else }}
+        checksum/config: "0"
+      {{- end }}
+      {{- if .Values.admin.podAnnotations }}
 {{ toYaml .Values.admin.podAnnotations | trim | indent 8}}
       {{- end }}
       labels:

--- a/stable/database/templates/deployment.yaml
+++ b/stable/database/templates/deployment.yaml
@@ -24,8 +24,15 @@ spec:
     type: RollingUpdate
   template:
     metadata:
-      {{- if .Values.database.podAnnotations }}
       annotations:
+      {{- if .Values.database.configFiles }}
+        {{- with .Values.database.configFiles }}
+        checksum/config: {{ toYaml . | sha256sum }}
+        {{- end }}
+      {{- else }}
+        checksum/config: "0"
+      {{- end }}
+      {{- if .Values.database.podAnnotations }}
 {{ toYaml .Values.database.podAnnotations | trim | indent 8 }}
       {{- end }}
       labels:

--- a/stable/database/templates/statefulset.yaml
+++ b/stable/database/templates/statefulset.yaml
@@ -26,8 +26,15 @@ spec:
   serviceName: {{ .Values.database.name }}
   template:
     metadata:
-      {{- if .Values.database.podAnnotations }}
       annotations:
+      {{- if .Values.database.configFiles }}
+        {{- with .Values.database.configFiles }}
+        checksum/config: {{ toYaml . | sha256sum }}
+        {{- end }}
+      {{- else }}
+        checksum/config: "0"
+      {{- end }}
+      {{- if .Values.database.podAnnotations }}
 {{ toYaml .Values.database.podAnnotations | trim | indent 8 }}
       {{- end }}
       labels:
@@ -379,8 +386,15 @@ spec:
   serviceName: {{ .Values.database.name }}
   template:
     metadata:
-      {{- if .Values.database.podAnnotations }}
       annotations:
+      {{- if .Values.database.configFiles }}
+        {{- with .Values.database.configFiles }}
+        checksum/config: {{ toYaml . | sha256sum }}
+        {{- end }}
+      {{- else }}
+        checksum/config: "0"
+      {{- end }}
+      {{- if .Values.database.podAnnotations }}
 {{ toYaml .Values.database.podAnnotations | trim | indent 8 }}
       {{- end }}
       labels:


### PR DESCRIPTION
… to do rolling upgrade if configmap is changed.

Add checksum on configuration ConfigMap.  this allows a rolling upgrade of the pods that map this configuration ConfigMap entries as files if any entry in the ConfigMap is changed.