### PR TITLE
[HELM-416] ignore completed pods in scheduled pod list

### DIFF
--- a/test/testlib/minikube_utilities.go
+++ b/test/testlib/minikube_utilities.go
@@ -451,6 +451,11 @@ func AwaitNrReplicasScheduled(t *testing.T, namespace string, expectedName strin
 		var podNames string
 		for _, pod := range FindAllPodsInSchema(t, namespace) {
 			if strings.Contains(pod.Name, expectedName) {
+				//ignore all completed pods
+				if pod.Status.Phase == corev1.PodSucceeded {
+					continue;
+				}
+
 				if arePodConditionsMet(&pod, corev1.PodScheduled, corev1.ConditionTrue) {
 					// build array of scheduled pods
 					pods = append(pods, pod)


### PR DESCRIPTION
test case is failing because it is expecting one pod but finds two - one is in Running state (the valid one) while the other one is in Completed state and has a similar name (contains an additional (*crd-job-1*) in the pod name)