### PR TITLE
this patch,  checks if downloaded tarbar is actually an archive inste…

### DIFF
--- a/stable/database/files/nuosm
+++ b/stable/database/files/nuosm
@@ -268,6 +268,16 @@ function perform_restore() {
 
     # restore data and/or fix the metadata
     log "restoring archive and/or clearing restored archive physical metadata"
+
+    if [ "$download_dir" != "$DB_DIR" ] ; then
+       # if not backup set then rename $download_dir to $DB_DIR.
+       if test -f "$download_dir/1.atm" ; then
+          rm -rf $DB_DIR
+	  mv $download_dir $DB_DIR
+	  download_dir=$DB_DIR
+       fi
+    fi
+
     status="$(nuodocker restore archive \
       --origin-dir $download_dir \
       "${journal_flags[@]}" \

--- a/stable/database/files/nuosm
+++ b/stable/database/files/nuosm
@@ -272,7 +272,7 @@ function perform_restore() {
     # if download is an archive, and not a backup then rename $download_dir to $DB_DIR
     # as if download was streamed instead.
     if [ "$restore_type" != "stream" ] && [ -f "$download_dir/1.atm" ];
-       rm -rf $DB_DIR
+       rmdir $DB_DIR
        mv $download_dir $DB_DIR
        download_dir=$DB_DIR
     fi

--- a/stable/database/files/nuosm
+++ b/stable/database/files/nuosm
@@ -269,13 +269,12 @@ function perform_restore() {
     # restore data and/or fix the metadata
     log "restoring archive and/or clearing restored archive physical metadata"
 
-    if [ "$download_dir" != "$DB_DIR" ] ; then
-       # if not backup set then rename $download_dir to $DB_DIR.
-       if test -f "$download_dir/1.atm" ; then
-          rm -rf $DB_DIR
-	  mv $download_dir $DB_DIR
-	  download_dir=$DB_DIR
-       fi
+    # if download is an archive, and not a backup then rename $download_dir to $DB_DIR
+    # as if download was streamed instead.
+    if [ "$restore_type" != "stream" ] && [ -f "$download_dir/1.atm" ];
+       rm -rf $DB_DIR
+       mv $download_dir $DB_DIR
+       download_dir=$DB_DIR
     fi
 
     status="$(nuodocker restore archive \


### PR DESCRIPTION
…ad of backupset.  if so then it just renames the directory as if it streamed the data.  So no need for source_type although it is there for backward compatiability.   This code might be better in nuodocker.py instead of the copy_tree that is done today.  But, it is easier to change here.

This is another change that I'm making for Medidata.   performance of stream / backupset for sftp.  Was / is based upon nuodocker.py doing a copy_tree for nonbackupsets when origin-dir and restore-dir are different.  This avoids that by always having origin-dir and restore-dir being the same for archive restores.  by using backupset and checking if tar uncompressed is actually an archive instead and if then renaming the download directory to DB_DIR.  since they are both off of DB_PARENTDIR  the rename is quick just inode change for top directory.