### PR TITLE
Automate publishing of incubator charts

### DIFF
--- a/.github/workflows/publish-charts.yml
+++ b/.github/workflows/publish-charts.yml
@@ -16,15 +16,15 @@ jobs:
           set -e
           VERSION="$(./release/relman.py --check-current --show-head-version)"
           if [ -z "$VERSION" ]; then
-            echo "No version tag found" 2>&1
+            echo "No version tag found" >&2
             exit 1
           fi
           if [ "refs/tags/v$VERSION" != "$GITHUB_REF" ]; then
-            echo "Unexpected version tag: \"refs/tags/v$VERSION\" != \"$GITHUB_REF\"" 2>&1
+            echo "Unexpected version tag: \"refs/tags/v$VERSION\" != \"$GITHUB_REF\"" >&2
             exit 1
           fi
           if [ ! -f "changelogs/v${VERSION}.md" ]; then
-            echo "No changelog found for $VERSION" 2>&1
+            echo "No changelog found for $VERSION" >&2
             exit 1
           fi
           echo "version=$VERSION" >> $GITHUB_OUTPUT
@@ -35,7 +35,8 @@ jobs:
           gh release create v${{ steps.vars.outputs.version }} \
             -t "NuoDB Helm Charts ${{ steps.vars.outputs.version }}" \
             -F changelogs/v${{ steps.vars.outputs.version }}.md \
-            package/v${{ steps.vars.outputs.version }}/*.tgz
+            package/stable/v${{ steps.vars.outputs.version }}/*.tgz \
+            package/incubator/v${{ steps.vars.outputs.version }}/*.tgz
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Update Helm index

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ To list the NuoDB charts added to your repository, run `helm search repo nuodb/`
 The Incubator repository contains enhancements not yet available in the supported releases. This repository includes a sample application load generator. If you would like to install this sample application, then add the Incubator charts to your local helm repository, run:
 
 ```
-helm repo add nuodb-incubator https://nuodb-charts-incubator.storage.googleapis.com/
+helm repo add nuodb-incubator https://nuodb.github.io/nuodb-helm-charts/incubator
 "nuodb-incubator" has been added to your repositories
 ```
 

--- a/scripts/ci/install_deps.sh
+++ b/scripts/ci/install_deps.sh
@@ -69,8 +69,8 @@ $ip demo.nuodb.local" | sudo tee -a /etc/hosts
   kubectl version
 
   # get the helm repo for upgrade testing
-  helm repo add nuodb https://storage.googleapis.com/nuodb-charts
-  helm repo add nuodb-incubator https://storage.googleapis.com/nuodb-charts-incubator
+  helm repo add nuodb https://nuodb.github.io/nuodb-helm-charts
+  helm repo add nuodb-incubator https://nuodb.github.io/nuodb-helm-charts/incubator
 
   # get HC Vault for testing
   helm repo add hashicorp https://helm.releases.hashicorp.com
@@ -117,7 +117,7 @@ elif [[ "$REQUIRES_MINISHIFT" == "true" ]]; then
 
   # get the helm repo for upgrade testing
   helm repo add nuodb https://nuodb.github.io/nuodb-helm-charts
-  helm repo add nuodb-incubator https://storage.googleapis.com/nuodb-charts-incubator
+  helm repo add nuodb-incubator https://nuodb.github.io/nuodb-helm-charts/incubator
 elif [[ "$REQUIRES_AKS" == "true" ]]; then
   if ! command -v az &> /dev/null; then
     # Install Azure cli if not already available

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -5,17 +5,23 @@ fail() {
     exit 1
 }
 
+package() {
+    # Create directory for packaged Helm charts
+    dest="package/$1/v$(./get-version.sh)"
+    mkdir -p "$dest"
+
+    # Package all Helm charts under specified directory
+    charts="$(find "$1" -maxdepth 2 -name Chart.yaml -exec dirname {}  \;)"
+    for dir in $charts; do
+        helm package "$dir" -d "$dest"
+    done
+}
+
 set -e
 
 # Change to root directory
 cd "$(dirname "$0")/.."
 
-# Create directory for packaged Helm charts
-dest="package/v$(./get-version.sh)"
-mkdir -p "$dest"
-
-# Package all Helm charts
-charts="$(find stable -maxdepth 2 -name Chart.yaml -exec dirname {}  \;)"
-for dir in $charts; do
-    helm package "$dir" -d "$dest"
-done
+# Package Helm charts
+package stable
+package incubator

--- a/scripts/update-index.sh
+++ b/scripts/update-index.sh
@@ -5,28 +5,43 @@ fail() {
     exit 1
 }
 
+check_package() {
+    [ -d "package/$1" ] || fail "package/$1 directory does not exist... run package.sh first"
+}
+
+update_index() {
+    # Merge new charts into current index
+    : ${GH_RELEASES_URL:="https://github.com/nuodb/nuodb-helm-charts/releases/download"}
+    helm repo index "package/$1" --merge "$1/index.yaml" --url "$GH_RELEASES_URL"
+
+    # Stage update to index file
+    mv "package/$1/index.yaml" "$1/index.yaml"
+    git add "$1/index.yaml"
+}
+
 set -e
 
 # Make sure there are no uncommitted changes
 GIT_STATUS="$(git status --porcelain)"
 [ "$GIT_STATUS" = "" ] || fail "Cannot publish charts with uncommitted changes:\n$GIT_STATUS"
 
-# Change to root directory and make sure package directory exists
+# Change to root directory and make sure package directories exist
 cd "$(dirname "$0")/.."
-[ -d package ] || fail "package directory does not exist... run package.sh first"
+check_package stable
+check_package incubator
 
 # Checkout gh-pages and fast forward to origin
 git checkout gh-pages
 git merge --ff-only origin/gh-pages
 
-# Update index with new Helm charts
-: ${GH_RELEASES_URL:="https://github.com/nuodb/nuodb-helm-charts/releases/download"}
-helm repo index package --merge index.yaml --url "$GH_RELEASES_URL"
+# Update indexes with new Helm charts
+update_index stable
+update_index incubator
 
-# Commit and push change if PUSH_UPDATE=true
+# Commit changes to indexes
+git commit -m "Add $(ls package/stable | sed 's|/||') charts to indexes"
+
+# Push changes if PUSH_UPDATE=true
 if [ "$PUSH_UPDATE" = true ]; then
-    mv package/index.yaml .
-    git add index.yaml
-    git commit -m "Adding $(ls package | sed 's|/||') charts to index"
     git push
 fi


### PR DESCRIPTION
This change updates the package.sh and update-index.sh scripts to also create incubator Helm charts, attach them to the created GitHub release, and add them to the gh-pages:incubator/index.yaml file.

This change assumes a change to the gh-pages branch to structure index files as follows:

```
index.yaml -> stable/index.yaml (symlink)
stable/
- index.yaml
incubator/
- index.yaml
```