### PR TITLE
Dbutson/latency check

### DIFF
--- a/stable/database/files/nuolatency.py
+++ b/stable/database/files/nuolatency.py
@@ -20,7 +20,7 @@ def latency_point(host, port = 48004, timeout = 5):
         s.connect((host, int(port)))
         s.shutdown(socket.SHUT_RD)
     except:
-        return 99999
+        raise ValueError("Connection Timeout")
 
     # Stop Timer
     s_runtime = (time() - s_start) * 1000
@@ -28,9 +28,12 @@ def latency_point(host, port = 48004, timeout = 5):
 
 def measure(host,port=48005,runs=9):
     total = 0
-    for n in range(0,runs):
-        total += latency_point(host)
-    return total / float(runs)
+    try:
+        for n in range(0,runs):
+            total += latency_point(host)
+        return total / float(runs)
+    except Value:
+        return 99999
 
 class LatencyCommands(nuodb_cli.AdminCommands):
 

--- a/stable/database/files/nuolatency.py
+++ b/stable/database/files/nuolatency.py
@@ -1,0 +1,54 @@
+import socket, pprint
+from time import time
+
+from pynuoadmin import nuodb_cli
+
+def latency_point(host, port = 48004, timeout = 5):
+    """
+    Calculate a latency point using sockets. If error return large number
+    """
+
+    # New Socket and Time out
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.settimeout(timeout)
+
+    # Start a timer
+    s_start = time()
+
+    # Try to Connect
+    try:
+        s.connect((host, int(port)))
+        s.shutdown(socket.SHUT_RD)
+    except:
+        return 99999
+
+    # Stop Timer
+    s_runtime = (time() - s_start) * 1000
+    return float(s_runtime)
+
+def measure(host,port=48005,runs=9):
+    total = 0
+    for n in range(0,runs):
+        total += latency_point(host)
+    return total / float(runs)
+
+class LatencyCommands(nuodb_cli.AdminCommands):
+
+    @nuodb_cli.subcommand
+    def find_closest_admin(self):
+        """
+        Find the closest (based upon latency) admin process.  This should be in same zone
+        """
+
+        closest = None
+        closest_measurement = 99999
+        
+        for s in self.conn._get_all('peers'):
+            addr = s['address']
+            host,port = addr.split(":")
+            measurement = measure(host,int(port))
+            if measurement < closest_measurement:
+                closest = s['id']
+                closest_measurement = measurement
+        print(closest)
+        return closest

--- a/stable/database/files/nuosm
+++ b/stable/database/files/nuosm
@@ -812,12 +812,26 @@ nuodocker_flags=()
 
 nuoserver=()
 if [ -e /usr/local/bin/nuolatency.py ] ; then
-    server_id=$(NUOCMD_PLUGINS=/usr/local/bin/nuolatency.py nuocmd find closest-admin)
-    if [ "${server_id}" != "" ] ; then
-	nuoserver+=("--server-id" $server_id)
-	trace "Use closest admin server: ${server_id}"
-    fi
+    for ((i=1;i<$#;i++)); do
+	if [ "${!i}" == "--admin-distribution-policy" ] ; then
+            j=$((i+1))
+            if [ "${!j}" == "closest" ] ; then
+		server_id=$(NUOCMD_PLUGINS=/usr/local/bin/nuolatency.py nuocmd find closest-admin)
+		if [ "${server_id}" != "" ] ; then
+                    nuoserver+=("--server-id" $server_id)
+                    # when passing server-id to nuodocker admin-distribution-policy is ignored so
+                    # we don't have to remove it from $@.
+		fi
+            fi
+	fi
+	if [ "${!i}" == "--server-id" ] ; then
+            # since server-id passed as argument we don't override it.
+            nuoserver=()
+            break
+	fi
+    done
 fi
+
 
 # expects NUOCMD_API_SERVER to be set.
 if [ -n "${NUODB_OPTIONS}" ] ; then

--- a/stable/database/files/nuosm
+++ b/stable/database/files/nuosm
@@ -810,9 +810,18 @@ trace "executing nuodocker to start SM"
 nuodocker_flags=()
 [ -n "$NUODB_DEBUG" ] && nuodocker_flags+=("--debug")
 
+nuoserver=()
+if [ -e /usr/local/bin/nuolatency.py ] ; then
+    server_id=$(NUOCMD_PLUGINS=/usr/local/bin/nuolatency.py nuocmd find closest-admin)
+    if [ "${server_id}" != "" ] ; then
+	nuoserver+=("--server-id" $server_id)
+	trace "Use closest admin server: ${server_id}"
+    fi
+fi
+
 # expects NUOCMD_API_SERVER to be set.
 if [ -n "${NUODB_OPTIONS}" ] ; then
-    exec nuodocker "${nuodocker_flags[@]}" start sm --archive-dir "${DB_DIR}" "${journal_flags[@]}" --dba-user "${DB_USER}" --dba-password "${DB_PASSWORD}" --db-name "${DB_NAME}" --options "${NUODB_OPTIONS}" "$@"
+    exec nuodocker "${nuodocker_flags[@]}" start sm --archive-dir "${DB_DIR}" "${journal_flags[@]}" --dba-user "${DB_USER}" --dba-password "${DB_PASSWORD}" --db-name "${DB_NAME}" --options "${NUODB_OPTIONS}" "${nuoserver[@]}" "$@"
 else
-    exec nuodocker "${nuodocker_flags[@]}" start sm --archive-dir "${DB_DIR}" "${journal_flags[@]}" --dba-user "${DB_USER}" --dba-password "${DB_PASSWORD}" --db-name "${DB_NAME}" "$@"
+    exec nuodocker "${nuodocker_flags[@]}" start sm --archive-dir "${DB_DIR}" "${journal_flags[@]}" --dba-user "${DB_USER}" --dba-password "${DB_PASSWORD}" --db-name "${DB_NAME}" "${nuoserver[@]}"  "$@"
 fi

--- a/stable/database/files/nuosm
+++ b/stable/database/files/nuosm
@@ -811,27 +811,16 @@ nuodocker_flags=()
 [ -n "$NUODB_DEBUG" ] && nuodocker_flags+=("--debug")
 
 nuoserver=()
-if [ -e /usr/local/bin/nuolatency.py ] ; then
-    for ((i=1;i<$#;i++)); do
-	if [ "${!i}" == "--admin-distribution-policy" ] ; then
-            j=$((i+1))
-            if [ "${!j}" == "closest" ] ; then
-		server_id=$(NUOCMD_PLUGINS=/usr/local/bin/nuolatency.py nuocmd find closest-admin)
-		if [ "${server_id}" != "" ] ; then
-                    nuoserver+=("--server-id" $server_id)
-                    # when passing server-id to nuodocker admin-distribution-policy is ignored so
-                    # we don't have to remove it from $@.
-		fi
-            fi
+if [ "${NUOADMIN_DISTRIBUTION_POLICY}" == "nearest" ] ; then
+    if [ -e /usr/local/bin/nuolatency.py ] ; then
+	server_id=$(NUOCMD_PLUGINS=/usr/local/bin/nuolatency.py nuocmd find closest-admin)
+	if [ "${server_id}" != "" ] ; then
+            nuoserver=("--server-id" $server_id)
 	fi
-	if [ "${!i}" == "--server-id" ] ; then
-            # since server-id passed as argument we don't override it.
-            nuoserver=()
-            break
-	fi
-    done
+    fi
+elif [ "${NUOADMIN_DISTRIBUTION_POLICY}" != "" ] ; then
+    nuoserver=( "--admin-distribution-policy" "{NUOADMIN_DISTRIBUTION_POLICY}" )
 fi
-
 
 # expects NUOCMD_API_SERVER to be set.
 if [ -n "${NUODB_OPTIONS}" ] ; then

--- a/stable/database/files/nuote
+++ b/stable/database/files/nuote
@@ -22,12 +22,26 @@ nuodocker_flags=()
 
 nuoserver=()
 if [ -e /usr/local/bin/nuolatency.py ] ; then
-    server_id=$(NUOCMD_PLUGINS=/usr/local/bin/nuolatency.py nuocmd find closest-admin)
-    if [ "${server_id}" != "" ] ; then
-	nuoserver+=("--server-id" $server_id)
-	trace "Use closest admin server: ${server_id}"
-    fi
+    for ((i=1;i<$#;i++)); do
+	if [ "${!i}" == "--admin-distribution-policy" ] ; then
+            j=$((i+1))
+            if [ "${!j}" == "closest" ] ; then
+		server_id=$(NUOCMD_PLUGINS=/usr/local/bin/nuolatency.py nuocmd find closest-admin)
+		if [ "${server_id}" != "" ] ; then
+                    nuoserver+=("--server-id" $server_id)
+                    # when passing server-id to nuodocker admin-distribution-policy is ignored so
+                    # we don't have to remove it from $@.
+		fi
+            fi
+	fi
+	if [ "${!i}" == "--server-id" ] ; then
+            # since server-id passed as argument we don't override it.
+            nuoserver=()
+            break
+	fi
+    done
 fi
+
     
 # expects NUOCMD_API_SERVER to be set.
 if [ -n "${NUODB_OPTIONS}" ] ; then

--- a/stable/database/files/nuote
+++ b/stable/database/files/nuote
@@ -21,25 +21,15 @@ nuodocker_flags=()
 [ -n "$NUODB_DEBUG" ] && nuodocker_flags+=("--debug")
 
 nuoserver=()
-if [ -e /usr/local/bin/nuolatency.py ] ; then
-    for ((i=1;i<$#;i++)); do
-	if [ "${!i}" == "--admin-distribution-policy" ] ; then
-            j=$((i+1))
-            if [ "${!j}" == "closest" ] ; then
-		server_id=$(NUOCMD_PLUGINS=/usr/local/bin/nuolatency.py nuocmd find closest-admin)
-		if [ "${server_id}" != "" ] ; then
-                    nuoserver+=("--server-id" $server_id)
-                    # when passing server-id to nuodocker admin-distribution-policy is ignored so
-                    # we don't have to remove it from $@.
-		fi
-            fi
+if [ "${NUOADMIN_DISTRIBUTION_POLICY}" == "nearest" ] ; then
+    if [ -e /usr/local/bin/nuolatency.py ] ; then
+	server_id=$(NUOCMD_PLUGINS=/usr/local/bin/nuolatency.py nuocmd find closest-admin)
+	if [ "${server_id}" != "" ] ; then
+            nuoserver+=("--server-id" $server_id)
 	fi
-	if [ "${!i}" == "--server-id" ] ; then
-            # since server-id passed as argument we don't override it.
-            nuoserver=()
-            break
-	fi
-    done
+    fi
+elif [ "${NUOADMIN_DISTRIBUTION_POLICY}" != "" ] ; then
+    nuoserver = ( "--admin-distribution-policy" "{NUOADMIN_DISTRIBUTION_POLICY}" )
 fi
 
     

--- a/stable/database/files/nuote
+++ b/stable/database/files/nuote
@@ -25,11 +25,11 @@ if [ "${NUOADMIN_DISTRIBUTION_POLICY}" == "nearest" ] ; then
     if [ -e /usr/local/bin/nuolatency.py ] ; then
 	server_id=$(NUOCMD_PLUGINS=/usr/local/bin/nuolatency.py nuocmd find closest-admin)
 	if [ "${server_id}" != "" ] ; then
-            nuoserver+=("--server-id" $server_id)
+            nuoserver=("--server-id" $server_id)
 	fi
     fi
 elif [ "${NUOADMIN_DISTRIBUTION_POLICY}" != "" ] ; then
-    nuoserver = ( "--admin-distribution-policy" "{NUOADMIN_DISTRIBUTION_POLICY}" )
+    nuoserver=( "--admin-distribution-policy" "{NUOADMIN_DISTRIBUTION_POLICY}" )
 fi
 
     

--- a/stable/database/files/nuote
+++ b/stable/database/files/nuote
@@ -20,9 +20,18 @@ fi
 nuodocker_flags=()
 [ -n "$NUODB_DEBUG" ] && nuodocker_flags+=("--debug")
 
+nuoserver=()
+if [ -e /usr/local/bin/nuolatency.py ] ; then
+    server_id=$(NUOCMD_PLUGINS=/usr/local/bin/nuolatency.py nuocmd find closest-admin)
+    if [ "${server_id}" != "" ] ; then
+	nuoserver+=("--server-id" $server_id)
+	trace "Use closest admin server: ${server_id}"
+    fi
+fi
+    
 # expects NUOCMD_API_SERVER to be set.
 if [ -n "${NUODB_OPTIONS}" ] ; then
-    exec nuodocker "${nuodocker_flags[@]}" start te --db-name "${DB_NAME}" --options "${NUODB_OPTIONS}" "$@"
+    exec nuodocker "${nuodocker_flags[@]}" start te --db-name "${DB_NAME}" --options "${NUODB_OPTIONS}" "${nuoserver[@]}" "$@"
 else
-    exec nuodocker "${nuodocker_flags[@]}" start te --db-name "${DB_NAME}" "$@"
+    exec nuodocker "${nuodocker_flags[@]}" start te --db-name "${DB_NAME}" "${nuoserver[@]}" "$@"
 fi

--- a/stable/database/templates/configmap.yaml
+++ b/stable/database/templates/configmap.yaml
@@ -7,6 +7,17 @@ metadata:
   name: {{ template "database.fullname" . }}-nuote
 data:
 {{ (.Files.Glob "files/nuote").AsConfig | indent 2 }}
+{{- if eq (include "defaulttrue" .Values.database.primaryRelease) "true" }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    {{- include "database.resourceLabels" . | nindent 4 }}
+  name: {{ template "database.fullname" . }}-nuolatency
+data:
+{{ (.Files.Glob "files/nuolatency.py").AsConfig | indent 2 }}
+{{- end }}
 {{/* 
   Remove this conditional rendering when support for storage groups is added
 */}}

--- a/stable/database/templates/deployment.yaml
+++ b/stable/database/templates/deployment.yaml
@@ -129,6 +129,9 @@ spec:
         {{- end }}
         - name: log-volume
           mountPath: /var/log/nuodb
+        - name: nuolatency
+          mountPath: /usr/local/bin/nuolatency.py
+          subPath: nuolatency.py
         - name: nuote
           mountPath: /usr/local/bin/nuote
           subPath: nuote
@@ -175,6 +178,10 @@ spec:
           persistentVolumeClaim:
             claimName: {{ template "database.fullname" . }}-log-te-volume
         {{- end }}
+        - name: nuolatency
+          configMap:
+            name: {{ template "database.fullname" . }}-nuolatency
+            defaultMode: 0644
         - name: nuote
           configMap:
             name: {{ template "database.fullname" . }}-nuote

--- a/stable/database/templates/statefulset.yaml
+++ b/stable/database/templates/statefulset.yaml
@@ -173,6 +173,9 @@ spec:
         {{- end }}
         - name: log-volume
           mountPath: /var/log/nuodb
+        - name: nuolatency
+          mountPath: /usr/local/bin/nuolatency.py
+          subPath: nuolatency.py
         - name: nuosm
           mountPath: /usr/local/bin/nuosm
           subPath: nuosm
@@ -240,6 +243,10 @@ spec:
       - name: log-volume
         emptyDir: {}
       {{- end }}
+      - name: nuolatency
+        configMap:
+          name: {{ template "database.fullname" . }}-nuolatency
+          defaultMode: 0644
       - name: nuosm
         configMap:
           name: {{ template "database.fullname" . }}-nuosm
@@ -528,6 +535,9 @@ spec:
         {{- end }}
         - name: log-volume
           mountPath: /var/log/nuodb
+        - name: nuolatency
+          mountPath: /usr/local/bin/nuolatency.py
+          subPath: nuolatency.py
         - name: nuosm
           mountPath: /usr/local/bin/nuosm
           subPath: nuosm
@@ -597,6 +607,10 @@ spec:
       - name: log-volume
         emptyDir: {}
       {{- end }}
+      - name: nuolatency
+        configMap:
+          name: {{ template "database.fullname" . }}-nuolatency
+          defaultMode: 0644
       - name: nuosm
         configMap:
           name: {{ template "database.fullname" . }}-nuosm


### PR DESCRIPTION
allows via env variable (NUOADMIN_DISTRIBUTION_POLICY) to set --admin-distribution-policy when calling docker start sm (nuosm) or docker start te (nuote).   This variable is currently also used in (nuote and nuosm) to instead find nearest admin and set server-id.  This code nuolatency.py should probably be in nuodocker as a distribution policy.  But for now is a handled in helm scripting (nuodocker requires change to image or cloning of nuodocker.py)