### PR TITLE
Update DNS configuration before multi-cluster tests

### DIFF
--- a/test/multicluster/minikube_base_multicluster_test.go
+++ b/test/multicluster/minikube_base_multicluster_test.go
@@ -86,6 +86,10 @@ func TestKubernetesBasicMultiCluster(t *testing.T) {
 	cluster2Context := testlib.NewClusterDeploymentContext(context,
 		&options, testlib.MULTI_CLUSTER_2, testlib.MULTI_CLUSTER_1)
 
+	// Add each DNS server as an upstream resolver for the other
+	testlib.UpdateDnsConfig(t, cluster1Context, cluster2Context)
+	testlib.UpdateDnsConfig(t, cluster2Context, cluster1Context)
+
 	defer testlib.Teardown(testlib.TEARDOWN_MULTICLUSTER)
 	defer testlib.Teardown(testlib.TEARDOWN_ADMIN)
 	defer testlib.Teardown(testlib.TEARDOWN_DATABASE)


### PR DESCRIPTION
The IPs for the elastic load balancer endpoints that are used to expose each DNS server are not permanent, so the CoreDNS configuration has to be updated to include the current IPs. This change programmatically resolves the IPs of each DNS load balancer and adds them as upstream resolvers for the other.

The "Corefile" configmap entry is assumed to contain the marker string "# BEGIN BASE CONFIG", which delimits the non-changing portion of the config and enables updates to the generated portion.