### PR TITLE
Failure to record metadata for backups

### DIFF
--- a/stable/database/files/nuobackup
+++ b/stable/database/files/nuobackup
@@ -105,9 +105,10 @@ function execute_backup() {
          --value "" --expected-value "${failed}"
 
       latest=$(nuocmd get value --key "$NUODB_BACKUP_KEY/$db_name/${backup_group}/latest" )
-      current=${latest:-0}
+      current=${latest:--1}
       # bump latest, and wrap around (simple ring-buffer)
       next=$(( (current + 1) % $NUODB_MAX_BACKUP_HISTORY ))
+      next_value=$(nuocmd get value --key "${NUODB_BACKUP_KEY}/${db_name}/${backup_group}/$next")
       # the backupset for all archives in the backup group will be the same
       # after a successful hotcopy
       backupset=$(echo "$current_backup" | head -1 | awk '{print $2}')
@@ -129,8 +130,8 @@ function execute_backup() {
          echo "$NUODB_BACKUP_KEY/$db_name/${backup_group}/$next/pods = [${pods[*]}]"
          echo "$NUODB_BACKUP_KEY/$db_name/latest = $backup_group"
 
-         nuocmd set value --key "$NUODB_BACKUP_KEY/$db_name/${backup_group}/$next" --value "$backupset" --expected-value "" && \
-         nuocmd set value --key "$NUODB_BACKUP_KEY/$db_name/${backup_group}/$next/pods" --value "${pods[*]}" --expected-value "" && \
+         nuocmd set value --key "$NUODB_BACKUP_KEY/$db_name/${backup_group}/$next" --value "$backupset" --expected-value "$next_value" && \
+         nuocmd set value --key "$NUODB_BACKUP_KEY/$db_name/${backup_group}/$next/pods" --value "${pods[*]}" --unconditional && \
          nuocmd set value --key "$NUODB_BACKUP_KEY/$db_name/${backup_group}/latest" --value "$next" --expected-value "$latest" && \
          nuocmd set value --key "$NUODB_BACKUP_KEY/$db_name/latest" --value "$backup_group" --unconditional
       else
@@ -313,12 +314,16 @@ elif [ "$backup_type" = "report-backups" ]; then
       groups=$(nuocmd get value --key "$NUODB_BACKUP_KEY/$db_name/backup-groups")
    fi
    for group in $groups; do
-      i=1
+      i=0
       while true; do
          backupset=$(nuocmd get value --key "$NUODB_BACKUP_KEY/$db_name/${group}/${i}")
-         [ -z "$backupset" ] && break
-         backup_pods=$(nuocmd get value --key "$NUODB_BACKUP_KEY/$db_name/${group}/${i}/pods")
-         echo "${group}:${i} ${backupset} ${backup_pods}"
+         if [ -n "$backupset" ]; then
+            backup_pods=$(nuocmd get value --key "$NUODB_BACKUP_KEY/$db_name/${group}/${i}/pods")
+            echo "${group}:${i} ${backupset} ${backup_pods}"
+         elif [ $i -ne 0 ]; then
+            # Backup index 0 may be missing is old deployments
+            break
+         fi
          (( i=i+1 ))
       done
    done

--- a/stable/database/templates/cronjob.yaml
+++ b/stable/database/templates/cronjob.yaml
@@ -87,6 +87,7 @@ spec:
             - { name: NUOCMD_API_SERVER,   value: "{{ template "admin.address" . }}:8888" }
             - { name: PEER_ADDRESS,        value: "{{ template "admin.address" . }}" }
             - { name: BACKUP_DIR,          value: "{{ .Values.database.sm.hotCopy.backupDir }}" }
+            {{- include "database.env" . | nindent 12 }}
             {{- include "sc.containerSecurityContext" . | indent 12 }}
             resources:
             {{- toYaml .Values.database.sm.hotCopy.jobResources | trim | nindent 14 }}
@@ -191,6 +192,7 @@ spec:
             - { name: NUOCMD_API_SERVER,   value: "{{ template "admin.address" . }}:8888" }
             - { name: PEER_ADDRESS,        value: "{{ template "admin.address" . }}" }
             - { name: BACKUP_DIR,          value: "{{ .Values.database.sm.hotCopy.backupDir }}" }
+            {{- include "database.env" . | nindent 12 }}
             {{- include "sc.containerSecurityContext" . | indent 12 }}
             resources:
             {{- toYaml .Values.database.sm.hotCopy.jobResources | trim | nindent 14 }}
@@ -297,6 +299,7 @@ spec:
             - { name: NUOCMD_API_SERVER,   value: "{{ template "admin.address" . }}:8888" }
             - { name: PEER_ADDRESS,        value: "{{ template "admin.address" . }}" }
             - { name: BACKUP_DIR,          value: "{{ .Values.database.sm.hotCopy.backupDir }}" }
+            {{- include "database.env" . | nindent 12 }}
             {{- include "sc.containerSecurityContext" . | indent 12 }}
             resources:
             {{- toYaml .Values.database.sm.hotCopy.jobResources | trim | nindent 14 }}

--- a/test/minikube/minikube_base_restore_test.go
+++ b/test/minikube/minikube_base_restore_test.go
@@ -24,13 +24,16 @@ import (
 
 func verifyBackup(t *testing.T, namespaceName string, podName string, databaseName string, options *helm.Options) {
 	// verify that the backup has been documented by the Admin layer
-	backupset, err := k8s.RunKubectlAndGetOutputE(t, options.KubectlOptions,
+	output, err := k8s.RunKubectlAndGetOutputE(t, options.KubectlOptions,
 		"exec", podName, "--",
 		"nuodocker", "get", "current-backup", "--db-name", databaseName,
 	)
+	require.NoError(t, err, "Error running 'nuodocker get current-backup': %s", output)
+	require.True(t, output != "")
 
-	require.NoError(t, err, "Error running: nuodocker get current-backup  ")
-	require.True(t, backupset != "")
+	latestGroup := testlib.GetLatestBackupGroup(t, namespaceName, podName, databaseName)
+	latestBackupSet := testlib.GetLatestBackup(t, namespaceName, podName, databaseName, latestGroup)
+	require.Contains(t, output, latestBackupSet, "Metadata for last backupset is not recorded")
 }
 
 func TestKubernetesBackupDatabase(t *testing.T) {
@@ -61,7 +64,7 @@ func TestKubernetesBackupDatabase(t *testing.T) {
 			},
 		}
 
-		testlib.StartDatabase(t, namespaceName, admin0, &databaseOptions)
+		databaseReleaseName := testlib.StartDatabase(t, namespaceName, admin0, &databaseOptions)
 
 		// Generate diagnose in case this test fails
 		testlib.AddDiagnosticTeardown(testlib.TEARDOWN_DATABASE, t, func() {
@@ -72,10 +75,74 @@ func TestKubernetesBackupDatabase(t *testing.T) {
 
 		testlib.CreateQuickstartSchema(t, namespaceName, admin0)
 
+		opt := testlib.GetExtractedOptions(&databaseOptions)
+		smPodName0 := fmt.Sprintf("sm-%s-%s-%s-%s-hotcopy-0",
+			databaseReleaseName, opt.DomainName, opt.ClusterName, opt.DbName)
+
 		defer testlib.Teardown(testlib.TEARDOWN_BACKUP)
 		testlib.AwaitJobSucceeded(t, namespaceName, "incremental-hotcopy-nuodb-demo-cluster0-0", 120*time.Second)
-		verifyBackup(t, namespaceName, admin0, "demo", &databaseOptions)
+		verifyBackup(t, namespaceName, smPodName0, "demo", &databaseOptions)
 	})
+
+}
+
+func TestKubernetesBackupHistory(t *testing.T) {
+	testlib.AwaitTillerUp(t)
+	defer testlib.VerifyTeardown(t)
+
+	adminOptions := helm.Options{}
+
+	defer testlib.Teardown(testlib.TEARDOWN_ADMIN)
+
+	helmChartReleaseName, namespaceName := testlib.StartAdmin(t, &adminOptions, 1, "")
+
+	admin0 := fmt.Sprintf("%s-nuodb-cluster0-0", helmChartReleaseName)
+
+	defer testlib.Teardown(testlib.TEARDOWN_DATABASE)
+	defer testlib.Teardown(testlib.TEARDOWN_BACKUP)
+
+	databaseOptions := helm.Options{
+		SetValues: map[string]string{
+			"database.sm.resources.requests.cpu":    testlib.MINIMAL_VIABLE_ENGINE_CPU,
+			"database.sm.resources.requests.memory": testlib.MINIMAL_VIABLE_ENGINE_MEMORY,
+			"database.te.resources.requests.cpu":    testlib.MINIMAL_VIABLE_ENGINE_CPU,
+			"database.te.resources.requests.memory": testlib.MINIMAL_VIABLE_ENGINE_MEMORY,
+		},
+		SetStrValues: map[string]string{
+			"database.env[0].name":  "NUODB_MAX_BACKUP_HISTORY",
+			"database.env[0].value": "2",
+		},
+	}
+
+	databaseReleaseName := testlib.StartDatabase(t, namespaceName, admin0, &databaseOptions)
+
+	opt := testlib.GetExtractedOptions(&databaseOptions)
+	kubectlOptions := databaseOptions.KubectlOptions
+	backupGroup0 := fmt.Sprintf("%s-0", opt.ClusterName)
+	smPodName0 := fmt.Sprintf("sm-%s-%s-%s-%s-hotcopy-0",
+		databaseReleaseName, opt.DomainName, opt.ClusterName, opt.DbName)
+	fullCronJob := fmt.Sprintf("full-hotcopy-%s-%s-%s", opt.DomainName, opt.DbName, backupGroup0)
+
+	// Executing 3 full backups with NUODB_MAX_BACKUP_HISTORY=2 will reuse
+	// index 0 to store metadata for the third backup
+	for i := 0; i < 3; i++ {
+		jobName := fmt.Sprintf("backup-database-%s", strings.ToLower(random.UniqueId()))
+		k8s.RunKubectl(t, kubectlOptions, "create", "job", "--from=cronjob/"+fullCronJob, jobName)
+		// Get logs from backup jobs in case the test fails
+		testlib.AddDiagnosticTeardown(testlib.TEARDOWN_DATABASE, t, func() {
+			podName := testlib.GetPodName(t, namespaceName, jobName)
+			testlib.GetAppLog(t, namespaceName, podName, "", &corev1.PodLogOptions{})
+		})
+		testlib.AwaitJobSucceeded(t, namespaceName, jobName, 120*time.Second)
+	}
+	// Verify that the last backupSet is stored as index 0
+	latestBackupSet := testlib.GetLatestBackup(t, namespaceName, smPodName0, opt.DbName, backupGroup0)
+	output, err := k8s.RunKubectlAndGetOutputE(t, kubectlOptions, "exec", smPodName0, "-c", "engine", "--",
+		"nuocmd", "get", "value", "--key", fmt.Sprintf("/nuodb/nuobackup/%s/%s/0", opt.DbName, backupGroup0))
+	require.NoError(t, err, output)
+	require.Equal(t, latestBackupSet, output, "")
+
+	verifyBackup(t, namespaceName, smPodName0, "demo", &databaseOptions)
 }
 
 func TestKubernetesJournalBackupSuspended(t *testing.T) {
@@ -171,7 +238,6 @@ func TestKubernetesJournalBackupSuspended(t *testing.T) {
 	// verify that the journal backup fails and another full backup is requested
 	// because the last full hot copy failed
 
-
 	require.Equal(t, 1, testlib.GetStringOccurrenceInLog(t, namespaceName, backupPodName,
 		"Executing incremental hot copy as journal hot copy is temporarily suspended", &corev1.PodLogOptions{}),
 		"Incremental hot copy not requested to enable journal after sync")
@@ -179,26 +245,26 @@ func TestKubernetesJournalBackupSuspended(t *testing.T) {
 		"Executing full hotcopy as a prerequisite for incremental hotcopy", &corev1.PodLogOptions{}),
 		"Full hot copy should be requested as previous full have failed")
 
-	verifyBackup(t, namespaceName, admin0, "demo", &options)
+	verifyBackup(t, namespaceName, smPodName0, "demo", &options)
 }
 
 func restoreDatabaseByArchiveType(t *testing.T, options helm.Options, namespaceName string, admin0 string, archiveType string) {
 	isLsaType := archiveType == "lsa"
 	name := "restoreFileArchive"
-	if(isLsaType) {
+	if isLsaType {
 		name = "restoreLsaArchive"
 	}
 
 	t.Run(name, func(t *testing.T) {
 		defer testlib.Teardown(testlib.TEARDOWN_DATABASE)
 
-		if(isLsaType) {
+		if isLsaType {
 			options.SetValues["database.archiveType"] = "lsa"
 		}
 
 		databaseChartName := testlib.StartDatabase(t, namespaceName, admin0, &options)
 
-		if(isLsaType) {
+		if isLsaType {
 			delete(options.SetValues, "database.archiveType")
 		}
 

--- a/test/minikube/minikube_long_restore_test.go
+++ b/test/minikube/minikube_long_restore_test.go
@@ -247,7 +247,7 @@ func TestKubernetesRestoreMultipleBackupGroups(t *testing.T) {
 		defer testlib.Teardown(testlib.TEARDOWN_RESTORE)
 		// Execute backup for backup group 1
 		backupsetGroup1 := testlib.BackupDatabase(t, namespaceName, hcSmPodName0, opt.DbName, "full", backupGroup1)
-		verifyBackupSet(t, namespaceName, backupsetGroup1, backupGroup1, 1, hcSmPodName1)
+		verifyBackupSet(t, namespaceName, backupsetGroup1, backupGroup1, 0, hcSmPodName1)
 
 		testlib.CreateQuickstartSchema(t, namespaceName, admin0)
 		// restore database
@@ -276,7 +276,7 @@ func TestKubernetesRestoreMultipleBackupGroups(t *testing.T) {
 		defer testlib.Teardown(testlib.TEARDOWN_RESTORE)
 		// Execute backup for backup group 0
 		backupsetGroup0 := testlib.BackupDatabase(t, namespaceName, hcSmPodName0, opt.DbName, "full", backupGroup0)
-		verifyBackupSet(t, namespaceName, backupsetGroup0, backupGroup0, 1, hcSmPodName0)
+		verifyBackupSet(t, namespaceName, backupsetGroup0, backupGroup0, 0, hcSmPodName0)
 
 		testlib.CreateQuickstartSchema(t, namespaceName, admin0)
 		// restore database
@@ -304,11 +304,11 @@ func TestKubernetesRestoreMultipleBackupGroups(t *testing.T) {
 		defer testlib.Teardown(testlib.TEARDOWN_RESTORE)
 		// Create another backup for backup group 0 (index 2)
 		newBackupset := testlib.BackupDatabase(t, namespaceName, hcSmPodName0, opt.DbName, "full", backupGroup0)
-		verifyBackupSet(t, namespaceName, newBackupset, backupGroup0, 2, hcSmPodName0)
+		verifyBackupSet(t, namespaceName, newBackupset, backupGroup0, 1, hcSmPodName0)
 
 		testlib.CreateQuickstartSchema(t, namespaceName, admin0)
 		// restore database
-		databaseOptions.SetValues["restore.source"] = "cluster0-0:2"
+		databaseOptions.SetValues["restore.source"] = "cluster0-0:1"
 		testlib.RestoreDatabase(t, namespaceName, admin0, &databaseOptions)
 		testlib.RestartDatabasePods(t, namespaceName, databaseChartName, &databaseOptions)
 		testlib.AwaitDatabaseUp(t, namespaceName, admin0, opt.DbName, opt.NrTePods+opt.NrSmPods)
@@ -402,7 +402,7 @@ func TestKubernetesRestoreCustomBackupGroups(t *testing.T) {
 		defer testlib.Teardown(testlib.TEARDOWN_RESTORE)
 		// Create another backup for backup group 0 (index 1)
 		newBackupset := testlib.BackupDatabase(t, namespaceName, hcSmPodName0, opt.DbName, "full", backupGroup0)
-		verifyBackupSet(t, namespaceName, newBackupset, backupGroup0, 1, hcSmPodName0)
+		verifyBackupSet(t, namespaceName, newBackupset, backupGroup0, 0, hcSmPodName0)
 
 		testlib.CreateQuickstartSchema(t, namespaceName, admin0)
 
@@ -432,7 +432,7 @@ func TestKubernetesRestoreCustomBackupGroups(t *testing.T) {
 		defer testlib.Teardown(testlib.TEARDOWN_RESTORE)
 		// Execute backup for backup group 1
 		newBackupset := testlib.BackupDatabase(t, namespaceName, hcSmPodName0, opt.DbName, "full", backupGroup1)
-		verifyBackupSet(t, namespaceName, newBackupset, backupGroup1, 1, hcSmPodName1)
+		verifyBackupSet(t, namespaceName, newBackupset, backupGroup1, 0, hcSmPodName1)
 
 		testlib.CreateQuickstartSchema(t, namespaceName, admin0)
 


### PR DESCRIPTION
**Issue**

Once the backup index reaches `NUODB_MAX_BACKUP_HISTORY`, it will be reset to
0. This will cause problems with recording future backup metadata history as
the values in the KV store for these keys are expected to be empty.

**Changes**

- Set the expected value for the next backup by first fetching the existing
  value. This solves the issue at hand while preserving the guard for
  concurrent modifications of the backup metadata at that index.
- Make sure that backup indexes always start with `0`. Previously the initial
  value was `1` but after reaching `NUODB_MAX_BACKUP_HISTORY`, the index was
reset to `0`. Changed the `report-backups` command to account for that.
- Render `database.env` Helm values in CronJob allowing users to pass opaque
  environment variables.

**Testing**

- Fixed initial backup indexes in restore tests that explicitly assert them
- Added integration and E2E tests