### PR TITLE
Storage groups support

### DIFF
--- a/stable/database/README.md
+++ b/stable/database/README.md
@@ -270,6 +270,9 @@ The following tables list the configurable parameters of the `database` chart an
 | `sm.tolerations` | Tolerations for NuoDB SM | `[]` |
 | `sm.topologySpreadConstraints` | Topology spread constraints for NuoDB SM | `[]` |
 | `sm.readinessTimeoutSeconds` | SM readiness probe timeout, sometimes needs adjusting depending on environment and pod resources | `5` |
+| `sm.storageGroup.enabled` | Enable Table Partitions and Storage Groups (TPSG) for all SMs in this database Helm release | `false` |
+| `sm.storageGroup.name` | The name of the storage group. Only alphanumeric and underscore ('_') characters are allowed. By default the Helm release name is used | `.Release.Name` |
+| `te.enablePod` | Create deployment for TEs | `true` |
 | `te.externalAccess.enabled` | Whether to deploy a Layer 4 service for the database | `false` |
 | `te.externalAccess.internalIP` | Whether to use an internal (to the cloud) or external (public) IP address for the load balancer. Only applies to external access of type `LoadBalancer` | `nil` |
 | `te.externalAccess.type` | The service type used to enable external database access. The supported types are `NodePort` and `LoadBalancer` (defaults to `LoadBalancer`) | `nil` |

--- a/stable/database/README.md
+++ b/stable/database/README.md
@@ -272,7 +272,7 @@ The following tables list the configurable parameters of the `database` chart an
 | `sm.readinessTimeoutSeconds` | SM readiness probe timeout, sometimes needs adjusting depending on environment and pod resources | `5` |
 | `sm.storageGroup.enabled` | Enable Table Partitions and Storage Groups (TPSG) for all SMs in this database Helm release | `false` |
 | `sm.storageGroup.name` | The name of the storage group. Only alphanumeric and underscore ('_') characters are allowed. By default the Helm release name is used | `.Release.Name` |
-| `te.enablePod` | Create deployment for TEs | `true` |
+| `te.enablePod` | Create deployment for TEs | `nil` |
 | `te.externalAccess.enabled` | Whether to deploy a Layer 4 service for the database | `false` |
 | `te.externalAccess.internalIP` | Whether to use an internal (to the cloud) or external (public) IP address for the load balancer. Only applies to external access of type `LoadBalancer` | `nil` |
 | `te.externalAccess.type` | The service type used to enable external database access. The supported types are `NodePort` and `LoadBalancer` (defaults to `LoadBalancer`) | `nil` |

--- a/stable/database/README.md
+++ b/stable/database/README.md
@@ -227,7 +227,7 @@ The following tables list the configurable parameters of the `database` chart an
 | `sm.logPersistence.size` | Amount of disk space allocated for log storage | `60Gi` |
 | `sm.logPersistence.storageClass` | Storage class for volume backing log storage.  This storage class must be pre-configured in the cluster | `-` |
 | `sm.hotCopy.replicas` | SM replicas with hot-copy enabled | `1` |
-| `sm.hotCopy.enablePod` | Create DS/SS for hot-copy enabled SMs | `true` |
+| `sm.hotCopy.enablePod` | Create StatefulSet for hot-copy enabled SMs | `true` |
 | `sm.hotCopy.enableBackups` | Enable full/incremental/journal backups | `true` |
 | `sm.hotCopy.deadline` | Deadline for a hotcopy job to start (seconds) | `1800` |
 | `sm.hotCopy.timeout` | Timeout for a started `full` or `incremental` hotcopy job to complete (seconds). The default timeout of "0" will force the backup jobs to wait forever for the requested hotcopy operation to complete | `0` |
@@ -257,7 +257,7 @@ The following tables list the configurable parameters of the `database` chart an
 | `sm.hotCopy.journalPath.size` | Amount of disk space allocated for SM journal | `20Gi` |
 | `sm.hotCopy.journalPath.storageClass` | Storage class for SM journal.  This storage class must be pre-configured in the cluster | `-` |
 | `sm.noHotCopy.replicas` | SM replicas with hot-copy disabled | `0` |
-| `sm.noHotCopy.enablePod` | Create DS/SS for non-hot-copy SMs | `true` |
+| `sm.noHotCopy.enablePod` | Create StatefulSet for non-hot-copy SMs | `true` |
 | `sm.noHotCopy.journalPath.enabled` | Whether to enable separate SM journal directory. For more info, read the [Journal HowTo](../../docs/HowToArchiveJournal.md) | `false` |
 | `sm.noHotCopy.journalPath.accessModes` | Volume access modes enabled (must match capabilities of the storage class) | `ReadWriteOnce` |
 | `sm.noHotCopy.journalPath.size` | Amount of disk space allocated for SM journal | `20Gi` |

--- a/stable/database/README.md
+++ b/stable/database/README.md
@@ -272,7 +272,7 @@ The following tables list the configurable parameters of the `database` chart an
 | `sm.readinessTimeoutSeconds` | SM readiness probe timeout, sometimes needs adjusting depending on environment and pod resources | `5` |
 | `sm.storageGroup.enabled` | Enable Table Partitions and Storage Groups (TPSG) for all SMs in this database Helm release | `false` |
 | `sm.storageGroup.name` | The name of the storage group. Only alphanumeric and underscore ('_') characters are allowed. By default the Helm release name is used | `.Release.Name` |
-| `te.enablePod` | Create deployment for TEs | `nil` |
+| `te.enablePod` | Create deployment for TEs. By default, the TE Deployment is disabled if TP/SG is enabled and this is a "secondary" release. | `nil` |
 | `te.externalAccess.enabled` | Whether to deploy a Layer 4 service for the database | `false` |
 | `te.externalAccess.internalIP` | Whether to use an internal (to the cloud) or external (public) IP address for the load balancer. Only applies to external access of type `LoadBalancer` | `nil` |
 | `te.externalAccess.type` | The service type used to enable external database access. The supported types are `NodePort` and `LoadBalancer` (defaults to `LoadBalancer`) | `nil` |

--- a/stable/database/files/nuobackup
+++ b/stable/database/files/nuobackup
@@ -136,7 +136,7 @@ function execute_backup() {
 
       # update the list of known backup groups for this database
       group_list="$(nuocmd get value --key $NUODB_BACKUP_KEY/$db_name/backup-groups)"
-      if [ -z "$(echo "$group_list" | grep -o $backup_group)" ]; then
+      if [ -z "$(echo "$group_list" | grep -wo "$backup_group")" ]; then
          new_list="$group_list $backup_group"
 
          echo "$NUODB_BACKUP_KEY/$db_name/backup-groups = $new_list"

--- a/stable/database/templates/_helpers.tpl
+++ b/stable/database/templates/_helpers.tpl
@@ -509,6 +509,9 @@ Renders the storage groups option for nuosm script
 {{- if has (upper .) $invalid }}
 {{- fail (printf "Invalid storage group name: %s" .) }}
 {{- end }}
+{{- if contains " " (trim .) }}
+{{- fail (printf "Multiple storage group names provided: %s" .) }}
+{{- end }}
 {{- end }}
 - "--storage-groups"
 - {{ .Values.database.sm.storageGroup.name | default .Release.Name | trim | quote }}

--- a/stable/database/templates/_helpers.tpl
+++ b/stable/database/templates/_helpers.tpl
@@ -497,3 +497,32 @@ Renders the name of the Secret for this database
 {{- define "database.secretName" -}}
 {{ .Values.admin.domain }}-{{ .Values.database.name }}
 {{- end -}}
+
+{{/*
+Renders the storage groups option for nuosm script
+*/}}
+{{- define "database.storageGroup.args" -}}
+{{- if .Values.database.sm.storageGroup }}
+{{- if .Values.database.sm.storageGroup.enabled }}
+{{- with .Values.database.sm.storageGroup.name }}
+{{- $invalid := list "ALL" "UNPARTITIONED" }}
+{{- if has (upper .) $invalid }}
+{{- fail (printf "Invalid storage group name: %s" .) }}
+{{- end }}
+{{- end }}
+- "--storage-groups"
+- {{ .Values.database.sm.storageGroup.name | default .Release.Name | trim | quote }}
+{{- end }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Renders the storage group domain process label
+*/}}
+{{- define "database.storageGroup.label" -}}
+{{- if .Values.database.sm.storageGroup }}
+{{- if .Values.database.sm.storageGroup.enabled }}
+{{- printf "sg %s" (.Values.database.sm.storageGroup.name | default .Release.Name | trim) -}}
+{{- end }}
+{{- end }}
+{{- end -}}

--- a/stable/database/templates/_helpers.tpl
+++ b/stable/database/templates/_helpers.tpl
@@ -529,3 +529,19 @@ Renders the storage group domain process label
 {{- end }}
 {{- end }}
 {{- end -}}
+
+{{/*
+Checks if the TE Deployment should be enabled. If the default value is absent,
+the TE Deployment is disabled if TPSG is enabled and this is a secondary release.
+*/}}
+{{- define "database.te.enablePod" -}}
+  {{- if kindIs "invalid" .Values.database.te.enablePod -}}
+    {{- if and (eq (include "defaultfalse" .Values.database.sm.storageGroup.enabled) "true") (eq (include "defaulttrue" .Values.database.primaryRelease) "false") -}}
+      {{- false -}}
+    {{- else -}}
+      {{- true -}}
+    {{- end -}}
+  {{- else -}}
+    {{- include "defaulttrue" .Values.database.te.enablePod -}}
+  {{- end -}}
+{{- end -}}

--- a/stable/database/templates/configmap.yaml
+++ b/stable/database/templates/configmap.yaml
@@ -7,10 +7,6 @@ metadata:
   name: {{ template "database.fullname" . }}-nuote
 data:
 {{ (.Files.Glob "files/nuote").AsConfig | indent 2 }}
-{{/* 
-  Remove this conditional rendering when support for storage groups is added
-*/}}
-{{- if eq (include "defaulttrue" .Values.database.primaryRelease) "true" }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -29,7 +25,6 @@ metadata:
   name: {{ template "database.fullname" . }}-nuobackup
 data:
 {{ (.Files.Glob "files/nuobackup").AsConfig | indent 2 }}
-{{- end }}
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/stable/database/templates/deployment.yaml
+++ b/stable/database/templates/deployment.yaml
@@ -1,4 +1,4 @@
-{{- if eq (include "defaulttrue" .Values.database.te.enablePod) "true" }}
+{{- if eq (include "database.te.enablePod" .) "true" }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/stable/database/templates/deployment.yaml
+++ b/stable/database/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{- if eq (include "defaulttrue" .Values.database.te.enablePod) "true" }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -216,3 +217,4 @@ spec:
       restartPolicy: Always
       schedulerName: default-scheduler
       terminationGracePeriodSeconds: 15
+{{- end }}

--- a/stable/database/templates/statefulset.yaml
+++ b/stable/database/templates/statefulset.yaml
@@ -1,7 +1,3 @@
-{{/* 
-  Remove this conditional rendering when support for storage groups is added
-*/}}
-{{- if eq (include "defaulttrue" .Values.database.primaryRelease) "true" }}
 {{- if eq (include "defaulttrue" .Values.database.sm.noHotCopy.enablePod) "true" }}
 ---
 apiVersion: apps/v1
@@ -103,14 +99,16 @@ spec:
     {{- end }}
           - "--options"
           - "mem {{ .Values.database.sm.resources.requests.memory}} {{ include "opt.key-values" .Values.database.sm.engineOptions }}"
-    {{- with .Values.database.sm.labels }}
+    {{- $labels := printf "%s %s" (include "database.storageGroup.label" .)  (include "opt.key-values" .Values.database.sm.labels) -}}
+    {{- if trim $labels }}
           - "--labels"
-          - "{{- include "opt.key-values" . }}"
+          - "{{ $labels }}"
     {{- end }}
     {{- with .Values.database.options }}
           - "--database-options"
           - "{{- include "opt.key-values" . }}"
     {{- end }}
+    {{- include "database.storageGroup.args" . | indent 10 }}
     {{- include "database.otherOptions" .Values.database.sm.otherOptions | indent 10 }}
     {{- include "sc.containerSecurityContext" . | indent 8 }}
     {{- include "database.envFrom" . | indent 8 }}
@@ -467,11 +465,12 @@ spec:
           - "--options"
           - "mem {{ .Values.database.sm.resources.requests.memory}} {{- if and (eq (include "defaulttrue" .Values.database.sm.hotCopy.enableBackups) "true") (eq (include "defaultfalse" .Values.database.sm.hotCopy.journalBackup.enabled) "true") }} journal-hot-copy enable {{- end }} {{- include "opt.key-values" .Values.database.sm.engineOptions}}"
           - "--labels"
-          - "role hotcopy backup {{ include "hotcopy.groupPrefix" . }} {{- include "opt.key-values" .Values.database.sm.labels }}"
+          - "role hotcopy backup {{ include "hotcopy.groupPrefix" . }} {{ include "database.storageGroup.label" . }} {{- include "opt.key-values" .Values.database.sm.labels }}"
 {{- with .Values.database.options}}
           - "--database-options"
           - "{{- range $opt, $val := . -}} {{$opt}} {{$val}} {{ end}}"
 {{- end}}
+    {{- include "database.storageGroup.args" . | indent 10 }}
     {{- include "database.otherOptions" .Values.database.sm.otherOptions | indent 10 }}
     {{- include "sc.containerSecurityContext" . | indent 8 }}
     {{- include "database.envFrom" . | indent 8 }}
@@ -753,5 +752,4 @@ spec:
         requests:
           storage: {{ .Values.database.sm.logPersistence.size }}
   {{- end }}
-{{- end }}
 {{- end }}

--- a/stable/database/values.yaml
+++ b/stable/database/values.yaml
@@ -441,7 +441,8 @@ database:
     # initially configured SG and the currently served SGs.
     storageGroup: 
       enabled: false
-      # The name of the storage group. By default the Helm release name is used.
+      # The name of the storage group. Only alphanumeric and underscore ('_')
+      # characters are allowed. By default the Helm release name is used.
       name: ""
 
   te:

--- a/stable/database/values.yaml
+++ b/stable/database/values.yaml
@@ -430,7 +430,24 @@ database:
     #Some clusters require longer readiness probe timeouts
     readinessTimeoutSeconds: 5
 
+    # Table Partitions and Storage Groups (TPSG) is the mechanism by which a
+    # version of an SQL table row is stored only on a subset of Storage Managers
+    # (SMs). The "storageGroup" section configures the named Storage Group (SG)
+    # which the SMs installed with this Helm release will initially serve when
+    # their archives are created. The "UNPARTITIONED" storage group is
+    # implicitly added as it is served by every SM in the database. The
+    # information about served SGs is stored in the archive and may change over
+    # time. The SM will emit warning messages if there is a mismatch between the
+    # initially configured SG and the currently served SGs.
+    storageGroup: 
+      enabled: false
+      # The name of the storage group. By default the Helm release name is used.
+      name: ""
+
   te:
+    # Provision Transaction Engine (TE) Deployment.
+    enablePod: true
+
     ## Enable persistent log volumes to retain logs when an external logging solution is not used.
     logPersistence:
       enabled: false

--- a/stable/database/values.yaml
+++ b/stable/database/values.yaml
@@ -447,7 +447,7 @@ database:
 
   te:
     # Provision Transaction Engine (TE) Deployment.
-    enablePod: true
+    # enablePod: true
 
     ## Enable persistent log volumes to retain logs when an external logging solution is not used.
     logPersistence:

--- a/stable/database/values.yaml
+++ b/stable/database/values.yaml
@@ -430,7 +430,7 @@ database:
     #Some clusters require longer readiness probe timeouts
     readinessTimeoutSeconds: 5
 
-    # Table Partitions and Storage Groups (TPSG) is the mechanism by which a
+    # Table Partitions and Storage Groups (TP/SG) is the mechanism by which a
     # version of an SQL table row is stored only on a subset of Storage Managers
     # (SMs). The "storageGroup" section configures the named Storage Group (SG)
     # which the SMs installed with this Helm release will initially serve when
@@ -446,7 +446,10 @@ database:
       name: ""
 
   te:
-    # Provision Transaction Engine (TE) Deployment.
+    # Provision Transaction Engine (TE) Deployment. By default, the TE
+    # Deployment is disabled if TP/SG is enabled and this is a "secondary"
+    # release.
+    #
     # enablePod: true
 
     ## Enable persistent log volumes to retain logs when an external logging solution is not used.

--- a/test/integration/template_database_test.go
+++ b/test/integration/template_database_test.go
@@ -361,6 +361,35 @@ func TestDatabaseDeploymentRenders(t *testing.T) {
 			assert.Equal(t, "te", obj.Spec.Template.ObjectMeta.Labels["component"])
 		}
 	})
+
+	t.Run("testTePodDisabledWithoutStorageGroupsSecondary", func(t *testing.T) {
+		options := &helm.Options{
+			SetValues: map[string]string{
+				"database.primaryRelease": "false",
+			},
+		}
+
+		// Run RenderTemplate to render the template and capture the output.
+		output := helm.RenderTemplate(t, options, helmChartPath, "release-name", []string{"templates/deployment.yaml"})
+
+		for _, obj := range testlib.SplitAndRenderDeployment(t, output, 1) {
+			assert.Equal(t, "te", obj.Spec.Selector.MatchLabels["component"])
+			assert.Equal(t, "te", obj.Spec.Template.ObjectMeta.Labels["component"])
+		}
+	})
+
+	t.Run("testTePodBogus", func(t *testing.T) {
+		options := &helm.Options{
+			SetValues: map[string]string{
+				"database.te.enablePod": "foo",
+			},
+		}
+
+		// Run RenderTemplate to render the template and capture the output.
+		_, err := helm.RenderTemplateE(t, options, helmChartPath, "release-name", []string{"templates/deployment.yaml"})
+		assert.NotNil(t, err, "template should have failed")
+		assert.Contains(t, err.Error(), "Invalid boolean value: foo")
+	})
 }
 
 func TestDatabaseOtherOptions(t *testing.T) {

--- a/test/integration/template_database_test.go
+++ b/test/integration/template_database_test.go
@@ -1903,6 +1903,23 @@ func TestDatabaseStorageGroups(t *testing.T) {
 		assert.Contains(t, err.Error(), "Invalid storage group name: ALL")
 	})
 
+	t.Run("testMultipleStorageGroupNames", func(t *testing.T) {
+		// Path to the helm chart we will test
+		helmChartPath := testlib.DATABASE_HELM_CHART_PATH
+		options := &helm.Options{
+			SetValues: map[string]string{
+				"database.sm.storageGroup.enabled": "true",
+				"database.sm.storageGroup.name":    "sg1 sg2",
+			},
+		}
+
+		// rendering fails
+		_, err := helm.RenderTemplateE(t, options, helmChartPath,
+			"release-name", []string{"templates/statefulset.yaml"})
+		assert.NotNil(t, err)
+		assert.Contains(t, err.Error(), "Multiple storage group names provided: sg1 sg2")
+	})
+
 	t.Run("testStorageGroupLabel", func(t *testing.T) {
 		// Path to the helm chart we will test
 		helmChartPath := testlib.DATABASE_HELM_CHART_PATH

--- a/test/minikube/minikube_external_access_test.go
+++ b/test/minikube/minikube_external_access_test.go
@@ -243,8 +243,8 @@ func TestKubernetesMultipleTEGroups(t *testing.T) {
 		group1ReleaseName := testlib.StartDatabase(t, namespaceName, admin0, &databaseOptions)
 		// all other Helm releases will be secondary releases with TEs only
 		databaseOptions.SetValues["database.primaryRelease"] = "false"
-		databaseOptions.SetValues["database.sm.hotCopy.replicas"] = "0"
-		databaseOptions.SetValues["database.sm.noHotCopy.replicas"] = "0"
+		databaseOptions.SetValues["database.sm.hotCopy.enablePod"] = "false"
+		databaseOptions.SetValues["database.sm.noHotCopy.enablePod"] = "false"
 		databaseOptions.SetValues["database.te.labels.tx-type"] = "TAP"
 		group2ReleaseName := testlib.StartDatabase(t, namespaceName, admin0, &databaseOptions)
 		opt := testlib.GetExtractedOptions(&databaseOptions)

--- a/test/minikube/minikube_long_restore_test.go
+++ b/test/minikube/minikube_long_restore_test.go
@@ -333,7 +333,7 @@ func TestKubernetesRestoreWithStorageGroups(t *testing.T) {
 	if os.Getenv("NUODB_LICENSE") != "ENTERPRISE" && os.Getenv("NUODB_LICENSE_CONTENT") == "" {
 		t.Skip("Cannot test multiple SMs without the Enterprise Edition")
 	}
-	testlib.SkipTestOnNuoDBVersionCondition(t, "< 4.2")
+	testlib.SkipTestOnNuoDBVersionCondition(t, "< 5.0.3")
 	testlib.AwaitTillerUp(t)
 	defer testlib.VerifyTeardown(t)
 	defer testlib.Teardown(testlib.TEARDOWN_ADMIN)
@@ -351,38 +351,64 @@ func TestKubernetesRestoreWithStorageGroups(t *testing.T) {
 			"database.sm.resources.requests.memory": testlib.MINIMAL_VIABLE_ENGINE_MEMORY,
 			"database.te.resources.requests.cpu":    "250m",
 			"database.te.resources.requests.memory": testlib.MINIMAL_VIABLE_ENGINE_MEMORY,
-			"database.sm.hotCopy.replicas":          "2",
 			"database.te.logPersistence.enabled":    "true",
+			"database.sm.storageGroup.enabled":      "true",
 			"database.env[0].name":                  "NUODB_DEBUG",
 			"database.env[0].value":                 "debug",
 			// include both HCSMs as each of them is serving separate storage group
-			"database.sm.hotCopy.backupGroups.group0.labels": "role hotcopy",
+			"database.sm.hotCopy.backupGroups.all-sg.labels": "role hotcopy",
 		},
 	}
 
 	defer testlib.Teardown(testlib.TEARDOWN_DATABASE)
-	databaseChartName := testlib.StartDatabase(t, namespaceName, admin0, &databaseOptions)
 
 	// Generate diagnose in case this test fails
 	testlib.AddDiagnosticTeardown(testlib.TEARDOWN_DATABASE, t, func() {
 		testlib.GetDiagnoseOnTestFailure(t, namespaceName, admin0)
 	})
 
+	// install database primary release which serves sg0
+	databaseOptions.SetValues["database.sm.storageGroup.name"] = "sg0"
+	sg0ReleaseName := testlib.StartDatabase(t, namespaceName, admin0, &databaseOptions)
+
+	// install database secondary release which serves sg1
+	databaseOptions.SetValues["database.primaryRelease"] = "false"
+	databaseOptions.SetValues["database.te.enablePod"] = "false"
+	databaseOptions.SetValues["database.sm.storageGroup.name"] = "sg1"
+	sg1ReleaseName := testlib.StartDatabase(t, namespaceName, admin0, &databaseOptions)
+
+	// set the total number of engines as in the test utilities they are
+	// inferred from the values
+	databaseOptions.SetValues["database.te.enablePod"] = "true"
+	databaseOptions.SetValues["database.te.replicas"] = "1"
+	databaseOptions.SetValues["database.sm.hotCopy.replicas"] = "2"
+
 	kubectlOptions := k8s.NewKubectlOptions("", "", namespaceName)
 	databaseOptions.KubectlOptions = kubectlOptions
 
 	opt := testlib.GetExtractedOptions(&databaseOptions)
-	tePodNameTemplate := fmt.Sprintf("te-%s-nuodb-%s-%s", databaseChartName, opt.ClusterName, opt.DbName)
-	smPodNameTemplate := fmt.Sprintf("sm-%s-nuodb-%s-%s", databaseChartName, opt.ClusterName, opt.DbName)
-	hcSmPodNameTemplate := fmt.Sprintf("%s-hotcopy", smPodNameTemplate)
-	hcSmPodName0 := fmt.Sprintf("%s-0", hcSmPodNameTemplate)
-	hcSmPodName1 := fmt.Sprintf("%s-1", hcSmPodNameTemplate)
+	tePodNameTemplate := fmt.Sprintf("te-%s-nuodb-%s-%s", sg0ReleaseName, opt.ClusterName, opt.DbName)
+	sg0HcSmPodTemplate := fmt.Sprintf("sm-%s-nuodb-%s-%s", sg0ReleaseName, opt.ClusterName, opt.DbName)
+	sg1HcSmPodTemplate := fmt.Sprintf("sm-%s-nuodb-%s-%s", sg1ReleaseName, opt.ClusterName, opt.DbName)
+	sg0HcSmPodName0 := fmt.Sprintf("%s-hotcopy-0", sg0HcSmPodTemplate)
+	sg1HcSmPodName0 := fmt.Sprintf("%s-hotcopy-0", sg1HcSmPodTemplate)
 
-	// Create 2 storage groups, each served by only one archive
-	k8s.RunKubectl(t, kubectlOptions, "exec", admin0, "--",
-		"nuocmd", "add", "storage-group", "--db-name", opt.DbName, "--sg-name", "sg0", "--archive-id", "0")
-	k8s.RunKubectl(t, kubectlOptions, "exec", admin0, "--",
-		"nuocmd", "add", "storage-group", "--db-name", opt.DbName, "--sg-name", "sg1", "--archive-id", "1")
+	testlib.AwaitDatabaseUp(t, namespaceName, admin0, opt.DbName, opt.NrSmPods+opt.NrTePods)
+
+	verifyStorageGroup := func(sgName string) {
+		sg := testlib.CheckStorageGroup(t, namespaceName, admin0, opt.DbName, sgName, "Available")
+		require.GreaterOrEqual(t, len(sg.ArchiveStates), 1)
+		require.GreaterOrEqual(t, len(sg.ProcessStates), 1)
+		require.GreaterOrEqual(t, len(sg.LeaderCandidates), 1)
+		for archiveId, state := range sg.ArchiveStates {
+			require.Equal(t, "ADDED", state, "Unexpected state for archiveId=%s", archiveId)
+		}
+		for nodeId, state := range sg.ProcessStates {
+			require.Equal(t, "RUNNING", state, "Unexpected state for nodeId=%s", nodeId)
+		}
+	}
+	verifyStorageGroup("sg0")
+	verifyStorageGroup("sg1")
 
 	// Populate some data partitioned and stored in each storage group
 	testlib.RunSQL(t, namespaceName, admin0, opt.DbName,
@@ -400,9 +426,8 @@ func TestKubernetesRestoreWithStorageGroups(t *testing.T) {
 		"INSERT INTO codes VALUES ('sg1', '2001')")
 
 	// Suspend the backup jobs and perform a backup
-	backupGroup0 := "group0"
-	testlib.SuspendDatabaseBackupJobs(t, namespaceName, opt.DomainName, opt.DbName, backupGroup0)
-	testlib.BackupDatabase(t, namespaceName, hcSmPodName0, opt.DbName, "full", backupGroup0)
+	testlib.SuspendDatabaseBackupJobs(t, namespaceName, opt.DomainName, opt.DbName, "all-sg")
+	testlib.BackupDatabase(t, namespaceName, sg0HcSmPodName0, opt.DbName, "full", "all-sg")
 
 	// Insert more rows
 	testlib.RunSQL(t, namespaceName, admin0, opt.DbName,
@@ -412,21 +437,21 @@ func TestKubernetesRestoreWithStorageGroups(t *testing.T) {
 
 	tePodName := testlib.GetPodName(t, namespaceName, tePodNameTemplate)
 	go testlib.GetAppLog(t, namespaceName, tePodName, "_pre-restart", &corev1.PodLogOptions{Follow: true})
-	go testlib.GetAppLog(t, namespaceName, hcSmPodName0, "_pre-restart", &corev1.PodLogOptions{Follow: true})
-	go testlib.GetAppLog(t, namespaceName, hcSmPodName1, "_pre-restart", &corev1.PodLogOptions{Follow: true})
+	go testlib.GetAppLog(t, namespaceName, sg0HcSmPodName0, "_pre-restart", &corev1.PodLogOptions{Follow: true})
+	go testlib.GetAppLog(t, namespaceName, sg1HcSmPodName0, "_pre-restart", &corev1.PodLogOptions{Follow: true})
 
 	defer testlib.Teardown(testlib.TEARDOWN_RESTORE)
 
 	// Get SM pod logs if the test fails
 	testlib.AddDiagnosticTeardown(testlib.TEARDOWN_DATABASE, t, func() {
-		testlib.GetAppLog(t, namespaceName, hcSmPodName0, "_post-restore", &corev1.PodLogOptions{})
-		testlib.GetAppLog(t, namespaceName, hcSmPodName1, "_post-restore", &corev1.PodLogOptions{})
+		testlib.GetAppLog(t, namespaceName, sg0HcSmPodName0, "_post-restore", &corev1.PodLogOptions{})
+		testlib.GetAppLog(t, namespaceName, sg1HcSmPodName0, "_post-restore", &corev1.PodLogOptions{})
 	})
 
 	// restore database to the latest backup
 	testlib.RestoreDatabase(t, namespaceName, admin0, &databaseOptions)
-	testlib.AwaitPodLog(t, namespaceName, hcSmPodName0, "_post-restart")
-	testlib.AwaitPodLog(t, namespaceName, hcSmPodName1, "_post-restart")
+	testlib.AwaitPodLog(t, namespaceName, sg0HcSmPodName0, "_post-restart")
+	testlib.AwaitPodLog(t, namespaceName, sg1HcSmPodName0, "_post-restart")
 
 	// verify that the database does NOT contain the data from AFTER the backup
 	output, err := testlib.RunSQL(t, namespaceName, admin0, opt.DbName, "select sg, count(*) from codes group by sg")

--- a/test/testlib/NuoDBStorageGroup.go
+++ b/test/testlib/NuoDBStorageGroup.go
@@ -1,0 +1,36 @@
+package testlib
+
+import (
+	"encoding/json"
+	"io"
+	"strings"
+)
+
+type NuoDBStorageGroup struct {
+	Id               int               `json:"sgId"`
+	Name             string            `json:"sgName"`
+	DbName           string            `json:"dbName"`
+	State            string            `json:"state"`
+	ArchiveStates    map[string]string `json:"archiveStates"`
+	ProcessStates    map[string]string `json:"processStates"`
+	LeaderCandidates []string          `json:"leaderCandidates"`
+}
+
+func UnmarshalStorageGroups(s string) (err error, sgs []NuoDBStorageGroup) {
+	dec := json.NewDecoder(strings.NewReader(s))
+
+	for {
+		var obj NuoDBStorageGroup
+		err = dec.Decode(&obj)
+		if err == io.EOF {
+			// all done
+			return nil, sgs
+		}
+
+		if err != nil {
+			return
+		}
+
+		sgs = append(sgs, obj)
+	}
+}

--- a/test/testlib/nuodb_database_utilities.go
+++ b/test/testlib/nuodb_database_utilities.go
@@ -670,6 +670,7 @@ func SuspendDatabaseBackupJobs(t *testing.T, namespaceName string, domain, dbNam
 			t.Logf("Suspending %s", cronJob)
 			k8s.RunKubectl(t, kubectlOptions, "patch", cronJob,
 				"-p", "{\"spec\" : {\"suspend\" : true }}")
+			DeleteJobPods(t, namespaceName, cronJob)
 		}
 	}
 }


### PR DESCRIPTION
**Changes**

- users can now enable Table Partitions and Storage Groups (TPSG) and supply SG name (by default the Helm release name) when installing the _database_ Helm chart. This requires NuoDB v5.0.3 or later.
- A one-to-one mapping between Helm release and NuoDB storage group simplifies deployment and operations. Storage group reconfiguration is not supported.
- Additional storage groups are added by installing the _database_ chart multiple times with `database.primaryRelease=false` option.
- added `database.te.enablePod` option which can be used to disable TE Deployment when additional storage groups are added.
- when TPSG is enabled the SMs serving storage group will be labeled with `sg <sgName>`.
- fix an issue in `nuobackup` where new backup groups doesn't get registered if it is a substring of an existing one

**Provision Database With Storage Groups (example)**

The steps below will deploy NuoDB database with 3 storage groups. Each SG will be served by 2 SMs, one regular and one HCSM enabling backup.

> **Note** It is recommended that storage groups are installed with `database.primaryRelease=false` option. This allows the user to remove any storage group without removing resources installed by the primary database release.

Install the primary _database_ release. In this example, it's used to deploy the TEs, however, several [TE groups](https://github.com/nuodb/nuodb-helm-charts/blob/master/docs/HowToConnectExternally.md#transaction-engine-groups) can be enabled as well.

```
helm upgrade --install database stable/database \
  --set database.sm.hotCopy.replicas=0 \
  --set database.sm.noHotCopy.replicas=0 \
  --set database.sm.backupGroups.main-cluster.labels="role hotcopy" \
  -f values.yaml
```

Install a secondary _database_ release per storage group.

```sh
helm upgrade --install sg1 stable/database \
  --set database.sm.storageGroup.enabled=true \
  --set database.primaryRelease=false \
  --set database.sm.noHotCopy.replicas=1 \
  --set database.te.enablePod=false \
  -f values.yaml

helm upgrade --install sg2 stable/database \
  --set database.sm.storageGroup.enabled=true \
  --set database.primaryRelease=false \
  --set database.sm.noHotCopy.replicas=1 \
  --set database.te.enablePod=false \
  -f values.yaml

helm upgrade --install sg3 stable/database \
  --set database.sm.storageGroup.enabled=true \
  --set database.primaryRelease=false \
  --set database.sm.noHotCopy.replicas=1 \
  --set database.te.enablePod=false \
  -f values.yaml
```

Check the database storage groups.

```sh
$ nuocmd get storage-groups --db-name demo
StorageGroup(archive_states={}, db_name=demo, id=1, leader_candidates=[], name=ALL, process_states={}, state=Available)
StorageGroup(archive_states={0: ADDED, 1: ADDED}, db_name=demo, id=10, leader_candidates=[0, 2], name=SG1, process_states={0: RUNNING, 2: RUNNING}, state=Available)
StorageGroup(archive_states={2: ADDED, 3: ADDED}, db_name=demo, id=11, leader_candidates=[1, 4], name=SG2, process_states={1: RUNNING, 4: RUNNING}, state=Available)
StorageGroup(archive_states={4: ADDED, 5: ADDED}, db_name=demo, id=12, leader_candidates=[3, 5], name=SG3, process_states={3: RUNNING, 5: RUNNING}, state=Available)
StorageGroup(archive_states={}, db_name=demo, id=2, leader_candidates=[0, 1, 2, 3, 4, 5], name=UNPARTITIONED, process_states={0: RUNNING, 1: RUNNING, 2: RUNNING, 3: RUNNING, 4: RUNNING, 5: RUNNING}, state=Available)
```

Spread table partitions over all SGs.

```sql
CREATE TABLE codes ( sg char(4), zip char(5) ) PARTITION BY RANGE (zip) ( 
	PARTITION p_sg1 VALUES LESS THAN ('2000') STORE IN SG1 
	PARTITION p_sg2 VALUES LESS THAN ('3000') STORE IN SG2 
	PARTITION p_sg3 VALUES LESS THAN ('4000') STORE IN SG3;

INSERT INTO codes VALUES ('sg1', '1001'), ('sg2', '2001'), ('sg3', '3001');
```

Check the row count in each partition.

```sql
SELECT 
	pids.PARTITIONNAME, 
	pids.STORAGEGROUP, 
	count(0) as COUNT 
FROM 
	codes c 
		INNER JOIN system.PARTITIONIDS pids 
			ON c._record_partitionid = pids.PARTITIONID 
GROUP BY pids.PARTITIONNAME, pids.STORAGEGROUP;
```

```
 PARTITIONNAME  STORAGEGROUP  COUNT
 -------------- ------------- ------

     P_SG1           SG1        1
     P_SG2           SG2        1
     P_SG3           SG3        1
```

**Delete Storage Group (example)**

Delete the partitions stored in SG2.

```sql
ALTER TABLE codes DROP PARTITION p_sg2;
```

Delete the corresponding Helm release.

```sh
helm delete sg2
```

Delete the storage group.

```sh
nuocmd delete storage-group --db-name demo --sg-name sg2
```

**Testing**

- integration tests for the new helper templates
- update the `TestKubernetesRestoreWithStorageGroups` test and use the new options to configure storage groups