### PR TITLE
Add storage group resource label

### DIFF
--- a/stable/database/templates/_helpers.tpl
+++ b/stable/database/templates/_helpers.tpl
@@ -513,10 +513,30 @@ release: {{ .Release.Name | quote }}
 {{- end -}}
 
 {{/*
+Renders the storage group labels. IMPORTANT: Adding new entries must be done
+with caution as these labels are rendered in the PVC spec which is immutable.
+The storage group name can not be reconfigured by definition.
+*/}}
+{{- define "database.storageGroupLabels" -}}
+{{- if .Values.database.sm.storageGroup -}}
+{{- if .Values.database.sm.storageGroup.enabled -}}
+storage-group: {{ include "database.storageGroup.name" . | quote }}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Renders the name of the Secret for this database
 */}}
 {{- define "database.secretName" -}}
 {{ .Values.admin.domain }}-{{ .Values.database.name }}
+{{- end -}}
+
+{{/*
+Renders the storage group name
+*/}}
+{{- define "database.storageGroup.name" -}}
+{{ .Values.database.sm.storageGroup.name | default .Release.Name | trim }}
 {{- end -}}
 
 {{/*
@@ -535,7 +555,7 @@ Renders the storage groups option for nuosm script
 {{- end }}
 {{- end }}
 - "--storage-groups"
-- {{ .Values.database.sm.storageGroup.name | default .Release.Name | trim | quote }}
+- {{ include "database.storageGroup.name" . | quote }}
 {{- end }}
 {{- end }}
 {{- end -}}
@@ -544,11 +564,11 @@ Renders the storage groups option for nuosm script
 Renders the storage group domain process label
 */}}
 {{- define "database.storageGroup.label" -}}
-{{- if .Values.database.sm.storageGroup }}
-{{- if .Values.database.sm.storageGroup.enabled }}
-{{- printf "sg %s" (.Values.database.sm.storageGroup.name | default .Release.Name | trim) -}}
-{{- end }}
-{{- end }}
+{{- if .Values.database.sm.storageGroup -}}
+{{- if .Values.database.sm.storageGroup.enabled -}}
+{{ printf "sg %s" (include "database.storageGroup.name" .) }}
+{{- end -}}
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/stable/database/templates/statefulset.yaml
+++ b/stable/database/templates/statefulset.yaml
@@ -10,6 +10,7 @@ metadata:
     kubectl.kubernetes.io/default-logs-container: engine
   labels:
     {{- include "database.resourceLabels" . | nindent 4 }}
+    {{- include "database.storageGroupLabels" . | nindent 4 }}
     component: sm
     role: nohotcopy
   name: {{ include "database.statefulset.name" (printf "sm-%s" (include "database.fullname" .)) }}
@@ -37,6 +38,7 @@ spec:
       {{- end }}
       labels:
         {{- include "database.resourceLabels" . | nindent 8 }}
+        {{- include "database.storageGroupLabels" . | nindent 8 }}
         component: sm
         role: nohotcopy
     spec:
@@ -107,7 +109,7 @@ spec:
     {{- end }}
           - "--options"
           - "mem {{ .Values.database.sm.resources.requests.memory}} {{ include "opt.key-values" .Values.database.sm.engineOptions }}"
-    {{- $labels := printf "%s %s" (include "database.storageGroup.label" .)  (include "opt.key-values" .Values.database.sm.labels) -}}
+    {{- $labels := printf "%s %s" (include "database.storageGroup.label" .) (include "opt.key-values" .Values.database.sm.labels) -}}
     {{- if trim $labels }}
           - "--labels"
           - "{{ $labels }}"
@@ -315,6 +317,7 @@ spec:
       name: archive-volume
       labels:
         {{- include "database.resourceLabels" . | nindent 8 }}
+        {{- include "database.storageGroupLabels" . | nindent 8 }}
     spec:
       accessModes:
       {{- range .Values.database.persistence.accessModes }}
@@ -340,6 +343,7 @@ spec:
       name: journal-volume
       labels:
         {{- include "database.resourceLabels" . | nindent 8 }}
+        {{- include "database.storageGroupLabels" . | nindent 8 }}
     spec:
       accessModes:
       {{- range .Values.database.sm.noHotCopy.journalPath.persistence.accessModes }}
@@ -394,6 +398,7 @@ metadata:
       Database deployment resource for NuoDB Storage Engines (SM).
   labels:
     {{- include "database.resourceLabels" . | nindent 4 }}
+    {{- include "database.storageGroupLabels" . | nindent 4 }}
     component: sm
     role: hotcopy
   name: {{ include "database.statefulset.name" (printf "sm-%s-hotcopy" (include "database.fullname" .)) }}
@@ -421,6 +426,7 @@ spec:
       {{- end }}
       labels:
         {{- include "database.resourceLabels" . | nindent 8 }}
+        {{- include "database.storageGroupLabels" . | nindent 8 }}
         component: sm
         role: hotcopy
     spec:
@@ -702,6 +708,7 @@ spec:
       name: archive-volume
       labels:
         {{- include "database.resourceLabels" . | nindent 8 }}
+        {{- include "database.storageGroupLabels" . | nindent 8 }}
     spec:
       accessModes:
       {{- range .Values.database.persistence.accessModes }}
@@ -727,6 +734,7 @@ spec:
       name: journal-volume
       labels:
         {{- include "database.resourceLabels" . | nindent 8 }}
+        {{- include "database.storageGroupLabels" . | nindent 8 }}
     spec:
       accessModes:
       {{- range .Values.database.sm.hotCopy.journalPath.persistence.accessModes }}
@@ -752,6 +760,7 @@ spec:
       name: backup-volume
       labels:
         {{- include "database.resourceLabels" . | nindent 8 }}
+        {{- include "database.storageGroupLabels" . | nindent 8 }}
     spec:
       accessModes:
       {{- range .Values.database.sm.hotCopy.persistence.accessModes }}

--- a/test/integration/template_database_test.go
+++ b/test/integration/template_database_test.go
@@ -39,6 +39,13 @@ func verifyDatabaseResourceLabels(t *testing.T, releaseName string, options *hel
 	} else if _, ok := obj.(*appsv1.Deployment); ok {
 		expectedLabels["component"] = "te"
 	}
+	if enabled := options.SetValues["database.sm.storageGroup.enabled"]; enabled == "true" {
+		sgValue := releaseName
+		if v, ok := options.SetValues["database.sm.storageGroup.name"]; ok {
+			sgValue = v
+		}
+		expectedLabels["storage-group"] = sgValue
+	}
 
 	msg, ok := testlib.MapContains(labels, expectedLabels)
 	require.Truef(t, ok, "Mandatory labels missing from resource %s: %s", obj.GetName(), msg)


### PR DESCRIPTION
**Changes**

```
Added `storage-group` label to relevant resources if TPSG is enabled for the
Helm release. Environments that use TPSG should be redeployed because of the
additional label added to the PVC section of the StatefulSet. This should be
fine as TPSG is an experimental feature in NuoDB Helm Charts v3.6.0.
```