### PR TITLE
Incremental backup after SM restart fails if the previous full was unsuccessful

### DIFF
--- a/stable/database/files/nuobackup
+++ b/stable/database/files/nuobackup
@@ -157,7 +157,7 @@ function full_exist() {
       --labels "${labels}" 2>&1)"
    if [ $? -ne 0 ] && echo "$error" | grep -q "No existing backup path found"; then
       # Check if full backup has been started already for all archiveIds. It
-      # won't be the case in the following scenarious:
+      # won't be the case in the following scenarios:
       # * initial database backup request
       # * backup request after the database have been restored
       # * new HC SM has been started in the backup group since the last full

--- a/stable/database/files/nuobackup
+++ b/stable/database/files/nuobackup
@@ -42,6 +42,7 @@ labels=""
 timeout=""
 backup_root=$BACKUP_DIR
 retry_failed="True"
+backup_database_output=""
 
 function get_current_backup() {
    output=$( nuodocker get current-backup \
@@ -56,7 +57,6 @@ function execute_backup() {
    local current
    local next
    local backupset
-   local output
    local failed
    local pods
 
@@ -65,7 +65,7 @@ function execute_backup() {
 
    # call nuodocker to perform the actual backup
    echo "Starting ${type} backup for database ${db_name} on processes with labels '${labels}' ..."
-   output=$(nuodocker backup database \
+   backup_database_output=$(nuodocker backup database \
       --db-name "${db_name}" \
       --type "${type}" \
       --backup-root "${backup_root}" \
@@ -73,7 +73,7 @@ function execute_backup() {
       "${extra_flags[@]}" 2>&1)
 
    retval=$?
-   echo "$output"
+   echo "$backup_database_output"
    if [ $retval != 0 ]; then
       echo >&2 "Error running hotcopy $retval"
       # Store failed backupset in KV store
@@ -85,17 +85,6 @@ function execute_backup() {
                --key "$NUODB_BACKUP_KEY/$db_name/${backup_group}/failed" \
                --value "${failed} ${backupset}" --expected-value "${failed}"
          fi
-      fi
-      if [ -n "$retry_failed" ] && [ "$type" = "journal" ] && echo "$output" | grep -q "Full or incremental hot copy must be completed before journal hot copy"; then
-         # journal hot copy has been temporarly suspended due to archive sync;
-         # perform incremental first and once completed retry the journal hot
-         # copy
-         retry_failed=""
-         echo "Executing incremental hot copy as journal hot copy is temporarily suspended"
-         execute_backup "incremental" || return $?
-         # retry the journal backup which should succeed now
-         execute_backup "journal"
-         retval=$?
       fi
       return $retval
    fi
@@ -158,6 +147,80 @@ function execute_backup() {
       # update the backup group that performed the latest backup
       latest=$( nuocmd get value --key "$NUODB_BACKUP_KEY/$db_name/latest" )
       nuocmd set value --key "$NUODB_BACKUP_KEY/$db_name/latest" --value "$backup_group" --expected-value "$latest"
+   fi
+}
+
+function full_exist() {
+   local error
+
+   error="$( nuodocker get current-backup \
+      --db-name "${db_name}" \
+      --labels "${labels}" 2>&1)"
+   if [ $? -ne 0 ] && echo "$error" | grep -q "No existing backup path found"; then
+      # Check if full backup has been started already for all archiveIds. It
+      # won't be the case in the following scenarious:
+      # * initial database backup request
+      # * backup request after the database have been restored
+      # * new HC SM has been started in the backup group since the last full
+      #   backup
+      # * the backup group selection has been changed
+      return 1
+   fi
+   return 0
+}
+
+function last_full_failed() {
+   local backupset
+   local failed
+
+   backupset=$(get_current_backup)
+   failed=$(nuocmd get value --key "$NUODB_BACKUP_KEY/$db_name/${backup_group}/failed")
+   if [ -n "$backupset" ] && echo "$failed" | grep -q "${backupset}"; then
+      return 0
+   fi
+   return 1
+}
+
+function execute_full() {
+   execute_backup "full"
+}
+
+function execute_incremental() {
+   local backupset
+
+   if ! full_exist; then
+      echo "Executing full hotcopy as a prerequisite for incremental hotcopy"
+      execute_full
+   elif last_full_failed; then
+      # Incremental hotcopy requires a full hotcopy element in the backupset;
+      # in case the full hotcopy has failed, all incrementals using that
+      # backupset will fail until next full hotcopy is scheduled; if the
+      # failure is transient or user corrected the problem (like freeing some
+      # disk space), then executing another full will have a great chance to
+      # finish
+      backupset=$(get_current_backup)
+      echo "Executing full hotcopy as a prerequisite for incremental hotcopy: full hotcopy in backupset ${backupset} has failed"
+      execute_full
+   else
+      execute_backup "incremental"
+   fi
+}
+
+function execute_journal() {
+   if ! full_exist; then
+      echo "Executing full hotcopy as a prerequisite for journal hotcopy"
+      execute_full
+   else 
+      execute_backup "journal"
+      if [ -n "$retry_failed" ] && echo "$backup_database_output" | grep -q "Full or incremental hot copy must be completed before journal hot copy"; then
+         # journal hot copy has been temporarly suspended due to archive sync;
+         # perform incremental hot copy first
+         retry_failed=""
+         echo "Executing incremental hot copy as journal hot copy is temporarily suspended"
+         execute_incremental || return $?
+         # retry the journal backup which should succeed now
+         execute_journal
+      fi
    fi
 }
 
@@ -241,35 +304,10 @@ elif [ "$backup_type" = "report-backups" ]; then
    exit 0
 fi
 
-if [ "$backup_type" != "full" ]; then
-   error="$( nuodocker get current-backup \
-      --db-name "${db_name}" \
-      --labels "${labels}" 2>&1)"
-   if [ $? -ne 0 ] && echo "$error" | grep -q "No existing backup path found"; then
-      # Check if full backup has been started already for all archiveIds
-      # This will most likely execute in the following scenarious:
-      # * initial database backup request
-      # * backup request after the database have been restored
-      # * new HC SM has been started since the last full backup
-      echo "Executing full hotcopy as a prerequisite for ${backup_type} hotcopy: ${error}"
-      execute_backup "full"
-   fi
-
-   if [ "$backup_type" == "incremental" ] && [ -n "$backup_group" ]; then
-      backupset=$(get_current_backup)
-      failed=$(nuocmd get value --key "$NUODB_BACKUP_KEY/$db_name/${backup_group}/failed")
-      if [ -n "$backupset" ] && echo "$failed" | grep -q "${backupset}"; then
-         # Incremental hotcopy requires a full hotcopy element in the backupset;
-         # in case the full hotcopy has failed, all incrementals using that
-         # backupset will fail until next full hotcopy is scheduled; if the
-         # failure is transient or user corrected the problem (like freeing some
-         # disk space), then executing another full will have a great chance to
-         # finish
-         error="full hotcopy in backupset ${backupset} has failed"
-         echo "Executing full hotcopy as a prerequisite for ${backup_type} hotcopy: ${error}"
-         execute_backup "full"
-      fi
-   fi
+if [ "$backup_type" == "full" ]; then
+   execute_full
+elif [ "$backup_type" == "incremental" ]; then
+   execute_incremental
+elif [ "$backup_type" == "journal" ]; then
+   execute_journal
 fi
-
-execute_backup "$backup_type"

--- a/stable/database/files/nuobackup
+++ b/stable/database/files/nuobackup
@@ -254,7 +254,7 @@ do
            backup_root="$1"; shift;;
         "--backup-root="* )
            backup_root="${opt#*=}";;
-        *) echo >&2 "Invalid nuobackup option: $opt ($@)"; exit 1;;
+        *) echo >&2 "Invalid nuobackup option: $opt ($*)"; exit 1;;
    esac
 done
 

--- a/stable/database/files/nuobackup
+++ b/stable/database/files/nuobackup
@@ -41,7 +41,6 @@ backup_group=""
 labels=""
 timeout=""
 backup_root=$BACKUP_DIR
-retry_failed="True"
 backup_database_output=""
 
 function get_current_backup() {
@@ -207,19 +206,25 @@ function execute_incremental() {
 }
 
 function execute_journal() {
+   local rc 
+
    if ! full_exist; then
       echo "Executing full hotcopy as a prerequisite for journal hotcopy"
       execute_full
    else 
       execute_backup "journal"
-      if [ -n "$retry_failed" ] && echo "$backup_database_output" | grep -q "Full or incremental hot copy must be completed before journal hot copy"; then
-         # journal hot copy has been temporarly suspended due to archive sync;
-         # perform incremental hot copy first
-         retry_failed=""
-         echo "Executing incremental hot copy as journal hot copy is temporarily suspended"
-         execute_incremental || return $?
-         # retry the journal backup which should succeed now
-         execute_journal
+      rc=$?
+      if [ $rc -ne 0 ]; then
+         if echo "$backup_database_output" | grep -q "Full or incremental hot copy must be completed before journal hot copy"; then
+            # journal hot copy has been temporarly suspended due to archive sync;
+            # perform incremental hot copy first
+            echo "Executing incremental hot copy as journal hot copy is temporarily suspended"
+            execute_incremental || return $?
+            # retry the journal backup which should succeed now
+            execute_backup "journal"
+         else
+            return $rc
+         fi
       fi
    fi
 }

--- a/test/minikube/minikube_base_restore_test.go
+++ b/test/minikube/minikube_base_restore_test.go
@@ -141,8 +141,11 @@ func TestKubernetesJournalBackupSuspended(t *testing.T) {
 	testlib.AwaitJobSucceeded(t, namespaceName, "journal-hotcopy-nuodb-demo-cluster0-0", 120*time.Second)
 	// verify that the journal backup fails and it's retried after requesting incremental
 	podName := testlib.GetPodName(t, namespaceName, "journal-hotcopy-nuodb-demo-cluster0-0")
-	require.Equal(t, testlib.GetStringOccurrenceInLog(t, namespaceName, podName,
-		"Executing incremental hot copy as journal hot copy is temporarily suspended", &corev1.PodLogOptions{}), 1,
+	testlib.AddDiagnosticTeardown(testlib.TEARDOWN_DATABASE, t, func() {
+		testlib.GetAppLog(t, namespaceName, podName, "", &corev1.PodLogOptions{})
+	})
+	require.Equal(t, 1, testlib.GetStringOccurrenceInLog(t, namespaceName, podName,
+		"Executing incremental hot copy as journal hot copy is temporarily suspended", &corev1.PodLogOptions{}),
 		"Incremental hot copy not requested to enable journal after sync")
 	verifyBackup(t, namespaceName, admin0, "demo", &options)
 }

--- a/test/minikube/minikube_base_restore_test.go
+++ b/test/minikube/minikube_base_restore_test.go
@@ -99,6 +99,7 @@ func TestKubernetesJournalBackupSuspended(t *testing.T) {
 			"database.sm.resources.requests.memory":     testlib.MINIMAL_VIABLE_ENGINE_MEMORY,
 			"database.te.resources.requests.cpu":        "250m",
 			"database.te.resources.requests.memory":     testlib.MINIMAL_VIABLE_ENGINE_MEMORY,
+			"database.te.replicas":                      "0",
 			"database.sm.hotCopy.replicas":              "2",
 			"database.sm.hotCopy.journalBackup.enabled": "true",
 		},
@@ -106,47 +107,81 @@ func TestKubernetesJournalBackupSuspended(t *testing.T) {
 
 	databaseReleaseName := testlib.StartDatabase(t, namespaceName, admin0, &options)
 
-	// Get logs from journal backup job in case this test fails
-	testlib.AddDiagnosticTeardown(testlib.TEARDOWN_DATABASE, t, func() {
-		podName := testlib.GetPodName(t, namespaceName, "journal-hotcopy-nuodb-demo-cluster0-0")
-		testlib.AwaitPodPhase(t, namespaceName, podName, corev1.PodFailed, 20*time.Second)
-		testlib.GetAppLog(t, namespaceName, podName, "", &corev1.PodLogOptions{})
-	})
-
-	testlib.CreateQuickstartSchema(t, namespaceName, admin0)
-
 	opt := testlib.GetExtractedOptions(&options)
 	kubectlOptions := k8s.NewKubectlOptions("", "", namespaceName)
+	teDeployment := fmt.Sprintf("te-%s-%s-%s-%s", databaseReleaseName, opt.DomainName, opt.ClusterName, opt.DbName)
 	smPodName0 := fmt.Sprintf("sm-%s-nuodb-%s-%s-hotcopy-0", databaseReleaseName, opt.ClusterName, opt.DbName)
+	smPodName1 := fmt.Sprintf("sm-%s-nuodb-%s-%s-hotcopy-1", databaseReleaseName, opt.ClusterName, opt.DbName)
 	// suspend full and incremental backup jobs
 	k8s.RunKubectl(t, kubectlOptions, "patch", "cronjob", "full-hotcopy-nuodb-demo-cluster0-0",
 		"-p", "{\"spec\" : {\"suspend\" : true }}")
 	k8s.RunKubectl(t, kubectlOptions, "patch", "cronjob", "incremental-hotcopy-nuodb-demo-cluster0-0",
 		"-p", "{\"spec\" : {\"suspend\" : true }}")
-	// Execute initial backup for all backup groups
-	backupGroup0 := fmt.Sprintf("%s-0", opt.ClusterName)
+	k8s.RunKubectl(t, kubectlOptions, "patch", "cronjob", "full-hotcopy-nuodb-demo-cluster0-1",
+		"-p", "{\"spec\" : {\"suspend\" : true }}")
+	k8s.RunKubectl(t, kubectlOptions, "patch", "cronjob", "incremental-hotcopy-nuodb-demo-cluster0-1",
+		"-p", "{\"spec\" : {\"suspend\" : true }}")
+
+	// execute initial backup for backup group 1 which should fail as the
+	// database is not initialized yet
 	backupGroup1 := fmt.Sprintf("%s-1", opt.ClusterName)
+	err := testlib.BackupDatabaseE(t, namespaceName, smPodName0, opt.DbName, "full", backupGroup1)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Database not fully initialized by a Transaction Engine")
+
+	// start the TE
+	testlib.ScaleDeployment(t, namespaceName, teDeployment, 1)
+	testlib.AwaitNrReplicasScheduled(t, namespaceName, teDeployment, 1)
+	tePodName := testlib.GetPodName(t, namespaceName, teDeployment)
+	testlib.AwaitPodUp(t, namespaceName, tePodName, 120*time.Second)
+
+	testlib.CreateQuickstartSchema(t, namespaceName, admin0)
+
+	// Execute initial backup for backup group 0
+	backupGroup0 := fmt.Sprintf("%s-0", opt.ClusterName)
 	testlib.BackupDatabase(t, namespaceName, smPodName0, opt.DbName, "full", backupGroup0)
-	testlib.BackupDatabase(t, namespaceName, smPodName0, opt.DbName, "full", backupGroup1)
-	// restarting one of the SMs will disable journal backup temporary until
-	// full or incremental are requested and complete
-	smPod0 := testlib.GetPod(t, namespaceName, smPodName0)
-	testlib.DeletePod(t, namespaceName, "pod/"+smPodName0)
-	testlib.AwaitPodObjectRecreated(t, namespaceName, smPod0, 30*time.Second)
-	testlib.DeleteJobPods(t, namespaceName, "journal-hotcopy-nuodb-demo-cluster0-0")
-	testlib.AwaitPodUp(t, namespaceName, smPodName0, 120*time.Second)
-	// schedule the journal backup job in the next munute
-	k8s.RunKubectl(t, kubectlOptions, "patch", "cronjob", "journal-hotcopy-nuodb-demo-cluster0-0",
-		"-p", "{\"spec\" : {\"schedule\" : \"?/1 * * * *\" }}")
-	testlib.AwaitJobSucceeded(t, namespaceName, "journal-hotcopy-nuodb-demo-cluster0-0", 120*time.Second)
-	// verify that the journal backup fails and it's retried after requesting incremental
-	podName := testlib.GetPodName(t, namespaceName, "journal-hotcopy-nuodb-demo-cluster0-0")
-	testlib.AddDiagnosticTeardown(testlib.TEARDOWN_DATABASE, t, func() {
-		testlib.GetAppLog(t, namespaceName, podName, "", &corev1.PodLogOptions{})
-	})
-	require.Equal(t, 1, testlib.GetStringOccurrenceInLog(t, namespaceName, podName,
+
+	restartSmAndExecuteJournalBackup := func(name string, backupGroup string) string {
+		// restarting an SM will disable journal backup temporary until full or
+		// incremental are requested and complete
+		pod := testlib.GetPod(t, namespaceName, name)
+		testlib.DeletePod(t, namespaceName, "pod/"+name)
+		testlib.AwaitPodObjectRecreated(t, namespaceName, pod, 30*time.Second)
+		testlib.AwaitPodUp(t, namespaceName, name, 120*time.Second)
+		cronJobName := fmt.Sprintf("journal-hotcopy-%s-%s-%s", opt.DomainName, opt.DbName, backupGroup)
+		testlib.DeleteJobPods(t, namespaceName, cronJobName)
+
+		// Get logs from journal backup job in case it fails
+		testlib.AddDiagnosticTeardown(testlib.TEARDOWN_DATABASE, t, func() {
+			podName := testlib.GetPodName(t, namespaceName, cronJobName)
+			testlib.AwaitPodPhase(t, namespaceName, podName, corev1.PodFailed, 20*time.Second)
+			testlib.GetAppLog(t, namespaceName, podName, "", &corev1.PodLogOptions{})
+		})
+
+		// schedule the journal backup job in the next minute
+		k8s.RunKubectl(t, kubectlOptions, "patch", "cronjob", cronJobName,
+			"-p", "{\"spec\" : {\"schedule\" : \"?/1 * * * *\" }}")
+		testlib.AwaitJobSucceeded(t, namespaceName, cronJobName, 120*time.Second)
+		return testlib.GetPodName(t, namespaceName, cronJobName)
+	}
+
+	backupJobName := restartSmAndExecuteJournalBackup(smPodName0, backupGroup0)
+	// verify that the journal backup fails and it's retried after requesting
+	// incremental
+	require.Equal(t, 1, testlib.GetStringOccurrenceInLog(t, namespaceName, backupJobName,
 		"Executing incremental hot copy as journal hot copy is temporarily suspended", &corev1.PodLogOptions{}),
 		"Incremental hot copy not requested to enable journal after sync")
+
+	backupJobName = restartSmAndExecuteJournalBackup(smPodName1, backupGroup1)
+	// verify that the journal backup fails and another full backup is requested
+	// because the last full hot copy failed
+	require.Equal(t, 1, testlib.GetStringOccurrenceInLog(t, namespaceName, backupJobName,
+		"Executing incremental hot copy as journal hot copy is temporarily suspended", &corev1.PodLogOptions{}),
+		"Incremental hot copy not requested to enable journal after sync")
+	require.Equal(t, 1, testlib.GetStringOccurrenceInLog(t, namespaceName, backupJobName,
+		"Executing full hotcopy as a prerequisite for incremental hotcopy", &corev1.PodLogOptions{}),
+		"Full hot copy should be requested as previous full have failed")
+
 	verifyBackup(t, namespaceName, admin0, "demo", &options)
 }
 

--- a/test/testlib/minikube_utilities.go
+++ b/test/testlib/minikube_utilities.go
@@ -1313,6 +1313,12 @@ func ScaleStatefulSet(t *testing.T, namespaceName string, name string, replicas 
 	k8s.RunKubectl(t, options, "scale", "statefulset", name, fmt.Sprintf("--replicas=%d", replicas))
 }
 
+func ScaleDeployment(t *testing.T, namespaceName string, name string, replicas int) {
+	options := k8s.NewKubectlOptions("", "", namespaceName)
+
+	k8s.RunKubectl(t, options, "scale", "deployment", name, fmt.Sprintf("--replicas=%d", replicas))
+}
+
 func GetGlobalLoadBalancerConfigE(t *testing.T, loadBalancerConfigs []NuoDBLoadBalancerConfig) (*NuoDBLoadBalancerConfig, error) {
 	for _, config := range loadBalancerConfigs {
 		if config.IsGlobal {


### PR DESCRIPTION
**Issue**

If the _journal_ hot copy is temporarily disabled due to SM sync, an incremental backup will be requested. The requested incremental will fail if the previous _full_ backup was not successful.

**Changes**

Refactor the `nuobackup` script and create a function for each backup type. This makes it easy to understand the prerequisites and post-failure actions for each hot copy type.

**Testing**

- changed the `TestKubernetesJournalBackupSuspended` E2E test so that the scenario is covered.
- added `testlib.BackupDatabaseE` function which doesn't fail the test if the requested database backup fails