### PR TITLE
Update TestAdminScaleDown to delete PVC before checking for Raft leader

### DIFF
--- a/test/minikube/minikube_base_database_test.go
+++ b/test/minikube/minikube_base_database_test.go
@@ -338,7 +338,7 @@ func TestKubernetesStartDatabaseShrinkedAdmin(t *testing.T) {
 	k8s.RunKubectl(t, kubectlOptions, "scale", "statefulset", admin, "--replicas=2")
 	admin2 := admin + "-2"
 	testlib.AwaitServerState(
-		t, namespaceName, admin0, admin2, "Disconnected", true, 60*time.Second)
+		t, namespaceName, admin0, admin2, "Disconnected", 60*time.Second)
 	k8s.RunKubectl(t, kubectlOptions, "delete", "pvc", "raftlog-"+admin2)
 
 	testlib.AwaitNrReplicasReady(t, namespaceName, admin, 2)

--- a/test/minikube/minikube_base_database_test.go
+++ b/test/minikube/minikube_base_database_test.go
@@ -334,10 +334,13 @@ func TestKubernetesStartDatabaseShrinkedAdmin(t *testing.T) {
 		testlib.DescribePods(t, namespaceName, admin)
 	})
 
-	// scale down the APs to 2; KAA will automatically evict the shut down AP
+	// scale down the APs to 2 and delete PVC for scaled down AP; KAA will automatically shrink membership to 2
 	k8s.RunKubectl(t, kubectlOptions, "scale", "statefulset", admin, "--replicas=2")
+	admin2 := admin + "-2"
 	testlib.AwaitServerState(
-		t, namespaceName, admin0, fmt.Sprintf("%s-2", admin), "Disconnected", true, 60*time.Second)
+		t, namespaceName, admin0, admin2, "Disconnected", true, 60*time.Second)
+	k8s.RunKubectl(t, kubectlOptions, "delete", "pvc", "raftlog-"+admin2)
+
 	testlib.AwaitNrReplicasReady(t, namespaceName, admin, 2)
 	// restart the current leader to bounce it
 	leader := testlib.AwaitDomainLeader(t, namespaceName, admin0, 60*time.Second)

--- a/test/testlib/nuodb_admin_utilities.go
+++ b/test/testlib/nuodb_admin_utilities.go
@@ -251,15 +251,14 @@ func AwaitDomainLeader(t *testing.T, namespace string, adminPod string, timeout 
 }
 
 func AwaitServerState(t *testing.T, namespace string, adminPod string,
-	serverId string, expectedState string, evicted bool, timeout time.Duration) {
+	serverId string, expectedState string, timeout time.Duration) {
 	Await(t, func() bool {
 		servers, err := GetDomainServersE(t, namespace, adminPod)
 		if err != nil {
 			return false
 		}
 		if server, ok := servers[serverId]; ok &&
-			server.ConnectedState.State == expectedState &&
-			server.IsEvicted == evicted {
+			server.ConnectedState.State == expectedState {
 			return true
 		}
 		return false


### PR DESCRIPTION
Deletion of the PVC for the scaled down APs will become a requirement for future versions of the product. This change updates TestAdminScaleDown so that it works with the new behavior, and also the existing behavior, which applies the consensus override immediately after the pod is deleted after being scaled down.