### PR TITLE
Limit CronJob and StatefulSet name length

### DIFF
--- a/stable/admin/templates/statefulset.yaml
+++ b/stable/admin/templates/statefulset.yaml
@@ -12,6 +12,7 @@ metadata:
     {{- end }}
   labels:
     {{- include "admin.resourceLabels" . | nindent 4 }}
+    component: admin
     {{- if (eq (default "cluster0" .Values.cloud.cluster.name) (default "cluster0" .Values.cloud.cluster.entrypointName)) }}
     bootstrapServers: {{ default 0 .Values.admin.bootstrapServers | quote }}
     {{- end }}

--- a/stable/database/templates/_helpers.tpl
+++ b/stable/database/templates/_helpers.tpl
@@ -26,6 +26,13 @@ and we have to allow for added suffixes including "-hotcopy" and "-NN" where NN 
 {{- end -}}
 
 {{/*
+The StatefulSet name is limited to 52 charts (https://github.com/kubernetes/kubernetes/issues/64023).
+*/}}
+{{- define "database.statefulset.name" -}}
+{{ template "truncWithHash" (list . 52) }}
+{{- end -}}
+
+{{/*
 Create chart name as used by the chart label.
 */}}
 {{- define "database.chart" -}}

--- a/stable/database/templates/_helpers.tpl
+++ b/stable/database/templates/_helpers.tpl
@@ -261,7 +261,8 @@ into account any schedule overrides configured per backup group.
 Renders the name of the HotCopy CronJob
 */}}
 {{- define "hotcopy.cronjob.name" -}}
-{{ printf "%s-hotcopy-%s-%s-%s" .hotCopyType .Values.admin.domain .Values.database.name .backupGroup | trunc 52 | trimSuffix "-" }}
+{{- $name := printf "%s-hotcopy-%s-%s-%s" .hotCopyType .Values.admin.domain .Values.database.name .backupGroup -}}
+{{ template "truncWithHash" (list $name 52) }}
 {{- end -}}
 
 {{/*
@@ -615,4 +616,24 @@ rendered, false otherwise.
 {{- end -}}
 {{- end -}}
 {{ $ret }}
+{{- end -}}
+
+{{/*
+Truncates a string to the max length of characters. If the original string
+length exceeds the supplied max length, a 7 characters SHA256 hash is
+calculated and appended to the truncated string to make it unique.
+*/}}
+{{- define "truncWithHash" -}}
+{{- $s := index . 0 -}}
+{{- $max := index . 1 -}}
+{{- if not (typeIs "string" $s) -}}
+{{- fail (printf "truncWithHash template failed: not supported type '%s'" (typeOf $s)) -}}
+{{- end -}}
+{{- if gt (len $s) $max -}}
+{{- $hash := sha256sum $s | trunc 7 -}}
+{{- $truncated := $s | trunc (int (sub $max 8)) | trimSuffix "-" -}}
+{{ printf "%s-%s" $truncated $hash }}
+{{- else -}}
+{{ $s }}
+{{- end -}}
 {{- end -}}

--- a/stable/database/templates/_helpers.tpl
+++ b/stable/database/templates/_helpers.tpl
@@ -636,6 +636,12 @@ calculated and appended to the truncated string to make it unique.
 {{- if not (typeIs "string" $s) -}}
 {{- fail (printf "truncWithHash template failed: not supported type '%s'" (typeOf $s)) -}}
 {{- end -}}
+{{- if not (typeIs "int" $max) -}}
+{{- fail (printf "truncWithHash template failed: not supported type '%s' for max length" (typeOf $max)) -}}
+{{- end -}}
+{{- if lt $max 15 -}}
+{{- fail (printf "truncWithHash template failed: max string length %d is too small; must be at lest 15 chars" $max) -}}
+{{- end -}}
 {{- if gt (len $s) $max -}}
 {{- $hash := sha256sum $s | trunc 7 -}}
 {{- $truncated := $s | trunc (int (sub $max 8)) | trimSuffix "-" -}}

--- a/stable/database/templates/deployment.yaml
+++ b/stable/database/templates/deployment.yaml
@@ -14,6 +14,7 @@ metadata:
     {{- end }}
   labels:
     {{- include "database.resourceLabels" . | nindent 4 }}
+    component: te
   name: te-{{ template "database.fullname" . }}
 spec:
   replicas: {{ .Values.database.te.replicas }}

--- a/stable/database/templates/statefulset.yaml
+++ b/stable/database/templates/statefulset.yaml
@@ -10,7 +10,9 @@ metadata:
     kubectl.kubernetes.io/default-logs-container: engine
   labels:
     {{- include "database.resourceLabels" . | nindent 4 }}
-  name: sm-{{ template "database.fullname" . }}
+    component: sm
+    role: nohotcopy
+  name: {{ include "database.statefulset.name" (printf "sm-%s" (include "database.fullname" .)) }}
 spec:
   replicas: {{ .Values.database.sm.noHotCopy.replicas }}
   selector:
@@ -391,7 +393,9 @@ metadata:
       Database deployment resource for NuoDB Storage Engines (SM).
   labels:
     {{- include "database.resourceLabels" . | nindent 4 }}
-  name: sm-{{ template "database.fullname" . }}-hotcopy
+    component: sm
+    role: hotcopy
+  name: {{ include "database.statefulset.name" (printf "sm-%s-hotcopy" (include "database.fullname" .)) }}
 spec:
   replicas: {{ .Values.database.sm.hotCopy.replicas }}
   selector:

--- a/test/integration/template_backup_test.go
+++ b/test/integration/template_backup_test.go
@@ -51,7 +51,7 @@ func TestDatabaseCronJobNames(t *testing.T) {
 		backupGroupTemplate := fmt.Sprintf("%s-%%d", backupGroupPrefix)
 		var hasBackupGroups bool
 		for k := range options.SetValues {
-			if strings.HasPrefix(k, "database.sm.hotCopy.backupGroups") {
+			if strings.HasPrefix(k, "database.sm.hotCopy.backupGroups.") {
 				hasBackupGroups = true
 				break
 			}

--- a/test/integration/template_backup_test.go
+++ b/test/integration/template_backup_test.go
@@ -21,6 +21,10 @@ func verifyBackupResourceLabels(t *testing.T, options *helm.Options, obj metav1.
 	require.Truef(t, ok, "Backup resource labels do not match for resource %s: %s", obj.GetName(), msg)
 }
 
+func truncate(s string, max int) string {
+	return s[:max]
+}
+
 func TestDatabaseBackupCronJobRenders(t *testing.T) {
 	// Path to the helm chart we will test
 	helmChartPath := "../../stable/database"
@@ -33,6 +37,123 @@ func TestDatabaseBackupCronJobRenders(t *testing.T) {
 	output := helm.RenderTemplate(t, options, helmChartPath, "release-name", []string{"templates/cronjob.yaml"})
 
 	testlib.SplitAndRenderCronJob(t, output, 2)
+}
+
+func TestDatabaseCronJobNames(t *testing.T) {
+	// Path to the helm chart we will test
+	helmChartPath := testlib.DATABASE_HELM_CHART_PATH
+	templateFn := func(options *helm.Options) string {
+		backupGroupPrefix := options.SetValues["database.sm.hotCopy.backupGroupPrefix"]
+		if backupGroupPrefix == "" {
+			// use the cluster name by default
+			backupGroupPrefix = options.SetValues["cluster.name"]
+		}
+		backupGroupTemplate := fmt.Sprintf("%s-%%d", backupGroupPrefix)
+		var hasBackupGroups bool
+		for k := range options.SetValues {
+			if strings.HasPrefix(k, "database.sm.hotCopy.backupGroups") {
+				hasBackupGroups = true
+				break
+			}
+		}
+		if hasBackupGroups {
+			// leave the caller to specify the full backup group name
+			backupGroupTemplate = "%s"
+		}
+		return fmt.Sprintf("%%s-hotcopy-%s-%s-%s",
+			options.SetValues["admin.domain"],
+			options.SetValues["database.name"],
+			backupGroupTemplate)
+	}
+	assertContainsPrefix := func(t *testing.T, list map[string]interface{}, prefix string) {
+		for k := range list {
+			if strings.HasPrefix(k, prefix) {
+				return
+			}
+		}
+		assert.Fail(t, "%v does not contain element with prefix %q", list, prefix)
+	}
+	t.Run("testDefault", func(t *testing.T) {
+		options := &helm.Options{
+			SetValues: map[string]string{
+				"cluster.name":                              "cluster0",
+				"admin.domain":                              "nuodb",
+				"database.name":                             "demo",
+				"database.sm.hotCopy.replicas":              "2",
+				"database.sm.hotCopy.journalBackup.enabled": "true",
+			},
+		}
+
+		output := helm.RenderTemplate(t, options, helmChartPath,
+			"release-name", []string{"templates/cronjob.yaml"})
+		actual := make(map[string]interface{})
+		for _, obj := range testlib.SplitAndRenderCronJob(t, output, 2) {
+			actual[obj.Name] = struct{}{}
+		}
+		assert.Contains(t, actual, fmt.Sprintf(templateFn(options), "full", 0))
+		assert.Contains(t, actual, fmt.Sprintf(templateFn(options), "full", 1))
+		assert.Contains(t, actual, fmt.Sprintf(templateFn(options), "incremental", 0))
+		assert.Contains(t, actual, fmt.Sprintf(templateFn(options), "incremental", 1))
+		assert.Contains(t, actual, fmt.Sprintf(templateFn(options), "journal", 0))
+		assert.Contains(t, actual, fmt.Sprintf(templateFn(options), "journal", 1))
+	})
+
+	t.Run("testBackupGroups", func(t *testing.T) {
+		options := &helm.Options{
+			SetValues: map[string]string{
+				"cluster.name":  "cluster0",
+				"admin.domain":  "nuodb",
+				"database.name": "demo",
+				"database.sm.hotCopy.journalBackup.enabled":          "true",
+				"database.sm.hotCopy.backupGroups.aws.labels":        "cloud aws",
+				"database.sm.hotCopy.backupGroups.gcp.processFilter": "label(cloud gcp)",
+			},
+		}
+
+		output := helm.RenderTemplate(t, options, helmChartPath,
+			"release-name", []string{"templates/cronjob.yaml"})
+		actual := make(map[string]interface{})
+		for _, obj := range testlib.SplitAndRenderCronJob(t, output, 2) {
+			actual[obj.Name] = struct{}{}
+		}
+		assert.Contains(t, actual, fmt.Sprintf(templateFn(options), "full", "aws"))
+		assert.Contains(t, actual, fmt.Sprintf(templateFn(options), "full", "gcp"))
+		assert.Contains(t, actual, fmt.Sprintf(templateFn(options), "incremental", "aws"))
+		assert.Contains(t, actual, fmt.Sprintf(templateFn(options), "incremental", "gcp"))
+		assert.Contains(t, actual, fmt.Sprintf(templateFn(options), "journal", "aws"))
+		assert.Contains(t, actual, fmt.Sprintf(templateFn(options), "journal", "gcp"))
+	})
+
+	t.Run("testLongDatabaseName", func(t *testing.T) {
+		options := &helm.Options{
+			SetValues: map[string]string{
+				"cluster.name":                              "cluster0",
+				"admin.domain":                              "nuodb",
+				"database.name":                             "superLongDatabaseName",
+				"database.sm.hotCopy.replicas":              "2",
+				"database.sm.hotCopy.journalBackup.enabled": "true",
+			},
+		}
+
+		output := helm.RenderTemplate(t, options, helmChartPath,
+			"release-name", []string{"templates/cronjob.yaml"})
+		actual := make(map[string]interface{})
+		for _, obj := range testlib.SplitAndRenderCronJob(t, output, 2) {
+			actual[obj.Name] = struct{}{}
+		}
+		// verify that unique names are generated for all CronJobs
+		assert.Equal(t, 6, len(actual))
+		for k := range actual {
+			// verify that all CronJob names are less than 52 characters
+			assert.LessOrEqual(t, len(k), 52, k)
+		}
+		assertContainsPrefix(t, actual, truncate(fmt.Sprintf(templateFn(options), "full", 0), 44))
+		assertContainsPrefix(t, actual, truncate(fmt.Sprintf(templateFn(options), "full", 1), 44))
+		assertContainsPrefix(t, actual, truncate(fmt.Sprintf(templateFn(options), "incremental", 0), 44))
+		assertContainsPrefix(t, actual, truncate(fmt.Sprintf(templateFn(options), "incremental", 1), 44))
+		assertContainsPrefix(t, actual, truncate(fmt.Sprintf(templateFn(options), "journal", 0), 44))
+		assertContainsPrefix(t, actual, truncate(fmt.Sprintf(templateFn(options), "journal", 1), 44))
+	})
 }
 
 func TestDatabaseBackupCronJobDisabled(t *testing.T) {

--- a/test/integration/template_backup_test.go
+++ b/test/integration/template_backup_test.go
@@ -46,7 +46,7 @@ func TestDatabaseCronJobNames(t *testing.T) {
 		backupGroupPrefix := options.SetValues["database.sm.hotCopy.backupGroupPrefix"]
 		if backupGroupPrefix == "" {
 			// use the cluster name by default
-			backupGroupPrefix = options.SetValues["cluster.name"]
+			backupGroupPrefix = options.SetValues["cloud.cluster.name"]
 		}
 		backupGroupTemplate := fmt.Sprintf("%s-%%d", backupGroupPrefix)
 		var hasBackupGroups bool
@@ -76,7 +76,7 @@ func TestDatabaseCronJobNames(t *testing.T) {
 	t.Run("testDefault", func(t *testing.T) {
 		options := &helm.Options{
 			SetValues: map[string]string{
-				"cluster.name":                              "cluster0",
+				"cloud.cluster.name":                        "cluster0",
 				"admin.domain":                              "nuodb",
 				"database.name":                             "demo",
 				"database.sm.hotCopy.replicas":              "2",
@@ -101,9 +101,9 @@ func TestDatabaseCronJobNames(t *testing.T) {
 	t.Run("testBackupGroups", func(t *testing.T) {
 		options := &helm.Options{
 			SetValues: map[string]string{
-				"cluster.name":  "cluster0",
-				"admin.domain":  "nuodb",
-				"database.name": "demo",
+				"cloud.cluster.name": "cluster0",
+				"admin.domain":       "nuodb",
+				"database.name":      "demo",
 				"database.sm.hotCopy.journalBackup.enabled":          "true",
 				"database.sm.hotCopy.backupGroups.aws.labels":        "cloud aws",
 				"database.sm.hotCopy.backupGroups.gcp.processFilter": "label(cloud gcp)",
@@ -127,9 +127,9 @@ func TestDatabaseCronJobNames(t *testing.T) {
 	t.Run("testLongDatabaseName", func(t *testing.T) {
 		options := &helm.Options{
 			SetValues: map[string]string{
-				"cluster.name":                              "cluster0",
+				"cloud.cluster.name":                        "cluster0",
 				"admin.domain":                              "nuodb",
-				"database.name":                             "superLongDatabaseName",
+				"database.name":                             "superlongdatabasename",
 				"database.sm.hotCopy.replicas":              "2",
 				"database.sm.hotCopy.journalBackup.enabled": "true",
 			},

--- a/test/integration/template_database_test.go
+++ b/test/integration/template_database_test.go
@@ -278,6 +278,27 @@ func TestDatabaseStatefulSetResourceLabels(t *testing.T) {
 
 }
 
+func TestDatabaseStatefulSetLongName(t *testing.T) {
+	// Path to the helm chart we will test
+	helmChartPath := "../../stable/database"
+
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"admin.domain":  "superlongadmindomainname",
+			"database.name": "superlongdatabasename",
+		},
+	}
+
+	// Run RenderTemplate to render the template and capture the output.
+	output := helm.RenderTemplate(t, options, helmChartPath, "release-name", []string{"templates/statefulset.yaml"})
+
+	for _, obj := range testlib.SplitAndRenderStatefulSet(t, output, 2) {
+		assert.LessOrEqual(t, len(obj.Name), 52, obj.Name)
+		assert.Equal(t, "sm", obj.Spec.Selector.MatchLabels["component"])
+		assert.Equal(t, "sm", obj.Spec.Template.ObjectMeta.Labels["component"])
+	}
+}
+
 func TestDatabaseVolumes(t *testing.T) {
 	// Path to the helm chart we will test
 	helmChartPath := "../../stable/database"


### PR DESCRIPTION
**Issues**

Using long identifiers for cluster, domain, and database names can cause issues in creating Kubernetes primitives. StatefulSet names can't exceed 52 chars until https://github.com/kubernetes/kubernetes/issues/64023 is fixed. Truncating CronJob names to 52 charts may omit the backup group name and lead to duplicate resources.

**Changes**

- Limit the _database_ StatefulSet names to 52 chars.  If the name exceeds the limit, add a 7 chars SHA256 hash suffix to avoid collisions.
- Limit the backup CronJob names to 52 chars. If the name exceeds the limit, add a 7 chars SHA256 hash suffix to avoid collisions.
- Added `component` label to all workloads (Deployment, StatefulSet) and `role` label to SM StatefulSets. This will simplify filtering workloads per component type.

**Example**

```
$ helm install admin  stable/admin \
  -f values.yaml \
  --set admin.domain=superlongdomainname
$ helm install database stable/database \
    -f values.yaml \
    --set admin.domain=superlongdomainname \
    --set database.name=superlongdatabasename

$ kubectl get pods
NAME                                                              READY   STATUS             RESTARTS      AGE
admin-superlongdomainname-cluster0-0                              1/1     Running            0             2m11s
sm-database-superlongdomainname-cluster0-sup-088aace-0            1/1     Running            0             85s
te-database-superlongdomainname-cluster0-superlongdat-786fhz5rv   1/1     Running            0             85s

$ kubectl get cronjobs
NAME                                                   SCHEDULE      SUSPEND   ACTIVE   LAST SCHEDULE   AGE
full-hotcopy-superlongdomainname-superlongda-ff68eea   35 22 * * 6   False     0        <none>          101s
incremental-hotcopy-superlongdomainname-supe-66c725e   ?/2 * * * *   False     1        78s             101s
journal-hotcopy-superlongdomainname-superlon-1f8ea1e   ?/1 * * * *   False     2        18s             101s
```

**Testing**

- new integration tests
- regression testing