### PR TITLE
added pod topology constraints

### DIFF
--- a/stable/database/README.md
+++ b/stable/database/README.md
@@ -268,6 +268,7 @@ The following tables list the configurable parameters of the `database` chart an
 | `sm.affinity` | Affinity rules for NuoDB SM | `{}` |
 | `sm.nodeSelector` | Node selector rules for NuoDB SM | `{}` |
 | `sm.tolerations` | Tolerations for NuoDB SM | `[]` |
+| `sm.topologySpreadConstraints` | Topology spread constraints for NuoDB SM | `[]` |
 | `sm.readinessTimeoutSeconds` | SM readiness probe timeout, sometimes needs adjusting depending on environment and pod resources | `5` |
 | `te.externalAccess.enabled` | Whether to deploy a Layer 4 service for the database | `false` |
 | `te.externalAccess.internalIP` | Whether to use an internal (to the cloud) or external (public) IP address for the load balancer. Only applies to external access of type `LoadBalancer` | `nil` |
@@ -291,6 +292,7 @@ The following tables list the configurable parameters of the `database` chart an
 | `te.affinity` | Affinity rules for NuoDB TE | `{}` |
 | `te.nodeSelector` | Node selector rules for NuoDB TE | `{}` |
 | `te.tolerations` | Tolerations for NuoDB TE | `[]` |
+| `te.topologySpreadConstraints` | Topology spread constraints for NuoDB TE | `[]` |
 | `te.otherOptions` | Additional key/value Docker options | `{}` |
 | `sm.otherOptions` | Additional key/value Docker options | `{}` |
 | `te.readinessTimeoutSeconds` | TE readiness probe timeout, sometimes needs adjusting depending on environment and pod resources | `5` |

--- a/stable/database/templates/deployment.yaml
+++ b/stable/database/templates/deployment.yaml
@@ -37,6 +37,10 @@ spec:
       priorityClassName: {{ default "" .Values.database.priorityClasses.te }}
       {{- end }}
       {{- include "securityContext" . | indent 6 }}
+      {{- if .Values.database.te.topologySpreadConstraints }}
+      topologySpreadConstraints:
+{{ tpl .Values.database.te.topologySpreadConstraints . | trim | indent 8 }}
+      {{- end }}
       {{- with .Values.database.te.nodeSelector }}
       nodeSelector:
 {{ toYaml . | trim | indent 8 }}

--- a/stable/database/templates/statefulset.yaml
+++ b/stable/database/templates/statefulset.yaml
@@ -41,6 +41,10 @@ spec:
       priorityClassName: {{ default "" .Values.database.priorityClasses.sm }}
       {{- end }}
       {{- include "securityContext" . | indent 6 }}
+      {{- if .Values.database.sm.topologySpreadConstraints }}
+      topologySpreadConstraints:
+{{ tpl .Values.database.sm.topologySpreadConstraints . | trim | indent 8 }}
+      {{- end }}
       {{- with .Values.database.sm.nodeSelector }}
       nodeSelector:
 {{ toYaml . | trim | indent 8 }}
@@ -394,6 +398,10 @@ spec:
       priorityClassName: {{ default "" .Values.database.priorityClasses.sm }}
       {{- end }}
       {{- include "securityContext" . | indent 6 }}
+      {{- if .Values.database.sm.topologySpreadConstraints }}
+      topologySpreadConstraints:
+{{ tpl .Values.database.sm.topologySpreadConstraints . | trim | indent 8 }}
+      {{- end }}
       {{- with .Values.database.sm.nodeSelector }}
       nodeSelector:
 {{ toYaml . | trim | indent 8 }}

--- a/stable/database/values.yaml
+++ b/stable/database/values.yaml
@@ -414,6 +414,7 @@ database:
     affinity: {}
     # nodeSelector: {}
     # tolerations: []
+    # topologySpreadConstraints: []
     
     ## labels
     # Additional Labels given to the SMs started
@@ -495,6 +496,7 @@ database:
     affinity: {}
     # nodeSelector: {}
     # tolerations: []
+    # topologySpreadConstraints: []
 
     # labels
     # Additional Labels given to the TEs started


### PR DESCRIPTION
For Medidata, I added topologySpreadConstraints to TE and SM to allow an even distribution of pods across availability zones.   In order to use:

database:
   te:
     topologySpreadConstraints: |-
      - maxSkew: 1
        topologyKey: topology.kubernetes.io/zone
        whenUnsatisfiable: DoNotSchedule
        labelSelector:
          matchLabels:
            release: {{ .Release.Name | quote }}
            component: te

not that we use `tpl` to format.  this is similar to what is done for affinity.