### PR TITLE
add annotation to job as method to record what was backed up.

### DIFF
--- a/stable/database/templates/cronjob.yaml
+++ b/stable/database/templates/cronjob.yaml
@@ -29,10 +29,14 @@ spec:
   failedJobsHistoryLimit: {{ .Values.database.sm.hotCopy.failureHistory}}
   jobTemplate:
     metadata:
+      annotations:
+        operation: full-hotcopy
+        backup-group-labels: "{{ $backupGroupLabels }}"
       labels:
         {{- include "database.resourceLabels" . | nindent 8 }}
         subgroup: backup
         backup-group: {{ $backupGroup }}
+        
     spec:
       template:
         spec:
@@ -130,6 +134,9 @@ spec:
   failedJobsHistoryLimit: {{ .Values.database.sm.hotCopy.failureHistory}}
   jobTemplate:
     metadata:
+      annotations:
+        operation: incremental-hotcopy
+        backup-group-labels: "{{ $backupGroupLabels }}"
       labels:
         {{- include "database.resourceLabels" . | nindent 8 }}
         subgroup: backup
@@ -229,6 +236,9 @@ spec:
   failedJobsHistoryLimit: {{ .Values.database.sm.hotCopy.failureHistory }}
   jobTemplate:
     metadata:
+      annotations:
+        operation: journal-hotcopy
+        backup-group-labels: "{{ $backupGroupLabels }}"
       labels:
         {{- include "database.resourceLabels" . | nindent 8 }}
         subgroup: backup


### PR DESCRIPTION
This seems to be all that is needed for the backup manager.   I've added annotations to the jobTemplate spec for backup to record type of backup performed and the backupGroupLabels used.