### PR TITLE
Dbutson/label volumes

### DIFF
--- a/stable/admin/templates/statefulset.yaml
+++ b/stable/admin/templates/statefulset.yaml
@@ -1,4 +1,4 @@
-apiVersion: "apps/v1"
+admin/templates/statefulset.yamlapiVersion: "apps/v1"
 kind: StatefulSet
 metadata:
   annotations:
@@ -251,6 +251,7 @@ spec:
   - metadata:
       name: raftlog
       labels:
+        use: raftlog-volume
         {{- include "admin.resourceLabels" . | nindent 8 }}
     spec:
     {{- if .Values.admin.persistence.storageClass }}
@@ -271,6 +272,7 @@ spec:
   - metadata:
       name: log-volume
       labels:
+        use: log-volume
         {{- include "admin.resourceLabels" . | nindent 8 }}
     spec:
     {{- if .Values.admin.logPersistence.storageClass }}

--- a/stable/admin/templates/statefulset.yaml
+++ b/stable/admin/templates/statefulset.yaml
@@ -1,4 +1,4 @@
-admin/templates/statefulset.yamlapiVersion: "apps/v1"
+apiVersion: "apps/v1"
 kind: StatefulSet
 metadata:
   annotations:

--- a/stable/database/templates/cronjob.yaml
+++ b/stable/database/templates/cronjob.yaml
@@ -242,7 +242,6 @@ metadata:
     {{- include "database.resourceLabels" . | nindent 4 }}
     subgroup: backup
     backup-group: {{ $backupGroup }}
-    backup-group-labels: "{{ $backupGroupLabels }}"
 spec:
   schedule: {{ include "hotcopy.group.schedule" (merge (dict "backupGroup" $backupGroup "hotCopyType" "journal") . ) }}
   startingDeadlineSeconds: {{ .Values.database.sm.hotCopy.journalBackup.deadline }}

--- a/stable/database/templates/cronjob.yaml
+++ b/stable/database/templates/cronjob.yaml
@@ -29,12 +29,23 @@ spec:
   failedJobsHistoryLimit: {{ .Values.database.sm.hotCopy.failureHistory}}
   jobTemplate:
     metadata:
+      annotations:
+        backup-group-labels: "{{ $backupGroupLabels }}"
+        operation: full-hotcopy
       labels:
         {{- include "database.resourceLabels" . | nindent 8 }}
         subgroup: backup
         backup-group: {{ $backupGroup }}
     spec:
       template:
+        metadata:
+          annotations:
+            backup-group-labels: "{{ $backupGroupLabels }}"
+            operation: full-hotcopy
+          labels:
+            {{- include "database.resourceLabels" . | nindent 12 }}
+            subgroup: backup
+            backup-group: {{ $backupGroup }}
         spec:
           {{- include "securityContext" . | indent 10 }}
           containers:
@@ -119,6 +130,9 @@ apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
   name: {{ include "hotcopy.cronjob.name" (merge (dict "backupGroup" $backupGroup "hotCopyType" "incremental") . ) }}
+  annotations:
+    backup-group-labels: "{{ $backupGroupLabels }}"
+    operation: full-hotcopy
   labels:
     {{- include "database.resourceLabels" . | nindent 4 }}
     subgroup: backup
@@ -130,6 +144,9 @@ spec:
   failedJobsHistoryLimit: {{ .Values.database.sm.hotCopy.failureHistory}}
   jobTemplate:
     metadata:
+      annotations:
+        backup-group-labels: "{{ $backupGroupLabels }}"
+        operation: incremental-hotcopy
       labels:
         {{- include "database.resourceLabels" . | nindent 8 }}
         subgroup: backup
@@ -218,10 +235,14 @@ apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
   name: {{ include "hotcopy.cronjob.name" (merge (dict "backupGroup" $backupGroup "hotCopyType" "journal") . ) }}
+  annotations:
+    backup-group-labels: "{{ $backupGroupLabels }}"
+    operation: journal-hotcopy
   labels:
     {{- include "database.resourceLabels" . | nindent 4 }}
     subgroup: backup
-    backup-group: {{ $backupGroup }} 
+    backup-group: {{ $backupGroup }}
+    backup-group-labels: "{{ $backupGroupLabels }}"
 spec:
   schedule: {{ include "hotcopy.group.schedule" (merge (dict "backupGroup" $backupGroup "hotCopyType" "journal") . ) }}
   startingDeadlineSeconds: {{ .Values.database.sm.hotCopy.journalBackup.deadline }}
@@ -235,6 +256,14 @@ spec:
         backup-group: {{ $backupGroup }}
     spec:
       template:
+        metadata:
+          annotations:
+            backup-group-labels: "{{ $backupGroupLabels }}"
+            operation: journal-hotcopy
+          labels:
+            {{- include "database.resourceLabels" . | nindent 12 }}
+            subgroup: backup
+            backup-group: "{{ $backupGroup }}"
         spec:
           {{- include "securityContext" . | indent 10 }}
           containers:

--- a/stable/database/templates/statefulset.yaml
+++ b/stable/database/templates/statefulset.yaml
@@ -287,6 +287,7 @@ spec:
   - metadata:
       name: archive-volume
       labels:
+        use: archive-volume
         {{- include "database.resourceLabels" . | nindent 8 }}
     spec:
       accessModes:
@@ -312,6 +313,7 @@ spec:
   - metadata:
       name: journal-volume
       labels:
+        use: journal-volume
         {{- include "database.resourceLabels" . | nindent 8 }}
     spec:
       accessModes:
@@ -338,6 +340,7 @@ spec:
   - metadata:
       name: log-volume
       labels:
+        use: log-volume
         {{- include "database.resourceLabels" . | nindent 8 }}
     spec:
       accessModes:
@@ -644,6 +647,7 @@ spec:
   - metadata:
       name: archive-volume
       labels:
+        use: archive-volume
         {{- include "database.resourceLabels" . | nindent 8 }}
     spec:
       accessModes:
@@ -669,6 +673,7 @@ spec:
   - metadata:
       name: journal-volume
       labels:
+        use: journal-volume
         {{- include "database.resourceLabels" . | nindent 8 }}
     spec:
       accessModes:
@@ -694,6 +699,8 @@ spec:
   - metadata:
       name: backup-volume
       labels:
+        use: backup-volume
+        groupPrefix: "{{- include "hotcopy.groupPrefix" . }}"
         {{- include "database.resourceLabels" . | nindent 8 }}
     spec:
       accessModes:
@@ -714,6 +721,7 @@ spec:
   - metadata:
       name: log-volume
       labels:
+        use: log-volume
         {{- include "database.resourceLabels" . | nindent 8 }}
     spec:
       accessModes:


### PR DESCRIPTION
add use label to pvc.  not necessarily needed but,  felt it would be useful.   Also added label to backup volume to associate with backup group.  Added annotations and labels to backup cronjobs.  All of this is done to assist in watching for backup jobs to complete and being able to snapshot volumes on completion of backup job. 