### PR TITLE
Add liveness probe and improve readiness probe plumbing

### DIFF
--- a/stable/admin/README.md
+++ b/stable/admin/README.md
@@ -208,7 +208,17 @@ The following tables list the configurable parameters for the `admin` option of 
 | `serviceSuffix.balancer` | The suffix to use for the LoadBalancer service name | `balancer` |
 | `serviceSuffix.clusterip` | The suffix to use for the ClusterIP service name | `clusterip` |
 | `serviceSuffix.nodeport` | The suffix to use for the NodePort service name | `nodeport` |
-| `readinessTimeoutSeconds` | Admin readiness probe timeout, sometimes needs adjusting depending on environment and pod resources | `1` |
+| `livenessProbe.enabled` | Whether to enable the liveness probe for the nuoadmin container | `true` |
+| `livenessProbe.initialDelaySeconds` | The initial delay for the liveness probe | `60` |
+| `livenessProbe.periodSeconds` | The period at which the liveness probe is invoked | `60` |
+| `livenessProbe.failureThreshold` | The number of times that the liveness probe must fail consecutively before the nuoadmin container is restarted | `10` |
+| `livenessProbe.timeoutSeconds` | The timeout for liveness probe invocations | `20` |
+| `readinessProbe.initialDelaySeconds` | The initial delay for the readiness probe | `10` |
+| `readinessProbe.periodSeconds` | The period at which the readiness probe is invoked | `15` |
+| `readinessProbe.failureThreshold` | The number of times that the readiness probe must fail consecutively before the nuoadmin container is considered not ready | `4` |
+| `readinessProbe.successThreshold` | The number of times that the readiness probe must succeed consecutively before the nuoadmin container is considered ready | `1` |
+| `readinessProbe.timeoutSeconds` | The timeout for readiness probe invocations | `10` |
+| `readinessTimeoutSeconds` | The timeout for readiness probe invocations. This is a deprecated alias for `readinessProbe.timeoutSeconds` that will become unsupported in some future release. | `nil` |
 | `podAnnotations` | Annotations to pass through to the Admin pod | `nil` |
 | `tde.secrets` | Transparent Data Encryption secret names used for different databases | `{}` |
 | `tde.storagePasswordsDir` | Transparent Data Encryption storage passwords mount path | `/etc/nuodb/tde` |
@@ -252,7 +262,7 @@ Features in this section have been deprecated but not yet removed.
 
 | Key | Description | Default |
 | ----- | ----------- | ------ |
-| `loadBalancerJob.enabled` | Create a job that sets the default load balancer policy for the admin tier. Replaced by Kubernetes Aware Admin. | false |
+| `loadBalancerJob.enabled` | Create a job that sets the default load balancer policy for the admin tier. Replaced by Kubernetes Aware Admin. | `false` |
 
 
 #### nuocollector.*

--- a/stable/admin/files/livenessprobe
+++ b/stable/admin/files/livenessprobe
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+# (C) Copyright NuoDB, Inc. 2023  All Rights Reserved
+# This file is licensed under the BSD 3-Clause License.
+# See https://github.com/nuodb/nuodb-helm-charts/blob/master/LICENSE
+
+# use 'nuocmd check server' (singular) to check that the local AP is caught up
+# with the Raft leader; specify a timeout to avoid failures due to concurrent
+# Raft commits
+out="$(nuocmd check server --check-converged --timeout 10 2>&1)"
+ret=$?
+
+# nuocmd returns exit code 2 if there is a parse error due to unrecognized
+# subcommand or arguments; avoid non-0 exit code due to parse error, which
+# could be due to the 'nuocmd check server' (singular) subcommand not being
+# supported by the version of NuoDB being used
+if [ $ret != 2 ]; then
+    # the command succeeded or failed with a non-parse error; emit command
+    # output and exit
+    echo "$out"
+    exit $ret
+fi

--- a/stable/admin/files/readinessprobe
+++ b/stable/admin/files/readinessprobe
@@ -33,7 +33,10 @@ nuocmd_fallback() {
 #      for the nuoadmin entrypoint script.
 #   3. It has the same commit index as the current Raft leader, which means
 #      that its Raft state is up-to-date.
-nuocmd_fallback check server --check-active --check-connected --check-converged
+#
+# specify a small timeout to avoid failing when check is performed concurrently
+# with Raft commit, which can cause indexes to temporarily be stale
+nuocmd_fallback check server --check-active --check-connected --check-converged --timeout 5
 
 # 'nuocmd check server' is unsupported; use the 'nuocmd check servers' (plural)
 # subcommand, which was used as the readiness probe in releases of

--- a/stable/admin/templates/_helpers.tpl
+++ b/stable/admin/templates/_helpers.tpl
@@ -428,3 +428,19 @@ rendered, false otherwise.
 {{- end -}}
 {{ $ret }}
 {{- end -}}
+
+{{/*
+Returns timeout for readiness probe. admin.readinessTimeoutSeconds no longer
+appears in values.yaml because it is deprecated and has been replaced by
+admin.readinessProbe.timeoutSeconds. Since there is no default value for
+admin.readinessTimeoutSeconds, it can only be set if the user explicitly
+specified it, so give it precedence over admin.readinessProbe.timeoutSeconds in
+that case.
+*/}}
+{{- define "admin.readinessTimeoutSeconds" -}}
+{{- if .Values.admin.readinessTimeoutSeconds -}}
+{{ .Values.admin.readinessTimeoutSeconds }}
+{{- else -}}
+{{ default 10 .Values.admin.readinessProbe.timeoutSeconds }}
+{{- end -}}
+{{- end -}}

--- a/stable/admin/templates/configmap.yaml
+++ b/stable/admin/templates/configmap.yaml
@@ -39,3 +39,14 @@ metadata:
   name: {{ template "admin.fullname" . }}-readinessprobe
 data:
 {{ (.Files.Glob "files/readinessprobe").AsConfig | indent 2 }}
+---
+{{- if eq (include "defaulttrue" .Values.admin.livenessProbe.enabled) "true" }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    {{- include "admin.resourceLabels" . | nindent 4 }}
+  name: {{ template "admin.fullname" . }}-livenessprobe
+data:
+{{ (.Files.Glob "files/livenessprobe").AsConfig | indent 2 }}
+{{- end }}

--- a/stable/admin/templates/statefulset.yaml
+++ b/stable/admin/templates/statefulset.yaml
@@ -149,21 +149,25 @@ spec:
           {{- end }}
           {{- range $opt, $val := .Values.admin.options}}
           - "{{$opt}}={{$val}}" 
-          {{- end}}
+          {{- end }}
         {{- include "sc.containerSecurityContext" . | indent 8 }}
+        {{- if eq (include "defaulttrue" .Values.admin.livenessProbe.enabled) "true" }}
         livenessProbe:
-          initialDelaySeconds: 30
-          periodSeconds: 15
-          tcpSocket:
-            port: 8888
+          initialDelaySeconds: {{ default 60 .Values.admin.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ default 60 .Values.admin.livenessProbe.periodSeconds }}
+          failureThreshold: {{ default 10 .Values.admin.livenessProbe.failureThreshold }}
+          exec:
+            command: [ "livenessprobe" ]
+          timeoutSeconds: {{ default 20 .Values.admin.livenessProbe.timeoutSeconds }}
+        {{- end }}
         readinessProbe:
-          initialDelaySeconds: 10
-          periodSeconds: 15
+          initialDelaySeconds: {{ default 10 .Values.admin.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ default 15 .Values.admin.readinessProbe.periodSeconds }}
+          failureThreshold: {{ default 4 .Values.admin.readinessProbe.failureThreshold }}
+          successThreshold: {{ default 1 .Values.admin.readinessProbe.successThreshold }}
           exec:
             command: [ "readinessprobe" ]
-          failureThreshold: 30
-          successThreshold: 2
-          timeoutSeconds: {{ default 5 .Values.admin.readinessTimeoutSeconds }}
+          timeoutSeconds: {{ include "admin.readinessTimeoutSeconds" . }}
         volumeMounts:
         - mountPath: /var/log/nuodb
           {{- if eq (include "defaultfalse" .Values.admin.logPersistence.enabled) "true" }}
@@ -192,6 +196,11 @@ spec:
         - name: readinessprobe
           mountPath: /usr/local/bin/readinessprobe
           subPath: readinessprobe
+        {{- if eq (include "defaulttrue" .Values.admin.livenessProbe.enabled) "true" }}
+        - name: livenessprobe
+          mountPath: /usr/local/bin/livenessprobe
+          subPath: livenessprobe
+        {{- end }}
         {{- if .Values.admin.tlsCACert }}
         - name: tls-ca-cert
           mountPath: /etc/nuodb/keys/ca.cert
@@ -274,6 +283,12 @@ spec:
         configMap:
           name: {{ template "admin.fullname" . }}-readinessprobe
           defaultMode: 0755
+      {{- if eq (include "defaulttrue" .Values.admin.livenessProbe.enabled) "true" }}
+      - name: livenessprobe
+        configMap:
+          name: {{ template "admin.fullname" . }}-livenessprobe
+          defaultMode: 0755
+      {{- end }}
   volumeClaimTemplates:
   - metadata:
       name: raftlog

--- a/stable/admin/values.yaml
+++ b/stable/admin/values.yaml
@@ -345,8 +345,38 @@ admin:
     balancer: balancer
     nodeport: nodeport
 
-  # Some clusters require longer readiness probe timeouts
-  readinessTimeoutSeconds: 5
+  # Configuration for liveness probe, which causes nuoadmin container to be
+  # restarted after some number of failures.
+  livenessProbe:
+    enabled: true
+
+    # By default, use 1-minute delay/period and restart after 10 failures. This
+    # will cause the nuoadmin container to be restarted after 10-11 minutes of
+    # probe failures.
+    initialDelaySeconds: 60
+    periodSeconds: 60
+    failureThreshold: 10
+
+    # The liveness probe has an internal timeout of 10 seconds to allow the AP
+    # to converge with the Raft leader. Specify double this value for the
+    # timeout used by the kubelet invoking the liveness probe.
+    timeoutSeconds: 20
+
+  # Configuration for readiness probe, which controls ready status and whether
+  # the pod has traffic from Services dispatched to it.
+  readinessProbe:
+
+    # By default, use 10/15-second delay/period and mark container as not ready
+    # after four failures, i.e. one minute of probe failures.
+    initialDelaySeconds: 10
+    periodSeconds: 15
+    failureThreshold: 4
+    successThreshold: 1
+
+    # The readiness probe has an internal timeout of 5 seconds to allow the AP
+    # to converge with the Raft leader. Specify double this value for the
+    # timeout used by the kubelet invoking the readiness probe.
+    timeoutSeconds: 10
 
   # These annotations will pass through to the pod as supplied, useful for integrating 3rd party products such as Vault.
   podAnnotations: {}

--- a/test/testlib/minikube_utilities.go
+++ b/test/testlib/minikube_utilities.go
@@ -504,7 +504,7 @@ func AwaitNoPods(t *testing.T, namespace string, expectedName string) {
 	}, 180*time.Second)
 }
 
-func findPod(t *testing.T, namespace string, expectedName string) (*corev1.Pod, error) {
+func FindPod(t *testing.T, namespace string, expectedName string) (*corev1.Pod, error) {
 	for _, pod := range FindAllPodsInSchema(t, namespace) {
 		if strings.Contains(pod.Name, expectedName) {
 			return &pod, nil
@@ -542,7 +542,7 @@ func GetPod(t *testing.T, namespace string, podName string) *corev1.Pod {
 }
 
 func GetPodName(t *testing.T, namespaceName string, expectedName string) string {
-	tePod, err := findPod(t, namespaceName, expectedName)
+	tePod, err := FindPod(t, namespaceName, expectedName)
 	require.NoError(t, err, "No pod found with name ", expectedName)
 
 	return tePod.Name
@@ -592,7 +592,7 @@ func AwaitPodStatus(t *testing.T, namespace string, podName string, condition co
 
 func AwaitPodPhase(t *testing.T, namespace string, podName string, phase corev1.PodPhase, timeout time.Duration) {
 	Await(t, func() bool {
-		pod, err := findPod(t, namespace, podName)
+		pod, err := FindPod(t, namespace, podName)
 		require.NoError(t, err, "awaitPodPhase: could not find pod with name matching ", podName)
 
 		return pod.Status.Phase == phase
@@ -601,7 +601,7 @@ func AwaitPodPhase(t *testing.T, namespace string, podName string, phase corev1.
 
 func AwaitJobSucceeded(t *testing.T, namespace string, jobName string, timeout time.Duration) {
 	Await(t, func() bool {
-		pod, err := findPod(t, namespace, jobName)
+		pod, err := FindPod(t, namespace, jobName)
 		if err != nil {
 			return false
 		}
@@ -630,7 +630,7 @@ func AwaitPodObjectRecreated(t *testing.T, namespace string, pod *corev1.Pod, ti
 
 func AwaitPodTemplateHasVersion(t *testing.T, namespace string, podNameTemplate string, expectedVersion string, timeout time.Duration) {
 	Await(t, func() bool {
-		pod, err := findPod(t, namespace, podNameTemplate)
+		pod, err := FindPod(t, namespace, podNameTemplate)
 
 		if err != nil {
 			t.Logf("No pod found with name %s", podNameTemplate)

--- a/test/testlib/nuodb_database_utilities.go
+++ b/test/testlib/nuodb_database_utilities.go
@@ -163,7 +163,7 @@ func StartDatabaseTemplate(t *testing.T, namespaceName string, adminPod string, 
 		helm.DeleteE(t, options, helmChartReleaseName, true)
 		AwaitNoPods(t, namespaceName, helmChartReleaseName)
 		// Delete database only if admin pod exists and tearing down the entrypoint cluster
-		_, err := findPod(t, namespaceName, adminPod)
+		_, err := FindPod(t, namespaceName, adminPod)
 		if err == nil && opt.ClusterName == opt.EntrypointClusterName && opt.DbPrimaryRelease {
 			db, err := GetDatabaseE(t, namespaceName, adminPod, opt.DbName)
 			// delete the database if it is not deleted already
@@ -278,7 +278,7 @@ func UpgradeDatabase(t *testing.T, namespaceName string, helmChartReleaseName st
 	// the TE ReplicaSet can be recreated with a different name so fetch the pod
 	// using a template continuously
 	Await(t, func() bool {
-		pod, err := findPod(t, namespaceName, tePodNameTemplate)
+		pod, err := FindPod(t, namespaceName, tePodNameTemplate)
 		if err != nil {
 			t.Logf("%s: %s", err.Error(), tePodNameTemplate)
 			return false
@@ -379,7 +379,7 @@ func BackupDatabaseE(
 	}()
 	var backupErr error
 	if err := AwaitE(t, func() bool {
-		pod, err := findPod(t, namespaceName, jobName)
+		pod, err := FindPod(t, namespaceName, jobName)
 		if err != nil {
 			return false
 		}


### PR DESCRIPTION
- Add liveness probe that uses `nuocmd check server --check-converged` to check the health of the nuoadmin container. By default, this is enabled and causes the nuoadmin container to restart after 10 minutes of probe failures. This replaces the existing liveness probe, which was a TCP probe on port 8888 that probably did nothing.
- Expose parameters for existing readiness probe as Helm values and lower the default failure threshold. Also use a small timeout on --check-converged to guard against concurrent commits causing false positives where the commit index is temporarily stale.