### PR TITLE
Retry requests proxied by Ingress controller

### DIFF
--- a/test/testlib/minikube_utilities.go
+++ b/test/testlib/minikube_utilities.go
@@ -1370,3 +1370,15 @@ func RemoveOrphanNamespaces(t *testing.T) {
 		}
 	}
 }
+
+func Retry(t *testing.T, fn func() error, attempts int, interval time.Duration) error {
+	if err := fn(); err != nil {
+		t.Logf("Retrying because of error: %s", err.Error())
+		if attempts--; attempts > 0 {
+			time.Sleep(interval)
+			return Retry(t, fn, attempts, 2*interval)
+		}
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
`TestKubernetesIngress` test has been flaky due to HAProxy reconfiguration.

```
TestKubernetesIngress 2022-06-03T00:58:25-04:00 logger.go:66: Defaulted container "admin" out of: admin, init-disk (init)
    minikube_external_access_test.go:113: Running command: </home/build/BUILDDIR/MASTER-NH-JOB1/dist/bin/nuocmd --api-server https://api.nuodb.local:30403 --client-key /home/build/BUILDDIR/MASTER-NH-JOB1/tmp/tmp/tls-keys2353524482/nuocmd.pem --verify-server /home/build/BUILDDIR/MASTER-NH-JOB1/tmp/tmp/tls-keys2353524482/ca.cert --show-json get processes --db-name demo>
    minikube_external_access_test.go:118: 
        	Error Trace:	minikube_external_access_test.go:118
        	            				minikube_external_access_test.go:335
        	Error:      	Received unexpected error:
        	            	exit status 1
        	Test:       	TestKubernetesIngress
        	Messages:   	Unable to connect to https://api.nuodb.local:30403: ('Connection aborted.', error(0, 'Error'))
```