### PR TITLE
Support readOnlyRootFilesystem and generic ephemeral volumes

### DIFF
--- a/incubator/demo-ycsb/Chart.yaml
+++ b/incubator/demo-ycsb/Chart.yaml
@@ -12,5 +12,5 @@ maintainers:
   email: support@nuodb.com
 engine: gotpl
 icon: https://raw.githubusercontent.com/nuodb/nuodb-helm-charts/master/images/nuodb.svg
-appVersion: 4.3.2
+appVersion: 5.0.3
 tillerVersion: ">=2.9"

--- a/stable/admin/Chart.yaml
+++ b/stable/admin/Chart.yaml
@@ -12,5 +12,5 @@ maintainers:
   email: support@nuodb.com
 engine: gotpl
 icon: https://raw.githubusercontent.com/nuodb/nuodb-helm-charts/master/images/nuodb.svg
-appVersion: 4.3.2
+appVersion: 5.0.3
 tillerVersion: ">=2.9"

--- a/stable/admin/README.md
+++ b/stable/admin/README.md
@@ -171,9 +171,9 @@ The following tables list the configurable parameters for the `admin` option of 
 | `persistence.accessModes` | Volume access modes enabled (must match capabilities of the storage class) | `ReadWriteMany` |
 | `persistence.size` | Amount of disk space allocated for admin RAFT state | `10Gi` |
 | `persistence.storageClass` | Storage class for volume backing admin RAFT state | `-` |
-| `ephemeralVolume.enabled` | Whether to create a generic ephemeral volumes rather than emptyDir for any storage that does not outlive the pod | `false` |
+| `ephemeralVolume.enabled` | Whether to create a generic ephemeral volume rather than emptyDir for any storage that does not outlive the pod | `false` |
 | `ephemeralVolume.size` | The size of the generic ephemeral volume to create | `1Gi` |
-| `ephemeralVolume.storageClass` | The storage class to use for the generic ephemeral volume | `-` |
+| `ephemeralVolume.storageClass` | The storage class to use for the generic ephemeral volume | `nil` |
 | `logPersistence.enabled` | Whether to enable persistent storage for logs | `false` |
 | `logPersistence.overwriteBackoff.copies` | How many copies of the crash directory to keep within windowMinutes | `3` |
 | `logPersistence.overwriteBackoff.windowMinutes` | The window within which to keep the number of crash copies | `120` |

--- a/stable/admin/README.md
+++ b/stable/admin/README.md
@@ -102,7 +102,7 @@ The following tables list the configurable parameters for the `nuodb` option:
 | ----- | ----------- | ------ |
 | `image.registry` | NuoDB container registry | `docker.io` |
 | `image.repository` | NuoDB container image name |`nuodb/nuodb-ce`|
-| `image.tag` | NuoDB container image tag | `4.0.8` |
+| `image.tag` | NuoDB container image tag | `5.0.3` |
 | `image.pullPolicy` | NuoDB container pull policy |`IfNotPresent`|
 | `image.pullSecrets` | Specify docker-registry secret names as an array | [] (does not add image pull secrets to deployed pods) |
 | `serviceAccount` | The name of the service account used by NuoDB Pods | `nuodb` |
@@ -171,6 +171,9 @@ The following tables list the configurable parameters for the `admin` option of 
 | `persistence.accessModes` | Volume access modes enabled (must match capabilities of the storage class) | `ReadWriteMany` |
 | `persistence.size` | Amount of disk space allocated for admin RAFT state | `10Gi` |
 | `persistence.storageClass` | Storage class for volume backing admin RAFT state | `-` |
+| `ephemeralVolume.enabled` | Whether to create a generic ephemeral volumes rather than emptyDir for any storage that does not outlive the pod | `false` |
+| `ephemeralVolume.size` | The size of the generic ephemeral volume to create | `1Gi` |
+| `ephemeralVolume.storageClass` | The storage class to use for the generic ephemeral volume | `-` |
 | `logPersistence.enabled` | Whether to enable persistent storage for logs | `false` |
 | `logPersistence.overwriteBackoff.copies` | How many copies of the crash directory to keep within windowMinutes | `3` |
 | `logPersistence.overwriteBackoff.windowMinutes` | The window within which to keep the number of crash copies | `120` |
@@ -191,6 +194,7 @@ The following tables list the configurable parameters for the `admin` option of 
 | `securityContext.capabilities` | Capabilities for to admin container security context | `{ add: [], drop: [] }` |
 | `securityContext.privileged` | Run the NuoDB Admin containers in privileged mode. Processes in privileged containers are essentially equivalent to root on the host | `false` |
 | `securityContext.allowPrivilegeEscalation` | Whether a process can gain more privileges than its parent process. This boolean directly controls if the `no_new_privs` flag will be set on the container process | `false` |
+| `securityContext.readOnlyRootFilesystem` | Whether to mount the root filesystem as read-only. This is supported for versions of the NuoDB image >=4.3.3 and 4.2.x versions >=4.2.5. | `false` |
 | `tlsCACert.secret` | TLS CA certificate secret name | `nil` |
 | `tlsCACert.key` | TLS CA certificate secret key | `nil` |
 | `tlsKeyStore.secret` | TLS keystore secret name | `nil` |

--- a/stable/admin/templates/_helpers.tpl
+++ b/stable/admin/templates/_helpers.tpl
@@ -415,12 +415,16 @@ rendered, false otherwise.
 {{- $ret := false -}}
 {{- if eq (include "defaultfalse" .Values.admin.logPersistence.enabled) "false" -}}
   {{- $ret = true -}}
-{{- else -}}
-  {{- if eq (include "defaultfalse" .Values.admin.securityContext.enabledOnContainer) "true" -}}
-  {{- if eq (include "defaultfalse" .Values.admin.securityContext.readOnlyRootFilesystem) "true" -}}
-    {{- $ret = true -}}
-  {{- end -}}
-  {{- end -}}
+{{- end -}}
+{{- if eq (include "defaultfalse" .Values.admin.securityContext.enabledOnContainer) "true" -}}
+{{- if eq (include "defaultfalse" .Values.admin.securityContext.readOnlyRootFilesystem) "true" -}}
+  {{- $ret = true -}}
+{{- end -}}
+{{- end -}}
+{{- if .Values.nuocollector }}
+{{- if eq (include "defaultfalse" .Values.nuocollector.enabled) "true" }}
+  {{- $ret = true -}}
+{{- end -}}
 {{- end -}}
 {{ $ret }}
 {{- end -}}

--- a/stable/admin/templates/_helpers.tpl
+++ b/stable/admin/templates/_helpers.tpl
@@ -408,7 +408,8 @@ emptyDir: {}
 {{- end -}}
 
 {{/*
-Returns true or false based on whether the ephemeral or emptyDir volume should be rendered.
+Returns true if either a generic ephemeral volume or emptyDir volume should be
+rendered, false otherwise.
 */}}
 {{- define "admin.enableEphemeralVolume" -}}
 {{- $ret := false -}}

--- a/stable/admin/templates/_sidecar.tpl
+++ b/stable/admin/templates/_sidecar.tpl
@@ -56,7 +56,8 @@ Also, we can't use a single if because lazy evaluation is not an option
   {{- include "sc.containerSecurityContext" . | indent 2 }}
   volumeMounts:
   - mountPath: /etc/telegraf/telegraf.d/dynamic/
-    name: nuocollector-config
+    name: eph-volume
+    subPath: telegraf
   - mountPath: /var/log/nuodb
     {{- if eq (include "defaultfalse" .Values.admin.logPersistence.enabled) "true" }}
     name: log-volume
@@ -78,8 +79,9 @@ Also, we can't use a single if because lazy evaluation is not an option
   - name: REQ_URL
     value: http://127.0.0.1:5000/reload
   volumeMounts:
-  - name: nuocollector-config
-    mountPath: /etc/telegraf/telegraf.d/dynamic/
+  - mountPath: /etc/telegraf/telegraf.d/dynamic/
+    name: eph-volume
+    subPath: telegraf
   - mountPath: /var/log/nuodb
     {{- if eq (include "defaultfalse" .Values.admin.logPersistence.enabled) "true" }}
     name: log-volume
@@ -88,15 +90,6 @@ Also, we can't use a single if because lazy evaluation is not an option
     subPath: log
     {{- end }}
 shareProcessNamespace: true
-{{- end }}
-{{- end }}
-{{- end -}}
-
-{{- define "nuodb.sidecar.volumes" -}}
-{{- if .Values.nuocollector }}
-{{- if eq (include "defaultfalse" .Values.nuocollector.enabled) "true" }}
-- name: nuocollector-config
-  emptyDir: {}
 {{- end }}
 {{- end }}
 {{- end -}}

--- a/stable/admin/templates/_sidecar.tpl
+++ b/stable/admin/templates/_sidecar.tpl
@@ -57,8 +57,13 @@ Also, we can't use a single if because lazy evaluation is not an option
   volumeMounts:
   - mountPath: /etc/telegraf/telegraf.d/dynamic/
     name: nuocollector-config
-  - name: log-volume
-    mountPath: /var/log/nuodb
+  - mountPath: /var/log/nuodb
+    {{- if eq (include "defaultfalse" .Values.admin.logPersistence.enabled) "true" }}
+    name: log-volume
+    {{- else }}
+    name: eph-volume
+    subPath: log
+    {{- end }}
 - name: nuocollector-config
   image: {{ template "nuocollector.watcher" . }}
   imagePullPolicy: {{ $.Values.nuocollector.watcher.pullPolicy }}
@@ -75,8 +80,13 @@ Also, we can't use a single if because lazy evaluation is not an option
   volumeMounts:
   - name: nuocollector-config
     mountPath: /etc/telegraf/telegraf.d/dynamic/
-  - name: log-volume
-    mountPath: /var/log/nuodb
+  - mountPath: /var/log/nuodb
+    {{- if eq (include "defaultfalse" .Values.admin.logPersistence.enabled) "true" }}
+    name: log-volume
+    {{- else }}
+    name: eph-volume
+    subPath: log
+    {{- end }}
 shareProcessNamespace: true
 {{- end }}
 {{- end }}

--- a/stable/admin/templates/statefulset.yaml
+++ b/stable/admin/templates/statefulset.yaml
@@ -70,7 +70,7 @@ spec:
         volumeMounts:
         - name: raftlog
           mountPath: /mnt/vardir
-        {{- if eq (include "defaulttrue" .Values.admin.logPersistence.enabled) "true" }}
+        {{- if eq (include "defaultfalse" .Values.admin.logPersistence.enabled) "true" }}
         - name: log-volume
           mountPath: /mnt/logdir
         {{- end }}
@@ -166,7 +166,7 @@ spec:
           timeoutSeconds: {{ default 5 .Values.admin.readinessTimeoutSeconds }}
         volumeMounts:
         - mountPath: /var/log/nuodb
-          {{- if eq (include "defaulttrue" .Values.admin.logPersistence.enabled) "true" }}
+          {{- if eq (include "defaultfalse" .Values.admin.logPersistence.enabled) "true" }}
           name: log-volume
           {{- else }}
           name: eph-volume

--- a/stable/admin/templates/statefulset.yaml
+++ b/stable/admin/templates/statefulset.yaml
@@ -224,7 +224,6 @@ spec:
       {{- include "nuodb.sidecar" . | nindent 6 }}
 {{- include "nuodb.imagePullSecrets" . | indent 6 }}
       volumes:
-      {{- include "nuodb.sidecar.volumes" . | nindent 6 }}
       {{- if .Values.admin.tde }}
       {{- if .Values.admin.tde.secrets }}
       {{- range $dbName, $secret := .Values.admin.tde.secrets }}

--- a/stable/admin/templates/statefulset.yaml
+++ b/stable/admin/templates/statefulset.yaml
@@ -70,8 +70,14 @@ spec:
         volumeMounts:
         - name: raftlog
           mountPath: /mnt/vardir
+        {{- if eq (include "defaulttrue" .Values.admin.logPersistence.enabled) "true" }}
         - name: log-volume
           mountPath: /mnt/logdir
+        {{- end }}
+        {{- if eq (include "admin.enableEphemeralVolume" .) "true" }}
+        - name: eph-volume
+          mountPath: /mnt/eph
+        {{- end }}
         {{- if eq (include "defaulttrue" .Values.admin.initContainers.runInitDiskAsRoot) "true" }}
         securityContext:
           runAsUser: 0
@@ -112,16 +118,21 @@ spec:
         - { name: COMPONENT_NAME,          value: "admin" }
         - { name: OVERWRITE_COPIES,    value: "{{ .Values.admin.logPersistence.overwriteBackoff.copies | default "3" }}" }
         - { name: OVERWRITE_WINDOW,    value: "{{ .Values.admin.logPersistence.overwriteBackoff.windowMinutes | default "120" }}" }
-      {{- if .Values.admin.tlsKeyStore }}
+        {{- if .Values.admin.tlsKeyStore }}
         {{- if .Values.admin.tlsKeyStore.password }}
         - { name: NUODB_KEYSTORE_PASSWORD,    value: {{ .Values.admin.tlsKeyStore.password | quote }} }
         {{- end }}
-      {{- end }}
-      {{- if .Values.admin.tlsTrustStore }}
+        {{- end }}
+        {{- if .Values.admin.tlsTrustStore }}
         {{- if .Values.admin.tlsTrustStore.password }}
         - { name: NUODB_TRUSTSTORE_PASSWORD,  value: {{ .Values.admin.tlsTrustStore.password | quote }} }
         {{- end }}
-      {{- end }}
+        {{- end }}
+        {{- if eq (include "defaultfalse" .Values.admin.securityContext.enabledOnContainer) "true" }}
+        {{- if eq (include "defaultfalse" .Values.admin.securityContext.readOnlyRootFilesystem) "true" }}
+        - { name: NUODOCKER_CONF_DIR, value: "/tmp"}
+        {{- end }}
+        {{- end }}
         args:
           - "nuoadmin"
           {{- if .Values.admin.evicted}}
@@ -154,8 +165,18 @@ spec:
           successThreshold: 2
           timeoutSeconds: {{ default 5 .Values.admin.readinessTimeoutSeconds }}
         volumeMounts:
-        - name: log-volume
-          mountPath: /var/log/nuodb
+        - mountPath: /var/log/nuodb
+          {{- if eq (include "defaulttrue" .Values.admin.logPersistence.enabled) "true" }}
+          name: log-volume
+          {{- else }}
+          name: eph-volume
+          subPath: log
+          {{- end }}
+        {{- if eq (include "admin.enableEphemeralVolume" .) "true" }}
+        - mountPath: /tmp
+          name: eph-volume
+          subPath: tmp
+        {{- end }}
         {{- with .Values.admin.configFiles }}
         {{- range $key, $val := . }}
         - name: configurations
@@ -237,9 +258,9 @@ spec:
           secretName: {{ .Values.admin.tlsClientPEM.secret }}
           defaultMode: 0440
       {{- end }}
-      {{- if eq (include "defaultfalse" .Values.admin.logPersistence.enabled) "false" }}
-      - name: log-volume
-        emptyDir: {}
+      {{- if eq (include "admin.enableEphemeralVolume" .) "true" }}
+      - name: eph-volume
+        {{- include "admin.ephemeralVolume" . | indent 8 }}
       {{- end }}
       {{- if .Values.admin.configFiles }}
       - name: configurations

--- a/stable/admin/values.yaml
+++ b/stable/admin/values.yaml
@@ -49,7 +49,7 @@ nuodb:
   image:
     registry: docker.io
     repository: nuodb/nuodb-ce
-    tag: 4.3.2
+    tag: 5.0.3
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
@@ -176,6 +176,18 @@ admin:
       - ReadWriteOnce
     # storageClass: "-"
 
+  ephemeralVolume:
+    # Whether to enable generic ephemeral volumes, rather than using emptyDir
+    # for data that does not have to outlive the pod.
+    # ref: https://kubernetes.io/docs/concepts/storage/ephemeral-volumes/#generic-ephemeral-volumes
+    enabled: false
+
+    # The size of the generic ephemeral volume.
+    size: 1Gi
+
+    # The storage class to use for the generic ephemeral volume.
+    # storageClass: "-"
+
   # The name of the PriorityClass that admin pods should belong to. For more
   # information on PriorityClasses, see
   # https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/
@@ -242,6 +254,10 @@ admin:
     # bool directly controls if the "no_new_privs" flag will be set on the
     # container process
     allowPrivilegeEscalation: false
+
+    # Whether to mount the root filesystem as read-only. This is supported for
+    # NuoDB image versions >=4.3.3 and 4.2.x versions >=4.2.5.
+    readOnlyRootFilesystem: false
 
   ## Specify one or more configMaps to import Environment Variables from
   # Ex:  configMapRef: [ myConfigMap, myOtherConfigMap ]

--- a/stable/database/Chart.yaml
+++ b/stable/database/Chart.yaml
@@ -12,5 +12,5 @@ maintainers:
   email: support@nuodb.com
 engine: gotpl
 icon: https://raw.githubusercontent.com/nuodb/nuodb-helm-charts/master/images/nuodb.svg
-appVersion: 4.3.2
+appVersion: 5.0.3
 tillerVersion: ">=2.9"

--- a/stable/database/README.md
+++ b/stable/database/README.md
@@ -221,10 +221,10 @@ The following tables list the configurable parameters of the `database` chart an
 | `autoImport.stripLevels` | The number of levels to strip off pathnames when unpacking a TAR file of an archive | `1` |
 | `autoImport.type` | Type of content in `source`. One of `stream` -> exact copy of an archive; or `backupset` -> a NuoDB hotcopy backupset | 'backupset' |
 | `autoRestore.*` | Enable and configure the automatic re-initialization of a single archive in a running database - see the options in `autoImport` | `disabled` |
-| `ephemeralVolume.enabled` | Whether to create a generic ephemeral volumes rather than emptyDir for any storage that does not outlive the pod | `false` |
+| `ephemeralVolume.enabled` | Whether to create a generic ephemeral volume rather than emptyDir for any storage that does not outlive the pod | `false` |
 | `ephemeralVolume.size` | The size of the generic ephemeral volume to create | `1Gi` |
 | `ephemeralVolume.sizeToMemory` | Whether to size the generic ephemeral volume based on the `resources.limits.memory` setting of the process so that at least one core file is retained for the lifetime of the pod | `false` |
-| `ephemeralVolume.storageClass` | The storage class to use for the generic ephemeral volume | `-` |
+| `ephemeralVolume.storageClass` | The storage class to use for the generic ephemeral volume | `nil` |
 | `sm.logPersistence.enabled` | Whether to enable persistent storage for logs | `false` |
 | `sm.logPersistence.overwriteBackoff.copies` | How many copies of the crash directory to keep within windowMinutes | `3` |
 | `sm.logPersistence.overwriteBackoff.windowMinutes` | The window within which to keep the number of crash copies | `120` |

--- a/stable/database/README.md
+++ b/stable/database/README.md
@@ -99,7 +99,7 @@ The following tables list the configurable parameters for the `nuodb` option:
 | ----- | ----------- | ------ |
 | `image.registry` | NuoDB container registry | `docker.io` |
 | `image.repository` | NuoDB container image name |`nuodb/nuodb-ce`|
-| `image.tag` | NuoDB container image tag | `4.0.8` |
+| `image.tag` | NuoDB container image tag | `5.0.3` |
 | `image.pullPolicy` | NuoDB container pull policy |`IfNotPresent`|
 | `image.pullSecrets` | Specify docker-registry secret names as an array | [] (does not add image pull secrets to deployed pods) |
 | `serviceAccount` | The name of the service account used by NuoDB Pods | `nuodb` |
@@ -203,6 +203,7 @@ The following tables list the configurable parameters of the `database` chart an
 | `securityContext.capabilities` | Capabilities for to engine container security context | `{ add: [], drop: [] }` |
 | `securityContext.privileged` | Run the NuoDB database containers in privileged mode. Processes in privileged containers are essentially equivalent to root on the host | `false` |
 | `securityContext.allowPrivilegeEscalation` | Whether a process can gain more privileges than its parent process. This boolean directly controls if the `no_new_privs` flag will be set on the container process | `false` |
+| `securityContext.readOnlyRootFilesystem` | Whether to mount the root filesystem as read-only | `false` |
 | `env` | Import ENV vars inside containers | `[]` |
 | `envFrom` | Import ENV vars from configMap(s) | `[]` |
 | `lbConfig.prefilter` | Database load balancer prefilter expression | `nil` |
@@ -220,6 +221,10 @@ The following tables list the configurable parameters of the `database` chart an
 | `autoImport.stripLevels` | The number of levels to strip off pathnames when unpacking a TAR file of an archive | `1` |
 | `autoImport.type` | Type of content in `source`. One of `stream` -> exact copy of an archive; or `backupset` -> a NuoDB hotcopy backupset | 'backupset' |
 | `autoRestore.*` | Enable and configure the automatic re-initialization of a single archive in a running database - see the options in `autoImport` | `disabled` |
+| `ephemeralVolume.enabled` | Whether to create a generic ephemeral volumes rather than emptyDir for any storage that does not outlive the pod | `false` |
+| `ephemeralVolume.size` | The size of the generic ephemeral volume to create | `1Gi` |
+| `ephemeralVolume.sizeToMemory` | Whether to size the generic ephemeral volume based on the `resources.limits.memory` setting of the process so that at least one core file is retained for the lifetime of the pod | `false` |
+| `ephemeralVolume.storageClass` | The storage class to use for the generic ephemeral volume | `-` |
 | `sm.logPersistence.enabled` | Whether to enable persistent storage for logs | `false` |
 | `sm.logPersistence.overwriteBackoff.copies` | How many copies of the crash directory to keep within windowMinutes | `3` |
 | `sm.logPersistence.overwriteBackoff.windowMinutes` | The window within which to keep the number of crash copies | `120` |

--- a/stable/database/templates/_helpers.tpl
+++ b/stable/database/templates/_helpers.tpl
@@ -594,7 +594,8 @@ emptyDir: {}
 {{- end -}}
 
 {{/*
-Returns true or false based on whether the ephemeral or emptyDir volume should be rendered.
+Returns true if either a generic ephemeral volume or emptyDir volume should be
+rendered, false otherwise.
 */}}
 {{- define "database.enableEphemeralVolume" -}}
 {{- $ := index . 0 -}}

--- a/stable/database/templates/_helpers.tpl
+++ b/stable/database/templates/_helpers.tpl
@@ -603,12 +603,16 @@ rendered, false otherwise.
 {{- $ret := false -}}
 {{- if eq (include "defaultfalse" $engine.logPersistence.enabled) "false" -}}
   {{- $ret = true -}}
-{{- else -}}
-  {{- if eq (include "defaultfalse" $.Values.database.securityContext.enabledOnContainer) "true" -}}
-  {{- if eq (include "defaultfalse" $.Values.database.securityContext.readOnlyRootFilesystem) "true" -}}
-    {{- $ret = true -}}
-  {{- end -}}
-  {{- end -}}
+{{- end -}}
+{{- if eq (include "defaultfalse" $.Values.database.securityContext.enabledOnContainer) "true" -}}
+{{- if eq (include "defaultfalse" $.Values.database.securityContext.readOnlyRootFilesystem) "true" -}}
+  {{- $ret = true -}}
+{{- end -}}
+{{- end -}}
+{{- if $.Values.nuocollector }}
+{{- if eq (include "defaultfalse" $.Values.nuocollector.enabled) "true" }}
+  {{- $ret = true -}}
+{{- end -}}
 {{- end -}}
 {{ $ret }}
 {{- end -}}

--- a/stable/database/templates/_helpers.tpl
+++ b/stable/database/templates/_helpers.tpl
@@ -171,6 +171,7 @@ Get the Container securityContext (core/v1/SecurityContext)
 securityContext:
   privileged: {{ include "defaultfalse" .Values.database.securityContext.privileged }}
   allowPrivilegeEscalation: {{ include "defaultfalse" .Values.database.securityContext.allowPrivilegeEscalation }}
+  readOnlyRootFilesystem: {{ include "defaultfalse" .Values.database.securityContext.readOnlyRootFilesystem }}
   {{- include "sc.capabilities" . | indent 2 }}
   {{- include "sc.runAs" . | indent 2 }}
   {{- end }}
@@ -257,7 +258,7 @@ into account any schedule overrides configured per backup group.
 {{- end -}}
 
 {{/*
-Renders the name of the HotCopy CrongJob
+Renders the name of the HotCopy CronJob
 */}}
 {{- define "hotcopy.cronjob.name" -}}
 {{ printf "%s-hotcopy-%s-%s-%s" .hotCopyType .Values.admin.domain .Values.database.name .backupGroup | trunc 52 | trimSuffix "-" }}
@@ -556,4 +557,57 @@ the TE Deployment is disabled if TPSG is enabled and this is a secondary release
   {{- else -}}
     {{- include "defaulttrue" .Values.database.te.enablePod -}}
   {{- end -}}
+{{- end -}}
+
+{{/*
+Renders an ephemeral volume for an engine process.
+*/}}
+{{- define "database.ephemeralVolume" -}}
+{{- $ := index . 0 -}}
+{{- $engine := index . 1 -}}
+{{- if eq (include "defaultfalse" $.Values.database.ephemeralVolume.enabled) "true" }}
+ephemeral:
+  volumeClaimTemplate:
+    metadata:
+      labels:
+        {{- include "database.resourceLabels" $ | nindent 10 }}
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      {{- if $.Values.database.ephemeralVolume.storageClass }}
+      {{- if (eq "-" $.Values.database.ephemeralVolume.storageClass) }}
+      storageClassName: ""
+      {{- else }}
+      storageClassName: {{ $.Values.database.ephemeralVolume.storageClass }}
+      {{- end }}
+      {{- end }}
+      resources:
+        requests:
+          {{- if eq (include "defaultfalse" $.Values.database.ephemeralVolume.sizeToMemory) "true" }}
+          storage: {{ $engine.resources.limits.memory }}
+          {{- else }}
+          storage: {{ $.Values.database.ephemeralVolume.size }}
+          {{- end }}
+{{- else }}
+emptyDir: {}
+{{- end }}
+{{- end -}}
+
+{{/*
+Returns true or false based on whether the ephemeral or emptyDir volume should be rendered.
+*/}}
+{{- define "database.enableEphemeralVolume" -}}
+{{- $ := index . 0 -}}
+{{- $engine := index . 1 -}}
+{{- $ret := false -}}
+{{- if eq (include "defaultfalse" $engine.logPersistence.enabled) "false" -}}
+  {{- $ret = true -}}
+{{- else -}}
+  {{- if eq (include "defaultfalse" $.Values.database.securityContext.enabledOnContainer) "true" -}}
+  {{- if eq (include "defaultfalse" $.Values.database.securityContext.readOnlyRootFilesystem) "true" -}}
+    {{- $ret = true -}}
+  {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{ $ret }}
 {{- end -}}

--- a/stable/database/templates/_sidecar.tpl
+++ b/stable/database/templates/_sidecar.tpl
@@ -12,7 +12,8 @@
   {{- include "sc.containerSecurityContext" $ | indent 2 }}
   volumeMounts:
   - mountPath: /etc/telegraf/telegraf.d/dynamic/
-    name: nuocollector-config
+    name: eph-volume
+    subPath: telegraf
   - mountPath: /var/log/nuodb
     {{- if eq (include "defaultfalse" $engine.logPersistence.enabled) "true" }}
     name: log-volume
@@ -34,8 +35,9 @@
   - name: REQ_URL
     value: http://127.0.0.1:5000/reload
   volumeMounts:
-  - name: nuocollector-config
-    mountPath: /etc/telegraf/telegraf.d/dynamic/
+  - mountPath: /etc/telegraf/telegraf.d/dynamic/
+    name: eph-volume
+    subPath: telegraf
   - mountPath: /var/log/nuodb
     {{- if eq (include "defaultfalse" $engine.logPersistence.enabled) "true" }}
     name: log-volume
@@ -44,15 +46,6 @@
     subPath: log
     {{- end }}
 shareProcessNamespace: true
-{{- end }}
-{{- end }}
-{{- end -}}
-
-{{- define "nuodb.sidecar.volumes" -}}
-{{- if .Values.nuocollector }}
-{{- if eq (include "defaultfalse" .Values.nuocollector.enabled) "true" }}
-- name: nuocollector-config
-  emptyDir: {}
 {{- end }}
 {{- end }}
 {{- end -}}

--- a/stable/database/templates/deployment.yaml
+++ b/stable/database/templates/deployment.yaml
@@ -71,8 +71,14 @@ spec:
           - -c
           - find /mnt/* -maxdepth 1 -not \( -perm -0770 -user 1000 \) -exec chmod -R ug+rwx {} \; -exec chown -R 1000 {} \; -exec echo {} \;
         volumeMounts:
+        {{- if eq (include "defaultfalse" .Values.database.te.logPersistence.enabled) "true" }}
         - name: log-volume
           mountPath: /mnt/logdir
+        {{- end }}
+        {{- if eq (include "database.enableEphemeralVolume" (list . .Values.database.te)) "true" }}
+        - name: eph-volume
+          mountPath: /mnt/eph
+        {{- end }}
         {{- if eq (include "defaulttrue" .Values.database.initContainers.runInitDiskAsRoot) "true" }}
         securityContext:
           runAsUser: 0
@@ -139,8 +145,18 @@ spec:
           subPath: {{ $key }}
         {{- end -}}
         {{- end }}
-        - name: log-volume
-          mountPath: /var/log/nuodb
+        - mountPath: /var/log/nuodb
+          {{- if eq (include "defaultfalse" .Values.database.te.logPersistence.enabled) "true" }}
+          name: log-volume
+          {{- else }}
+          name: eph-volume
+          subPath: log
+          {{- end }}
+        {{- if eq (include "database.enableEphemeralVolume" (list . .Values.database.te)) "true" }}
+        - name: eph-volume
+          mountPath: /tmp
+          subPath: tmp
+        {{- end }}
         - name: nuote
           mountPath: /usr/local/bin/nuote
           subPath: nuote
@@ -171,7 +187,7 @@ spec:
           # the TE becomes unready if it does not start within 5 minutes = 30s + 5s*54
           successThreshold: 2
           timeoutSeconds: {{ default 5 .Values.database.te.readinessTimeoutSeconds }}
-      {{- include "nuodb.sidecar" . | nindent 6 }}
+      {{- include "nuodb.sidecar" (list . .Values.database.te) | nindent 6 }}
 {{- include "nuodb.imagePullSecrets" . | indent 6 }}
       volumes:
         {{- include "nuodb.sidecar.volumes" . | nindent 8 }}
@@ -180,12 +196,14 @@ spec:
           configMap:
             name: {{ template "database.fullname" . }}-configuration
         {{- end }}
+        {{- if eq (include "defaultfalse" .Values.database.te.logPersistence.enabled) "true" }}
         - name: log-volume
-        {{- if eq (include "defaultfalse" .Values.database.te.logPersistence.enabled) "false" }}
-          emptyDir: {}
-        {{- else }}
           persistentVolumeClaim:
             claimName: {{ template "database.fullname" . }}-log-te-volume
+        {{- end }}
+        {{- if eq (include "database.enableEphemeralVolume" (list . .Values.database.te)) "true" }}
+        - name: eph-volume
+          {{- include "database.ephemeralVolume" (list . .Values.database.te) | indent 10 }}
         {{- end }}
         - name: nuote
           configMap:

--- a/stable/database/templates/deployment.yaml
+++ b/stable/database/templates/deployment.yaml
@@ -190,7 +190,6 @@ spec:
       {{- include "nuodb.sidecar" (list . .Values.database.te) | nindent 6 }}
 {{- include "nuodb.imagePullSecrets" . | indent 6 }}
       volumes:
-        {{- include "nuodb.sidecar.volumes" . | nindent 8 }}
         {{- if .Values.database.configFiles }}
         - name: configurations
           configMap:

--- a/stable/database/templates/statefulset.yaml
+++ b/stable/database/templates/statefulset.yaml
@@ -255,7 +255,6 @@ spec:
       {{- include "nuodb.sidecar" (list . .Values.database.sm) | nindent 6 }}
 {{- include "nuodb.imagePullSecrets" . | indent 6 }}
       volumes:
-      {{- include "nuodb.sidecar.volumes" . | nindent 6 }}
       {{- if .Values.database.configFiles }}
       - name: configurations
         configMap:
@@ -640,7 +639,6 @@ spec:
       {{- include "nuodb.sidecar" (list . .Values.database.sm) | nindent 6 }}
 {{- include "nuodb.imagePullSecrets" . | indent 6 }}
       volumes:
-      {{- include "nuodb.sidecar.volumes" . | nindent 6 }}
       {{- if .Values.database.configFiles }}
       - name: configurations
         configMap:

--- a/stable/database/templates/statefulset.yaml
+++ b/stable/database/templates/statefulset.yaml
@@ -78,8 +78,14 @@ spec:
         - name: journal-volume
           mountPath: /mnt/journal
         {{- end }}
+        {{- if eq (include "defaultfalse" .Values.database.sm.logPersistence.enabled) "true" }}
         - name: log-volume
           mountPath: /mnt/logdir
+        {{- end }}
+        {{- if eq (include "database.enableEphemeralVolume" (list . .Values.database.sm)) "true" }}
+        - name: eph-volume
+          mountPath: /mnt/eph
+        {{- end }}
         {{- if eq (include "defaulttrue" .Values.database.initContainers.runInitDiskAsRoot) "true" }}
         securityContext:
           runAsUser: 0
@@ -180,8 +186,18 @@ spec:
           subPath: {{ $key }}
         {{- end -}}
         {{- end }}
-        - name: log-volume
-          mountPath: /var/log/nuodb
+        - mountPath: /var/log/nuodb
+          {{- if eq (include "defaultfalse" .Values.database.sm.logPersistence.enabled) "true" }}
+          name: log-volume
+          {{- else }}
+          name: eph-volume
+          subPath: log
+          {{- end }}
+        {{- if eq (include "database.enableEphemeralVolume" (list . .Values.database.sm)) "true" }}
+        - name: eph-volume
+          mountPath: /tmp
+          subPath: tmp
+        {{- end }}
         - name: nuosm
           mountPath: /usr/local/bin/nuosm
           subPath: nuosm
@@ -236,7 +252,7 @@ spec:
           # the SM becomes unready if it does not start within 15 minutes = 30s + 15s*58
           successThreshold: 2
           timeoutSeconds: {{ default 5 .Values.database.sm.readinessTimeoutSeconds }}
-      {{- include "nuodb.sidecar" . | nindent 6 }}
+      {{- include "nuodb.sidecar" (list . .Values.database.sm) | nindent 6 }}
 {{- include "nuodb.imagePullSecrets" . | indent 6 }}
       volumes:
       {{- include "nuodb.sidecar.volumes" . | nindent 6 }}
@@ -245,9 +261,9 @@ spec:
         configMap:
           name: {{ template "database.fullname" . }}-configuration
       {{- end }}
-      {{- if eq (include "defaultfalse" .Values.database.sm.logPersistence.enabled) "false" }}
-      - name: log-volume
-        emptyDir: {}
+      {{- if eq (include "database.enableEphemeralVolume" (list . .Values.database.sm)) "true" }}
+      - name: eph-volume
+        {{- include "database.ephemeralVolume" (list . .Values.database.sm) | indent 8 }}
       {{- end }}
       - name: nuosm
         configMap:
@@ -446,8 +462,14 @@ spec:
         {{- end }}
         - name: backup-volume
           mountPath: /mnt/backup
+        {{- if eq (include "defaultfalse" .Values.database.sm.logPersistence.enabled) "true" }}
         - name: log-volume
           mountPath: /mnt/logdir
+        {{- end }}
+        {{- if eq (include "database.enableEphemeralVolume" (list . .Values.database.sm)) "true" }}
+        - name: eph-volume
+          mountPath: /mnt/eph
+        {{- end }}
         {{- if eq (include "defaulttrue" .Values.database.initContainers.runInitDiskAsRoot) "true" }}
         securityContext:
           runAsUser: 0
@@ -547,8 +569,18 @@ spec:
           subPath: {{ $key }}
         {{- end -}}
         {{- end }}
-        - name: log-volume
-          mountPath: /var/log/nuodb
+        - mountPath: /var/log/nuodb
+          {{- if eq (include "defaultfalse" .Values.database.sm.logPersistence.enabled) "true" }}
+          name: log-volume
+          {{- else }}
+          name: eph-volume
+          subPath: log
+          {{- end }}
+        {{- if eq (include "database.enableEphemeralVolume" (list . .Values.database.sm)) "true" }}
+        - name: eph-volume
+          mountPath: /tmp
+          subPath: tmp
+        {{- end }}
         - name: nuosm
           mountPath: /usr/local/bin/nuosm
           subPath: nuosm
@@ -605,7 +637,7 @@ spec:
           # the SM becomes unready if it does not start within 15 minutes = 30s + 15s*58
           successThreshold: 2
           timeoutSeconds: {{ default 5 .Values.database.sm.readinessTimeoutSeconds }}
-      {{- include "nuodb.sidecar" . | nindent 6 }}
+      {{- include "nuodb.sidecar" (list . .Values.database.sm) | nindent 6 }}
 {{- include "nuodb.imagePullSecrets" . | indent 6 }}
       volumes:
       {{- include "nuodb.sidecar.volumes" . | nindent 6 }}
@@ -614,9 +646,9 @@ spec:
         configMap:
           name: {{ template "database.fullname" . }}-configuration
       {{- end }}
-      {{- if eq (include "defaultfalse" .Values.database.sm.logPersistence.enabled) "false" }}
-      - name: log-volume
-        emptyDir: {}
+      {{- if eq (include "database.enableEphemeralVolume" (list . .Values.database.sm)) "true" }}
+      - name: eph-volume
+        {{- include "database.ephemeralVolume" (list . .Values.database.sm) | indent 8 }}
       {{- end }}
       - name: nuosm
         configMap:

--- a/stable/database/values.yaml
+++ b/stable/database/values.yaml
@@ -42,7 +42,7 @@ nuodb:
   image:
     registry: docker.io
     repository: nuodb/nuodb-ce
-    tag: 4.3.2
+    tag: 5.0.3
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.
@@ -209,6 +209,9 @@ database:
     # container process
     allowPrivilegeEscalation: false
 
+    # Whether to mount the root filesystem as read-only.
+    readOnlyRootFilesystem: false
+
   ## Import Environment Variables inside containers
   # List of EnvVar v1 core definitions
   # ref: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#envvar-v1-core
@@ -275,6 +278,25 @@ database:
   # database name may be deployed into the same Kubernetes namespace. Set to
   # `false` to deploy secondary database Helm releases.
   primaryRelease: true
+
+  ephemeralVolume:
+    # Whether to enable generic ephemeral volumes, rather than using emptyDir
+    # for data that does not have to outlive the pod.
+    # ref: https://kubernetes.io/docs/concepts/storage/ephemeral-volumes/#generic-ephemeral-volumes
+    enabled: false
+
+    # The size of the generic ephemeral volume.
+    size: 1Gi
+
+    # Whether to size the volume according to the resources.limits.memory
+    # setting of the process, to guarantee that we have enough space to store
+    # at least one core file. Since core files are compressed before they hit
+    # the disk, it is likely that this setting is sufficient to retain many
+    # core files.
+    sizeToMemory: false
+
+    # The storage class to use for the generic ephemeral volume.
+    # storageClass: "-"
 
   sm:
     ## Enable persistent log volumes to retain logs when an external logging solution is not used.

--- a/stable/restore/Chart.yaml
+++ b/stable/restore/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   email: support@nuodb.com
 engine: gotpl
 icon: https://raw.githubusercontent.com/nuodb/nuodb-helm-charts/master/images/nuodb.svg
-appVersion: 4.3.2
+appVersion: 5.0.3
 tillerVersion: ">=2.9"

--- a/stable/restore/README.md
+++ b/stable/restore/README.md
@@ -111,6 +111,10 @@ The following tables list the configurable parameters of the database chart and 
 | `securityContext.enabled` | Creates a security context for Pods containing the `securityContext.runAsUser` and `securityContext.fsGroup` values | `false` |
 | `securityContext.runAsUser` | The user ID for the Pod security context created if `securityContext.enabled` is `true`. | `1000` |
 | `securityContext.fsGroup` | The `fsGroup` for the Pod security context created if any of `securityContext.fsGroupOnly`, `securityContext.runAsNonRootGroup`, or `securityContext.enabled` are `true`. | `1000` |
+| `securityContext.readOnlyRootFilesystem` | Whether to mount the root filesystem as read-only | `false` |
+| `ephemeralVolume.enabled` | Whether to create a generic ephemeral volume rather than emptyDir for any storage that does not outlive the pod | `false` |
+| `ephemeralVolume.size` | The size of the generic ephemeral volume to create | `1Gi` |
+| `ephemeralVolume.storageClass` | The storage class to use for the generic ephemeral volume | `nil` |
 
 #### nuodb.*
 

--- a/stable/restore/templates/_helpers.tpl
+++ b/stable/restore/templates/_helpers.tpl
@@ -313,3 +313,31 @@ Renders the name of the Secret for the database selected for restore
 {{- define "database.secretName" -}}
 {{ .Values.admin.domain }}-{{ template "restore.target" . }}
 {{- end -}}
+
+{{/*
+Renders an ephemeral volume.
+*/}}
+{{- define "database.ephemeralVolume" -}}
+{{- if eq (include "defaultfalse" .Values.database.ephemeralVolume.enabled) "true" }}
+ephemeral:
+  volumeClaimTemplate:
+    metadata:
+      labels:
+        {{- include "restore.resourceLabels" . | nindent 8 }}
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      {{- if .Values.database.ephemeralVolume.storageClass }}
+      {{- if (eq "-" .Values.database.ephemeralVolume.storageClass) }}
+      storageClassName: ""
+      {{- else }}
+      storageClassName: {{ .Values.database.ephemeralVolume.storageClass }}
+      {{- end }}
+      {{- end }}
+      resources:
+        requests:
+          storage: {{ .Values.database.ephemeralVolume.size }}
+{{- else }}
+emptyDir: {}
+{{- end }}
+{{- end -}}

--- a/stable/restore/templates/job.yaml
+++ b/stable/restore/templates/job.yaml
@@ -81,7 +81,7 @@ spec:
 {{- include "nuodb.imagePullSecrets" . | indent 6 }}
       volumes:
       - name: log-volume
-        emptyDir: {}
+        {{- include "database.ephemeralVolume" . | indent 8 }}
       - name: nuorestore
         configMap:
           name: {{ template "restore.fullname" . }}-nuorestore

--- a/stable/restore/values.yaml
+++ b/stable/restore/values.yaml
@@ -103,6 +103,21 @@ database:
     # container process
     allowPrivilegeEscalation: false
 
+    # Whether to mount the root filesystem as read-only.
+    readOnlyRootFilesystem: false
+
+  ephemeralVolume:
+    # Whether to enable generic ephemeral volumes, rather than using emptyDir
+    # for data that does not have to outlive the pod.
+    # ref: https://kubernetes.io/docs/concepts/storage/ephemeral-volumes/#generic-ephemeral-volumes
+    enabled: false
+
+    # The size of the generic ephemeral volume.
+    size: 1Gi
+
+    # The storage class to use for the generic ephemeral volume.
+    # storageClass: "-"
+
 restore:
 
   ## Provide a name in place of the chart name for `app:` labels

--- a/stable/restore/values.yaml
+++ b/stable/restore/values.yaml
@@ -32,7 +32,7 @@ nuodb:
   image:
     registry: docker.io
     repository: nuodb/nuodb-ce
-    tag: 4.3.2
+    tag: 5.0.3
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.

--- a/stable/storage-class/Chart.yaml
+++ b/stable/storage-class/Chart.yaml
@@ -12,5 +12,5 @@ maintainers:
   email: support@nuodb.com
 engine: gotpl
 icon: https://raw.githubusercontent.com/nuodb/nuodb-helm-charts/master/images/nuodb.svg
-appVersion: 4.3.2
+appVersion: 5.0.3
 tillerVersion: ">=2.9"

--- a/stable/transparent-hugepage/Chart.yaml
+++ b/stable/transparent-hugepage/Chart.yaml
@@ -13,5 +13,5 @@ maintainers:
   email: support@nuodb.com
 engine: gotpl
 icon: https://raw.githubusercontent.com/nuodb/nuodb-helm-charts/master/images/nuodb.svg
-appVersion: 4.3.2
+appVersion: 5.0.3
 tillerVersion: ">=2.9"

--- a/test/integration/template_admin_test.go
+++ b/test/integration/template_admin_test.go
@@ -888,7 +888,7 @@ func TestAdminSecurityContext(t *testing.T) {
 			assert.True(t, *containerSecurityContext.ReadOnlyRootFilesystem)
 
 			// Check that /tmp directory has ephemeral volume mounted to it
-			var tmpVolumeMount *v1.VolumeMount = nil
+			var tmpVolumeMount *v1.VolumeMount
 			for _, volumeMount := range container.VolumeMounts {
 				if volumeMount.MountPath == "/tmp" {
 					tmpVolumeMount = volumeMount.DeepCopy()
@@ -899,7 +899,7 @@ func TestAdminSecurityContext(t *testing.T) {
 			assert.Equal(t, "tmp", tmpVolumeMount.SubPath)
 
 			// Check that NUODOCKER_CONF_DIR=/tmp for generated nuoadmin.conf
-			var confDirEnv *v1.EnvVar = nil
+			var confDirEnv *v1.EnvVar
 			for _, env := range container.Env {
 				if env.Name == "NUODOCKER_CONF_DIR" {
 					confDirEnv = env.DeepCopy()

--- a/test/integration/template_admin_test.go
+++ b/test/integration/template_admin_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/gruntwork-io/terratest/modules/helm"
@@ -305,24 +306,102 @@ func TestAdminStatefulSetVolumes(t *testing.T) {
 	// Path to the helm chart we will test
 	helmChartPath := "../../stable/admin"
 
-	options := &helm.Options{
-		SetValues: map[string]string{"admin.logPersistence.enabled": "true"},
+	findEphemeralVolume := func(volumes []v1.Volume) *v1.Volume {
+		for _, volume := range volumes {
+			if volume.Name == "eph-volume" {
+				return &volume
+			}
+		}
+		return nil
 	}
 
-	// Run RenderTemplate to render the template and capture the output.
-	output := helm.RenderTemplate(t, options, helmChartPath, "release-name", []string{"templates/statefulset.yaml"})
+	assertStorageEquals := func(t *testing.T, volume *v1.Volume, size string) {
+		quantity, err := resource.ParseQuantity(size)
+		assert.NoError(t, err)
+		assert.Equal(t, volume.Ephemeral.VolumeClaimTemplate.Spec.Resources.Requests.Storage(), &quantity)
+	}
 
-	for _, obj := range testlib.SplitAndRenderStatefulSet(t, output, 1) {
-		vcts := make(map[string]bool)
+	t.Run("testDefault", func(t *testing.T) {
+		options := &helm.Options{}
 
-		for _, val := range obj.Spec.VolumeClaimTemplates {
-			vcts[val.ObjectMeta.Name] = true
+		// Render and decode StatefulSets
+		output := helm.RenderTemplate(t, options, helmChartPath, "release-name", []string{"templates/statefulset.yaml"})
+		for _, obj := range testlib.SplitAndRenderStatefulSet(t, output, 1) {
+			assert.True(t, strings.Contains(obj.Spec.VolumeClaimTemplates[0].ObjectMeta.Name, "raftlog"))
+			assert.Equal(t, 1, len(obj.Spec.VolumeClaimTemplates))
+
+			// Expect an emptyDir volume
+			ephemeralVolume := findEphemeralVolume(obj.Spec.Template.Spec.Volumes)
+			assert.NotNil(t, ephemeralVolume, "Expected to find eph-volume")
+			assert.NotNil(t, ephemeralVolume.EmptyDir, "Expected emptyDir volume")
+			assert.Nil(t, ephemeralVolume.Ephemeral, "Did not expect ephemeral volume")
+		}
+	})
+
+	t.Run("testEphemeralVolume", func(t *testing.T) {
+		options := &helm.Options{
+			SetValues: map[string]string{"admin.ephemeralVolume.enabled": "true"},
 		}
 
-		assert.Contains(t, vcts, "raftlog")
-		assert.Contains(t, vcts, "log-volume")
+		// Render and decode StatefulSets
+		output := helm.RenderTemplate(t, options, helmChartPath, "release-name", []string{"templates/statefulset.yaml"})
+		for _, obj := range testlib.SplitAndRenderStatefulSet(t, output, 1) {
+			assert.True(t, strings.Contains(obj.Spec.VolumeClaimTemplates[0].ObjectMeta.Name, "raftlog"))
+			assert.Equal(t, 1, len(obj.Spec.VolumeClaimTemplates))
 
-	}
+			// Expect an ephemeral volume
+			ephemeralVolume := findEphemeralVolume(obj.Spec.Template.Spec.Volumes)
+			assert.NotNil(t, ephemeralVolume, "Expected to find eph-volume")
+			assert.Nil(t, ephemeralVolume.EmptyDir, "Did not expect emptyDir volume")
+			assert.NotNil(t, ephemeralVolume.Ephemeral, "Expected ephemeral volume")
+			assertStorageEquals(t, ephemeralVolume, "1Gi")
+		}
+	})
+
+	t.Run("testLogPersistenceEnabled", func(t *testing.T) {
+		options := &helm.Options{
+			SetValues: map[string]string{"admin.logPersistence.enabled": "true"},
+		}
+
+		// Render and decode StatefulSets
+		output := helm.RenderTemplate(t, options, helmChartPath, "release-name", []string{"templates/statefulset.yaml"})
+		for _, obj := range testlib.SplitAndRenderStatefulSet(t, output, 1) {
+			assert.True(t, strings.Contains(obj.Spec.VolumeClaimTemplates[0].ObjectMeta.Name, "raftlog"))
+			assert.True(t, strings.Contains(obj.Spec.VolumeClaimTemplates[1].ObjectMeta.Name, "log-volume"))
+			assert.Equal(t, 2, len(obj.Spec.VolumeClaimTemplates))
+
+			// Expect no ephemeral volume
+			ephemeralVolume := findEphemeralVolume(obj.Spec.Template.Spec.Volumes)
+			assert.Nil(t, ephemeralVolume, "Did not expect to find eph-volume")
+		}
+	})
+
+	t.Run("testLogPersistenceEnabledWithReadOnlyRootFilesystem", func(t *testing.T) {
+		options := &helm.Options{
+			SetValues: map[string]string{
+				"admin.ephemeralVolume.enabled":                "true",
+				"admin.ephemeralVolume.size":                   "5Gi",
+				"admin.securityContext.enabledOnContainer":     "true",
+				"admin.securityContext.readOnlyRootFilesystem": "true",
+				"admin.logPersistence.enabled":                 "true",
+			},
+		}
+
+		// Render and decode StatefulSets
+		output := helm.RenderTemplate(t, options, helmChartPath, "release-name", []string{"templates/statefulset.yaml"})
+		for _, obj := range testlib.SplitAndRenderStatefulSet(t, output, 1) {
+			assert.True(t, strings.Contains(obj.Spec.VolumeClaimTemplates[0].ObjectMeta.Name, "raftlog"))
+			assert.True(t, strings.Contains(obj.Spec.VolumeClaimTemplates[1].ObjectMeta.Name, "log-volume"))
+			assert.Equal(t, 2, len(obj.Spec.VolumeClaimTemplates))
+
+			// Expect an ephemeral volume
+			ephemeralVolume := findEphemeralVolume(obj.Spec.Template.Spec.Volumes)
+			assert.NotNil(t, ephemeralVolume, "Expected to find eph-volume")
+			assert.Nil(t, ephemeralVolume.EmptyDir, "Did not expect emptyDir volume")
+			assert.NotNil(t, ephemeralVolume.Ephemeral, "Expected ephemeral volume")
+			assertStorageEquals(t, ephemeralVolume, "5Gi")
+		}
+	})
 }
 
 func TestAdminMultiClusterEnvVars(t *testing.T) {
@@ -790,6 +869,44 @@ func TestAdminSecurityContext(t *testing.T) {
 			assert.NotNil(t, containerSecurityContext)
 			assert.True(t, *containerSecurityContext.Privileged)
 			assert.True(t, *containerSecurityContext.AllowPrivilegeEscalation)
+		}
+	})
+
+	t.Run("testReadOnlyRootFilesystem", func(t *testing.T) {
+		options := &helm.Options{
+			SetValues: map[string]string{
+				"admin.securityContext.enabledOnContainer":     "true",
+				"admin.securityContext.readOnlyRootFilesystem": "true",
+			},
+		}
+
+		output := helm.RenderTemplate(t, options, helmChartPath, "release-name", []string{"templates/statefulset.yaml"})
+		for _, obj := range testlib.SplitAndRenderStatefulSet(t, output, 1) {
+			container := obj.Spec.Template.Spec.Containers[0]
+			containerSecurityContext := container.SecurityContext
+			assert.NotNil(t, containerSecurityContext)
+			assert.True(t, *containerSecurityContext.ReadOnlyRootFilesystem)
+
+			// Check that /tmp directory has ephemeral volume mounted to it
+			var tmpVolumeMount *v1.VolumeMount = nil
+			for _, volumeMount := range container.VolumeMounts {
+				if volumeMount.MountPath == "/tmp" {
+					tmpVolumeMount = volumeMount.DeepCopy()
+				}
+			}
+			assert.NotNil(t, tmpVolumeMount, "Expected /tmp volume mount")
+			assert.Equal(t, "eph-volume", tmpVolumeMount.Name)
+			assert.Equal(t, "tmp", tmpVolumeMount.SubPath)
+
+			// Check that NUODOCKER_CONF_DIR=/tmp for generated nuoadmin.conf
+			var confDirEnv *v1.EnvVar = nil
+			for _, env := range container.Env {
+				if env.Name == "NUODOCKER_CONF_DIR" {
+					confDirEnv = env.DeepCopy()
+				}
+			}
+			assert.NotNil(t, confDirEnv, "Expected to find NUODOCKER_CONF_DIR environment variable")
+			assert.Equal(t, "/tmp", confDirEnv.Value)
 		}
 	})
 

--- a/test/integration/template_collector_test.go
+++ b/test/integration/template_collector_test.go
@@ -62,8 +62,9 @@ func checkSidecarContainers(t *testing.T, containers []v1.Container, options *he
 			continue
 		}
 		assert.Contains(t, container.VolumeMounts, v1.VolumeMount{
-			Name:      "nuocollector-config",
+			Name:      "eph-volume",
 			MountPath: "/etc/telegraf/telegraf.d/dynamic/",
+			SubPath:   "telegraf",
 		})
 		if logPersistenceEnabled {
 			assert.Contains(t, container.VolumeMounts, v1.VolumeMount{
@@ -96,20 +97,16 @@ func checkSidecarContainers(t *testing.T, containers []v1.Container, options *he
 }
 
 func checkSpecVolumes(t *testing.T, volumes []v1.Volume, options *helm.Options, chartPath string) {
-	require.NotEmpty(t, volumes)
-	found := false
+	if options.SetValues["nuocollector.enabled"] == "false" {
+		return
+	}
+	// Check that ephemeral volume is enabled. This is needed to share telegraf config.
 	for _, volume := range volumes {
-		if volume.Name == "nuocollector-config" {
-			found = true
-			// Check that empty dir is mounted
-			assert.NotNil(t, volume.EmptyDir)
+		if volume.Name == "eph-volume" {
+			return
 		}
 	}
-	if options.SetValues["nuocollector.enabled"] == "true" {
-		assert.True(t, found, "nuocollector-config should be declared as volume")
-	} else {
-		assert.False(t, found, "nuocollector-config is declared as volume with nuocollector disabled")
-	}
+	assert.Fail(t, "eph-volume should be declared as volume")
 }
 
 func checkPluginsRendered(t *testing.T, configMaps []v1.ConfigMap, options *helm.Options, chartPath string, expectedNrPlugins int) {
@@ -207,6 +204,25 @@ func TestNuoDBCollectorSidecarsDisabled(t *testing.T) {
 			"nuocollector.watcher.registry":   "docker.io",
 			"nuocollector.watcher.repository": "kiwigrid/k8s-sidecar",
 			"nuocollector.watcher.tag":        "latest",
+		},
+	}
+	executeSidecarTests(t, options)
+}
+
+func TestNuoDBCollectorSidecarsLogPersistence(t *testing.T) {
+
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"admin.logPersistence.enabled":       "true",
+			"database.sm.logPersistence.enabled": "true",
+			"database.te.logPersistence.enabled": "true",
+			"nuocollector.enabled":               "true",
+			"nuocollector.image.registry":        "docker.io",
+			"nuocollector.image.repository":      "nuodb/nuocd",
+			"nuocollector.image.tag":             "1.0.0",
+			"nuocollector.watcher.registry":      "docker.io",
+			"nuocollector.watcher.repository":    "kiwigrid/k8s-sidecar",
+			"nuocollector.watcher.tag":           "latest",
 		},
 	}
 	executeSidecarTests(t, options)

--- a/test/integration/template_database_test.go
+++ b/test/integration/template_database_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/gruntwork-io/terratest/modules/helm"
@@ -277,28 +278,218 @@ func TestDatabaseStatefulSetResourceLabels(t *testing.T) {
 
 }
 
-func TestDatabaseStatefulSetVolumes(t *testing.T) {
+func TestDatabaseVolumes(t *testing.T) {
 	// Path to the helm chart we will test
 	helmChartPath := "../../stable/database"
 
-	options := &helm.Options{
-		SetValues: map[string]string{"database.sm.logPersistence.enabled": "true"},
-	}
-
-	// Run RenderTemplate to render the template and capture the output.
-	output := helm.RenderTemplate(t, options, helmChartPath, "release-name", []string{"templates/statefulset.yaml"})
-
-	for _, obj := range testlib.SplitAndRenderStatefulSet(t, output, 2) {
-		if strings.Contains(obj.Name, "-hotcopy") {
-			assert.True(t, strings.Contains(obj.Spec.VolumeClaimTemplates[0].ObjectMeta.Name, "archive-volume"))
-			assert.True(t, strings.Contains(obj.Spec.VolumeClaimTemplates[1].ObjectMeta.Name, "backup-volume"))
-			assert.True(t, strings.Contains(obj.Spec.VolumeClaimTemplates[2].ObjectMeta.Name, "log-volume"))
-		} else {
-			assert.True(t, strings.Contains(obj.Spec.VolumeClaimTemplates[0].ObjectMeta.Name, "archive-volume"))
-			assert.True(t, strings.Contains(obj.Spec.VolumeClaimTemplates[1].ObjectMeta.Name, "log-volume"))
+	findEphemeralVolume := func(volumes []v1.Volume) *v1.Volume {
+		for _, volume := range volumes {
+			if volume.Name == "eph-volume" {
+				return &volume
+			}
 		}
+		return nil
 	}
 
+	assertStorageEquals := func(t *testing.T, volume *v1.Volume, size string) {
+		quantity, err := resource.ParseQuantity(size)
+		assert.NoError(t, err)
+		assert.Equal(t, volume.Ephemeral.VolumeClaimTemplate.Spec.Resources.Requests.Storage(), &quantity)
+	}
+
+	t.Run("testDefault", func(t *testing.T) {
+		options := &helm.Options{}
+
+		// Render and decode StatefulSets
+		output := helm.RenderTemplate(t, options, helmChartPath, "release-name", []string{"templates/statefulset.yaml"})
+		for _, obj := range testlib.SplitAndRenderStatefulSet(t, output, 2) {
+			if strings.Contains(obj.Name, "-hotcopy") {
+				assert.True(t, strings.Contains(obj.Spec.VolumeClaimTemplates[0].ObjectMeta.Name, "archive-volume"))
+				assert.True(t, strings.Contains(obj.Spec.VolumeClaimTemplates[1].ObjectMeta.Name, "backup-volume"))
+				assert.Equal(t, 2, len(obj.Spec.VolumeClaimTemplates))
+			} else {
+				assert.True(t, strings.Contains(obj.Spec.VolumeClaimTemplates[0].ObjectMeta.Name, "archive-volume"))
+				assert.Equal(t, 1, len(obj.Spec.VolumeClaimTemplates))
+			}
+
+			// Expect an emptyDir volume
+			ephemeralVolume := findEphemeralVolume(obj.Spec.Template.Spec.Volumes)
+			assert.NotNil(t, ephemeralVolume, "Expected to find eph-volume")
+			assert.NotNil(t, ephemeralVolume.EmptyDir, "Expected emptyDir volume")
+			assert.Nil(t, ephemeralVolume.Ephemeral, "Did not expect ephemeral volume")
+		}
+
+		// Render and decode Deployments
+		output = helm.RenderTemplate(t, options, helmChartPath, "release-name", []string{"templates/deployment.yaml"})
+		for _, obj := range testlib.SplitAndRenderDeployment(t, output, 1) {
+			// Expect an emptyDir volume
+			ephemeralVolume := findEphemeralVolume(obj.Spec.Template.Spec.Volumes)
+			assert.NotNil(t, ephemeralVolume, "Expected to find eph-volume")
+			assert.NotNil(t, ephemeralVolume.EmptyDir, "Expected emptyDir volume")
+			assert.Nil(t, ephemeralVolume.Ephemeral, "Did not expect ephemeral volume")
+		}
+	})
+
+	t.Run("testEphemeralVolume", func(t *testing.T) {
+		options := &helm.Options{
+			SetValues: map[string]string{"database.ephemeralVolume.enabled": "true"},
+		}
+
+		// Render and decode StatefulSets
+		output := helm.RenderTemplate(t, options, helmChartPath, "release-name", []string{"templates/statefulset.yaml"})
+		for _, obj := range testlib.SplitAndRenderStatefulSet(t, output, 2) {
+			if strings.Contains(obj.Name, "-hotcopy") {
+				assert.True(t, strings.Contains(obj.Spec.VolumeClaimTemplates[0].ObjectMeta.Name, "archive-volume"))
+				assert.True(t, strings.Contains(obj.Spec.VolumeClaimTemplates[1].ObjectMeta.Name, "backup-volume"))
+				assert.Equal(t, 2, len(obj.Spec.VolumeClaimTemplates))
+			} else {
+				assert.True(t, strings.Contains(obj.Spec.VolumeClaimTemplates[0].ObjectMeta.Name, "archive-volume"))
+				assert.Equal(t, 1, len(obj.Spec.VolumeClaimTemplates))
+			}
+
+			// Expect an ephemeral volume
+			ephemeralVolume := findEphemeralVolume(obj.Spec.Template.Spec.Volumes)
+			assert.NotNil(t, ephemeralVolume, "Expected to find eph-volume")
+			assert.Nil(t, ephemeralVolume.EmptyDir, "Did not expect emptyDir volume")
+			assert.NotNil(t, ephemeralVolume.Ephemeral, "Expected ephemeral volume")
+			assertStorageEquals(t, ephemeralVolume, "1Gi")
+		}
+
+		// Render and decode Deployments
+		output = helm.RenderTemplate(t, options, helmChartPath, "release-name", []string{"templates/deployment.yaml"})
+		for _, obj := range testlib.SplitAndRenderDeployment(t, output, 1) {
+			// Expect an ephemeral volume
+			ephemeralVolume := findEphemeralVolume(obj.Spec.Template.Spec.Volumes)
+			assert.NotNil(t, ephemeralVolume, "Expected to find eph-volume")
+			assert.Nil(t, ephemeralVolume.EmptyDir, "Did not expect emptyDir volume")
+			assert.NotNil(t, ephemeralVolume.Ephemeral, "Expected ephemeral volume")
+			assertStorageEquals(t, ephemeralVolume, "1Gi")
+		}
+	})
+
+	t.Run("testEphemeralVolumeSizeToMemory", func(t *testing.T) {
+		options := &helm.Options{
+			SetValues: map[string]string{
+				"database.ephemeralVolume.enabled":      "true",
+				"database.ephemeralVolume.sizeToMemory": "true",
+				"database.sm.resources.limits.memory":   "5Gi",
+				"database.te.resources.limits.memory":   "10Gi",
+			},
+		}
+
+		// Render and decode StatefulSets
+		output := helm.RenderTemplate(t, options, helmChartPath, "release-name", []string{"templates/statefulset.yaml"})
+		for _, obj := range testlib.SplitAndRenderStatefulSet(t, output, 2) {
+			if strings.Contains(obj.Name, "-hotcopy") {
+				assert.True(t, strings.Contains(obj.Spec.VolumeClaimTemplates[0].ObjectMeta.Name, "archive-volume"))
+				assert.True(t, strings.Contains(obj.Spec.VolumeClaimTemplates[1].ObjectMeta.Name, "backup-volume"))
+				assert.Equal(t, 2, len(obj.Spec.VolumeClaimTemplates))
+			} else {
+				assert.True(t, strings.Contains(obj.Spec.VolumeClaimTemplates[0].ObjectMeta.Name, "archive-volume"))
+				assert.Equal(t, 1, len(obj.Spec.VolumeClaimTemplates))
+			}
+
+			// Expect an ephemeral volume
+			ephemeralVolume := findEphemeralVolume(obj.Spec.Template.Spec.Volumes)
+			assert.NotNil(t, ephemeralVolume, "Expected to find eph-volume")
+			assert.Nil(t, ephemeralVolume.EmptyDir, "Did not expect emptyDir volume")
+			assert.NotNil(t, ephemeralVolume.Ephemeral, "Expected ephemeral volume")
+			assertStorageEquals(t, ephemeralVolume, "5Gi")
+		}
+
+		// Render and decode Deployments
+		output = helm.RenderTemplate(t, options, helmChartPath, "release-name", []string{"templates/deployment.yaml"})
+		for _, obj := range testlib.SplitAndRenderDeployment(t, output, 1) {
+			// Expect an ephemeral volume
+			ephemeralVolume := findEphemeralVolume(obj.Spec.Template.Spec.Volumes)
+			assert.NotNil(t, ephemeralVolume, "Expected to find eph-volume")
+			assert.Nil(t, ephemeralVolume.EmptyDir, "Did not expect emptyDir volume")
+			assert.NotNil(t, ephemeralVolume.Ephemeral, "Expected ephemeral volume")
+			assertStorageEquals(t, ephemeralVolume, "10Gi")
+		}
+	})
+
+	t.Run("testLogPersistenceEnabled", func(t *testing.T) {
+		options := &helm.Options{
+			SetValues: map[string]string{
+				"database.sm.logPersistence.enabled": "true",
+				"database.te.logPersistence.enabled": "true",
+			},
+		}
+
+		// Render and decode StatefulSets
+		output := helm.RenderTemplate(t, options, helmChartPath, "release-name", []string{"templates/statefulset.yaml"})
+		for _, obj := range testlib.SplitAndRenderStatefulSet(t, output, 2) {
+			if strings.Contains(obj.Name, "-hotcopy") {
+				assert.True(t, strings.Contains(obj.Spec.VolumeClaimTemplates[0].ObjectMeta.Name, "archive-volume"))
+				assert.True(t, strings.Contains(obj.Spec.VolumeClaimTemplates[1].ObjectMeta.Name, "backup-volume"))
+				assert.True(t, strings.Contains(obj.Spec.VolumeClaimTemplates[2].ObjectMeta.Name, "log-volume"))
+				assert.Equal(t, 3, len(obj.Spec.VolumeClaimTemplates))
+			} else {
+				assert.True(t, strings.Contains(obj.Spec.VolumeClaimTemplates[0].ObjectMeta.Name, "archive-volume"))
+				assert.True(t, strings.Contains(obj.Spec.VolumeClaimTemplates[1].ObjectMeta.Name, "log-volume"))
+				assert.Equal(t, 2, len(obj.Spec.VolumeClaimTemplates))
+			}
+
+			// Expect no ephemeral volume
+			ephemeralVolume := findEphemeralVolume(obj.Spec.Template.Spec.Volumes)
+			assert.Nil(t, ephemeralVolume, "Did not expect to find eph-volume")
+		}
+
+		// Render and decode Deployments
+		output = helm.RenderTemplate(t, options, helmChartPath, "release-name", []string{"templates/deployment.yaml"})
+		for _, obj := range testlib.SplitAndRenderDeployment(t, output, 1) {
+			// Expect no ephemeral volume
+			ephemeralVolume := findEphemeralVolume(obj.Spec.Template.Spec.Volumes)
+			assert.Nil(t, ephemeralVolume, "Did not expect to find eph-volume")
+		}
+	})
+
+	t.Run("testLogPersistenceEnabledWithReadOnlyRootFilesystem", func(t *testing.T) {
+		options := &helm.Options{
+			SetValues: map[string]string{
+				"database.ephemeralVolume.enabled":                "true",
+				"database.ephemeralVolume.size":                   "5Gi",
+				"database.securityContext.enabledOnContainer":     "true",
+				"database.securityContext.readOnlyRootFilesystem": "true",
+				"database.sm.logPersistence.enabled":              "true",
+				"database.te.logPersistence.enabled":              "true",
+			},
+		}
+
+		// Render and decode StatefulSets
+		output := helm.RenderTemplate(t, options, helmChartPath, "release-name", []string{"templates/statefulset.yaml"})
+		for _, obj := range testlib.SplitAndRenderStatefulSet(t, output, 2) {
+			if strings.Contains(obj.Name, "-hotcopy") {
+				assert.True(t, strings.Contains(obj.Spec.VolumeClaimTemplates[0].ObjectMeta.Name, "archive-volume"))
+				assert.True(t, strings.Contains(obj.Spec.VolumeClaimTemplates[1].ObjectMeta.Name, "backup-volume"))
+				assert.True(t, strings.Contains(obj.Spec.VolumeClaimTemplates[2].ObjectMeta.Name, "log-volume"))
+				assert.Equal(t, 3, len(obj.Spec.VolumeClaimTemplates))
+			} else {
+				assert.True(t, strings.Contains(obj.Spec.VolumeClaimTemplates[0].ObjectMeta.Name, "archive-volume"))
+				assert.True(t, strings.Contains(obj.Spec.VolumeClaimTemplates[1].ObjectMeta.Name, "log-volume"))
+				assert.Equal(t, 2, len(obj.Spec.VolumeClaimTemplates))
+			}
+
+			// Expect an ephemeral volume
+			ephemeralVolume := findEphemeralVolume(obj.Spec.Template.Spec.Volumes)
+			assert.NotNil(t, ephemeralVolume, "Expected to find eph-volume")
+			assert.Nil(t, ephemeralVolume.EmptyDir, "Did not expect emptyDir volume")
+			assert.NotNil(t, ephemeralVolume.Ephemeral, "Expected ephemeral volume")
+			assertStorageEquals(t, ephemeralVolume, "5Gi")
+		}
+
+		// Render and decode Deployments
+		output = helm.RenderTemplate(t, options, helmChartPath, "release-name", []string{"templates/deployment.yaml"})
+		for _, obj := range testlib.SplitAndRenderDeployment(t, output, 1) {
+			// Expect an ephemeral volume
+			ephemeralVolume := findEphemeralVolume(obj.Spec.Template.Spec.Volumes)
+			assert.NotNil(t, ephemeralVolume, "Expected to find eph-volume")
+			assert.Nil(t, ephemeralVolume.EmptyDir, "Did not expect emptyDir volume")
+			assert.NotNil(t, ephemeralVolume.Ephemeral, "Expected ephemeral volume")
+			assertStorageEquals(t, ephemeralVolume, "5Gi")
+		}
+	})
 }
 
 func TestDatabaseDeploymentRenders(t *testing.T) {
@@ -1230,6 +1421,44 @@ func TestDatabaseSecurityContext(t *testing.T) {
 			assert.NotNil(t, containerSecurityContext)
 			assert.True(t, *containerSecurityContext.Privileged)
 			assert.True(t, *containerSecurityContext.AllowPrivilegeEscalation)
+		}
+	})
+
+	t.Run("testReadOnlyRootFilesystem", func(t *testing.T) {
+		options := &helm.Options{
+			SetValues: map[string]string{
+				"database.securityContext.enabledOnContainer":     "true",
+				"database.securityContext.readOnlyRootFilesystem": "true",
+			},
+		}
+
+		checkContainer := func(t *testing.T, container v1.Container) {
+			containerSecurityContext := container.SecurityContext
+			assert.NotNil(t, containerSecurityContext)
+			assert.True(t, *containerSecurityContext.ReadOnlyRootFilesystem)
+
+			// Check that /tmp directory has ephemeral volume mounted to it
+			var tmpVolumeMount *v1.VolumeMount = nil
+			for _, volumeMount := range container.VolumeMounts {
+				if volumeMount.MountPath == "/tmp" {
+					tmpVolumeMount = volumeMount.DeepCopy()
+				}
+			}
+			assert.NotNil(t, tmpVolumeMount, "Expected /tmp volume mount")
+			assert.Equal(t, "eph-volume", tmpVolumeMount.Name)
+			assert.Equal(t, "tmp", tmpVolumeMount.SubPath)
+		}
+
+		// Check SM StatefulSets
+		output := helm.RenderTemplate(t, options, helmChartPath, "release-name", []string{"templates/statefulset.yaml"})
+		for _, obj := range testlib.SplitAndRenderStatefulSet(t, output, 2) {
+			checkContainer(t, obj.Spec.Template.Spec.Containers[0])
+		}
+
+		// Check TE Deployment
+		output = helm.RenderTemplate(t, options, helmChartPath, "release-name", []string{"templates/deployment.yaml"})
+		for _, obj := range testlib.SplitAndRenderDeployment(t, output, 1) {
+			checkContainer(t, obj.Spec.Template.Spec.Containers[0])
 		}
 	})
 

--- a/test/integration/template_database_test.go
+++ b/test/integration/template_database_test.go
@@ -1438,7 +1438,7 @@ func TestDatabaseSecurityContext(t *testing.T) {
 			assert.True(t, *containerSecurityContext.ReadOnlyRootFilesystem)
 
 			// Check that /tmp directory has ephemeral volume mounted to it
-			var tmpVolumeMount *v1.VolumeMount = nil
+			var tmpVolumeMount *v1.VolumeMount
 			for _, volumeMount := range container.VolumeMounts {
 				if volumeMount.MountPath == "/tmp" {
 					tmpVolumeMount = volumeMount.DeepCopy()

--- a/test/integration/template_database_test.go
+++ b/test/integration/template_database_test.go
@@ -291,6 +291,17 @@ func TestDatabaseVolumes(t *testing.T) {
 		return nil
 	}
 
+	// Returns a map of mount point to subpath for all eph-volume mounts
+	findEphemeralVolumeMounts := func(mounts []v1.VolumeMount) map[string]string {
+		ret := make(map[string]string)
+		for _, mount := range mounts {
+			if mount.Name == "eph-volume" {
+				ret[mount.MountPath] = mount.SubPath
+			}
+		}
+		return ret
+	}
+
 	assertStorageEquals := func(t *testing.T, volume *v1.Volume, size string) {
 		quantity, err := resource.ParseQuantity(size)
 		assert.NoError(t, err)
@@ -317,6 +328,13 @@ func TestDatabaseVolumes(t *testing.T) {
 			assert.NotNil(t, ephemeralVolume, "Expected to find eph-volume")
 			assert.NotNil(t, ephemeralVolume.EmptyDir, "Expected emptyDir volume")
 			assert.Nil(t, ephemeralVolume.Ephemeral, "Did not expect ephemeral volume")
+
+			// Expect volume mounts for eph-volume
+			mounts := findEphemeralVolumeMounts(obj.Spec.Template.Spec.Containers[0].VolumeMounts)
+			assert.Equal(t, mounts, map[string]string{
+				"/tmp":           "tmp",
+				"/var/log/nuodb": "log",
+			})
 		}
 
 		// Render and decode Deployments
@@ -327,6 +345,13 @@ func TestDatabaseVolumes(t *testing.T) {
 			assert.NotNil(t, ephemeralVolume, "Expected to find eph-volume")
 			assert.NotNil(t, ephemeralVolume.EmptyDir, "Expected emptyDir volume")
 			assert.Nil(t, ephemeralVolume.Ephemeral, "Did not expect ephemeral volume")
+
+			// Expect volume mounts for eph-volume
+			mounts := findEphemeralVolumeMounts(obj.Spec.Template.Spec.Containers[0].VolumeMounts)
+			assert.Equal(t, mounts, map[string]string{
+				"/tmp":           "tmp",
+				"/var/log/nuodb": "log",
+			})
 		}
 	})
 
@@ -353,6 +378,13 @@ func TestDatabaseVolumes(t *testing.T) {
 			assert.Nil(t, ephemeralVolume.EmptyDir, "Did not expect emptyDir volume")
 			assert.NotNil(t, ephemeralVolume.Ephemeral, "Expected ephemeral volume")
 			assertStorageEquals(t, ephemeralVolume, "1Gi")
+
+			// Expect volume mounts for eph-volume
+			mounts := findEphemeralVolumeMounts(obj.Spec.Template.Spec.Containers[0].VolumeMounts)
+			assert.Equal(t, mounts, map[string]string{
+				"/tmp":           "tmp",
+				"/var/log/nuodb": "log",
+			})
 		}
 
 		// Render and decode Deployments
@@ -364,6 +396,13 @@ func TestDatabaseVolumes(t *testing.T) {
 			assert.Nil(t, ephemeralVolume.EmptyDir, "Did not expect emptyDir volume")
 			assert.NotNil(t, ephemeralVolume.Ephemeral, "Expected ephemeral volume")
 			assertStorageEquals(t, ephemeralVolume, "1Gi")
+
+			// Expect volume mounts for eph-volume
+			mounts := findEphemeralVolumeMounts(obj.Spec.Template.Spec.Containers[0].VolumeMounts)
+			assert.Equal(t, mounts, map[string]string{
+				"/tmp":           "tmp",
+				"/var/log/nuodb": "log",
+			})
 		}
 	})
 
@@ -395,6 +434,13 @@ func TestDatabaseVolumes(t *testing.T) {
 			assert.Nil(t, ephemeralVolume.EmptyDir, "Did not expect emptyDir volume")
 			assert.NotNil(t, ephemeralVolume.Ephemeral, "Expected ephemeral volume")
 			assertStorageEquals(t, ephemeralVolume, "5Gi")
+
+			// Expect volume mounts for eph-volume
+			mounts := findEphemeralVolumeMounts(obj.Spec.Template.Spec.Containers[0].VolumeMounts)
+			assert.Equal(t, mounts, map[string]string{
+				"/tmp":           "tmp",
+				"/var/log/nuodb": "log",
+			})
 		}
 
 		// Render and decode Deployments
@@ -406,6 +452,13 @@ func TestDatabaseVolumes(t *testing.T) {
 			assert.Nil(t, ephemeralVolume.EmptyDir, "Did not expect emptyDir volume")
 			assert.NotNil(t, ephemeralVolume.Ephemeral, "Expected ephemeral volume")
 			assertStorageEquals(t, ephemeralVolume, "10Gi")
+
+			// Expect volume mounts for eph-volume
+			mounts := findEphemeralVolumeMounts(obj.Spec.Template.Spec.Containers[0].VolumeMounts)
+			assert.Equal(t, mounts, map[string]string{
+				"/tmp":           "tmp",
+				"/var/log/nuodb": "log",
+			})
 		}
 	})
 
@@ -434,6 +487,10 @@ func TestDatabaseVolumes(t *testing.T) {
 			// Expect no ephemeral volume
 			ephemeralVolume := findEphemeralVolume(obj.Spec.Template.Spec.Volumes)
 			assert.Nil(t, ephemeralVolume, "Did not expect to find eph-volume")
+
+			// Expect no volume mounts for eph-volume
+			mounts := findEphemeralVolumeMounts(obj.Spec.Template.Spec.Containers[0].VolumeMounts)
+			assert.Equal(t, mounts, map[string]string{})
 		}
 
 		// Render and decode Deployments
@@ -442,6 +499,10 @@ func TestDatabaseVolumes(t *testing.T) {
 			// Expect no ephemeral volume
 			ephemeralVolume := findEphemeralVolume(obj.Spec.Template.Spec.Volumes)
 			assert.Nil(t, ephemeralVolume, "Did not expect to find eph-volume")
+
+			// Expect no volume mounts for eph-volume
+			mounts := findEphemeralVolumeMounts(obj.Spec.Template.Spec.Containers[0].VolumeMounts)
+			assert.Equal(t, mounts, map[string]string{})
 		}
 	})
 
@@ -477,6 +538,10 @@ func TestDatabaseVolumes(t *testing.T) {
 			assert.Nil(t, ephemeralVolume.EmptyDir, "Did not expect emptyDir volume")
 			assert.NotNil(t, ephemeralVolume.Ephemeral, "Expected ephemeral volume")
 			assertStorageEquals(t, ephemeralVolume, "5Gi")
+
+			// Expect only /tmp volume mount for eph-volume
+			mounts := findEphemeralVolumeMounts(obj.Spec.Template.Spec.Containers[0].VolumeMounts)
+			assert.Equal(t, mounts, map[string]string{"/tmp": "tmp"})
 		}
 
 		// Render and decode Deployments
@@ -488,6 +553,10 @@ func TestDatabaseVolumes(t *testing.T) {
 			assert.Nil(t, ephemeralVolume.EmptyDir, "Did not expect emptyDir volume")
 			assert.NotNil(t, ephemeralVolume.Ephemeral, "Expected ephemeral volume")
 			assertStorageEquals(t, ephemeralVolume, "5Gi")
+
+			// Expect only /tmp volume mount for eph-volume
+			mounts := findEphemeralVolumeMounts(obj.Spec.Template.Spec.Containers[0].VolumeMounts)
+			assert.Equal(t, mounts, map[string]string{"/tmp": "tmp"})
 		}
 	})
 }

--- a/test/multicluster/minikube_base_multicluster_test.go
+++ b/test/multicluster/minikube_base_multicluster_test.go
@@ -74,9 +74,6 @@ func TestKubernetesBasicMultiCluster(t *testing.T) {
 			"database.sm.resources.requests.memory": testlib.MINIMAL_VIABLE_ENGINE_MEMORY,
 			"database.te.resources.requests.cpu":    testlib.MINIMAL_VIABLE_ENGINE_CPU,
 			"database.te.resources.requests.memory": testlib.MINIMAL_VIABLE_ENGINE_MEMORY,
-			// K8s version of AKS cluster does not support generic ephemeral volumes
-			"admin.ephemeralVolume.enabled":    "false",
-			"database.ephemeralVolume.enabled": "false",
 		},
 	}
 

--- a/test/multicluster/minikube_base_multicluster_test.go
+++ b/test/multicluster/minikube_base_multicluster_test.go
@@ -74,6 +74,9 @@ func TestKubernetesBasicMultiCluster(t *testing.T) {
 			"database.sm.resources.requests.memory": testlib.MINIMAL_VIABLE_ENGINE_MEMORY,
 			"database.te.resources.requests.cpu":    testlib.MINIMAL_VIABLE_ENGINE_CPU,
 			"database.te.resources.requests.memory": testlib.MINIMAL_VIABLE_ENGINE_MEMORY,
+			// K8s version of AKS cluster does not support generic ephemeral volumes
+			"admin.ephemeralVolume.enabled":    "false",
+			"database.ephemeralVolume.enabled": "false",
 		},
 	}
 


### PR DESCRIPTION
This change adds support for the security feature
readOnlyRootFilesystem, which prevents any modifications from being made to the root filesystem, and also adds support for generic ephemeral volumes, which is an alternative to emptyDir that provisions an actual PVC that is bound to the lifecycle of the pod.

Generic ephemeral volumes can be used in place of emptyDir volumes. Regardless of what sort of ephemeral storage used for the pod, this change also volume mounts a subpath of the ephemeral storage into /tmp, which is a location that NuoDB processes write to that we were not mounting a volume to.

This change also bumps the default image version to 5.0.3, which supports readOnlyRootFilesystem. readOnlyRootFilesystem=true for the admin requires the NUODOCKER_CONF_DIR environment variable to be used to specify the directory to create the generated nuoadmin.conf file into. This functionality is available in >=4.3.3 and >=4.2.5.