### PR TITLE
Preprovision PVCs with data sources and other fixes

### DIFF
--- a/stable/database/README.md
+++ b/stable/database/README.md
@@ -215,6 +215,7 @@ The following tables list the configurable parameters of the `database` chart an
 | `persistence.archiveDataSource.*` | The data source to use to initialize the archive volume. This takes precedence over the archive snapshot resolved from `database.snapshotRestore`. | `disabled` |
 | `persistence.journalDataSource.*` | The data source to use to initialize the journal volume. This takes precedence over the journal snapshot resolved from `database.snapshotRestore`. | `disabled` |
 | `persistence.validateDataSources` | Whether to validate that data sources resolved from `database.snapshotRestore` or specified explicitly using `persistence.archiveDataSource` and `persistence.journalDataSource` actually exist. This is useful because data source references that do not exist are silently ignored by Kubernetes. | `true` |
+| `persistence.preprovisionVolumes` | Whether to explicitly provision PVCs for all SMs specified by `database.sm.noHotCopy.replicas`. If data sources are configured, then they will appear in the preprovisioned PVCs of the non-hotcopy SMs but not in the `volumeClaimTemplates` section, so that the existence of the volume snapshots is not required in order to scale up the non-hotcopy SM StatefulSet. | `false` |
 | `configFilesPath` | Directory path where `configFiles.*` are found | `/etc/nuodb/` |
 | `configFiles.*` | See below. | `{}` |
 | `podAnnotations` | Annotations to pass through to the SM an TE pods | `nil` |

--- a/stable/database/files/backup_hooks.py
+++ b/stable/database/files/backup_hooks.py
@@ -212,7 +212,7 @@ def post_backup(backup_id, query):
     # Delete backup ID files and payload file
     if os.path.exists(ARCHIVE_BACKUP_ID_FILE):
         os.remove(ARCHIVE_BACKUP_ID_FILE)
-    if os.path.exists(JOURNAL_BACKUP_ID_FILE):
+    if JOURNAL_BACKUP_ID_FILE is not None and os.path.exists(JOURNAL_BACKUP_ID_FILE):
         os.remove(JOURNAL_BACKUP_ID_FILE)
     if os.path.exists(BACKUP_PAYLOAD_FILE):
         os.remove(BACKUP_PAYLOAD_FILE)

--- a/stable/database/files/backup_hooks.py
+++ b/stable/database/files/backup_hooks.py
@@ -46,8 +46,9 @@ def write_file(path, content):
     # default. Making the file group-writable ensures that it is accessible to
     # the nuodb user in OpenShift deployments where an arbitrary uid is used
     # with gid 0.
-    os.chown(path, 1000, 0)
-    os.chmod(path, mode=0o660)
+    if os.getuid() == 0:
+        os.chown(path, 1000, 0)
+        os.chmod(path, mode=0o660)
 
 
 def get_nuodb_pids():

--- a/stable/database/files/nuosm
+++ b/stable/database/files/nuosm
@@ -454,16 +454,16 @@ function loadFromSnapshot() {
     local recreate_archives="true"
   elif [ -n "$BACKUP_ID" ] && [ -f "${DB_DIR}/backup.txt" ]; then
     # Check backup ID in archive
-    if ! checkBackupId "${DB_DIR}/backup.txt"; then
-      die 1 "Incorrect backup id in archive"
+    if checkBackupId "${DB_DIR}/backup.txt"; then
+      local recreate_archives="true"
+    else
+      log "Incorrect backup id in archive... Did the SM crash during a snapshot?"
     fi
 
     # Check backup ID in journal
     if [ "$SEPARATE_JOURNAL" == "true" ] && ! checkBackupId "${JOURNAL_DIR}/backup.txt"; then
-      die 1 "Incorrect backup id in journal"
+      log "Incorrect backup id in journal... Did the SM crash during a snapshot?"
     fi
-
-    local recreate_archives="true"
   fi
 
   if [ "$recreate_archives" == "true" ]; then

--- a/stable/database/files/nuosm
+++ b/stable/database/files/nuosm
@@ -402,64 +402,74 @@ function checkBackupId() {
 function loadFromSnapshot() {
   local recreate_archives="false"
 
-  if [ ! -f "$DB_DIR/state.dat" ]; then
-    local archives=$( find "/var/opt/nuodb/archive" -name info.json )
-    if [ -z "$archives" ] || [ $(echo "$archives" | wc -l) != 1 ]; then 
+  if [ ! -f "$DB_DIR/info.json" ]; then
+    local archives="$(find /var/opt/nuodb/archive -name info.json)"
+    if [ -z "$archives" ] || [ "$(echo "$archives" | wc -l)" != 1 ]; then
+      # Relax check for archive snapshot for SMs other than ordinal 0. It is
+      # possible that a database that was restored from a backup with
+      # pre-provisioned PVCs has been scaled up. In this case, the new SMs will
+      # have empty PVCs, so no archive snapshot will be found.
+      local ordinal="${POD_NAME##*-}"
+      if [ -z "$archives" ] && [ "$ordinal" != 0 ]; then
+        log "No archive snapshot found for $POD_NAME with non-0 ordinal $ordinal"
+        return 1
+      fi
       die 1 "Did not find exactly 1 archive: ${archives}"
     fi
 
-    local archive_path=$( dirname $archives )
+    local archive_path="$(dirname "$archives")"
     log "Found snapshot at ${archive_path}"
 
     if [ -n "$BACKUP_ID" ]; then
-      if ! checkBackupId ${archive_path}/backup.txt ; then
+      if ! checkBackupId "${archive_path}/backup.txt"; then
         die 1 "Incorrect backup id in archive"
       fi
     fi
 
     if [ "$SEPARATE_JOURNAL" == "true" ]; then
-      local relative_archive=$(realpath --relative-base=/var/opt/nuodb/archive $archive_path)
+      local relative_archive="$(realpath --relative-base=/var/opt/nuodb/archive "$archive_path")"
       local expected_journal="/var/opt/nuodb/journal/${relative_archive}"
 
-      if [ ! -d $expected_journal ]; then
+      if [ ! -d "$expected_journal" ]; then
         die 1 "Did not find a journal snapshot at '$expected_journal'"
       fi
-      
+
       if [ -n "$BACKUP_ID" ]; then
-        if ! checkBackupId ${expected_journal}/backup.txt ; then
+        if ! checkBackupId "${expected_journal}/backup.txt"; then
           die 1 "Incorrect backup id in journal"
         fi
       fi
 
-      rm -rf ${JOURNAL_DIR}
-      mv ${expected_journal} ${JOURNAL_DIR}
+      rm -rf "${JOURNAL_DIR}"
+      mv "${expected_journal}" "${JOURNAL_DIR}"
 
     fi
 
     # Don't move the archive until after we have done error checking.
     # Once we move the archive, we are going to be in the `archive already exists` branch
     # when kubernetes retries/restarts the pod.
-    rm -rf ${DB_DIR}
-    mv ${archive_path} ${DB_DIR}
+    rm -rf "${DB_DIR}"
+    mv "${archive_path}" "${DB_DIR}"
 
     local recreate_archives="true"
-  else
-    trace "archive already exists, not looking for snapshot archives"
-
-    local backup_file=${DB_DIR}/backup.txt
-    if [ -n "$BACKUP_ID" ] && [ -f  $backup_file ] ; then
-      if [ "$(cat $backup_file | tr -d [:space:])" == "$BACKUP_ID" ] ; then
-        local recreate_archives="true"
-      else
-        log "Archive present but with a wrong backupId. Did the SM crash during a snapshot?"
-      fi
+  elif [ -n "$BACKUP_ID" ] && [ -f "${DB_DIR}/backup.txt" ]; then
+    # Check backup ID in archive
+    if ! checkBackupId "${DB_DIR}/backup.txt"; then
+      die 1 "Incorrect backup id in archive"
     fi
+
+    # Check backup ID in journal
+    if [ "$SEPARATE_JOURNAL" == "true" ] && ! checkBackupId "${JOURNAL_DIR}/backup.txt"; then
+      die 1 "Incorrect backup id in journal"
+    fi
+
+    local recreate_archives="true"
   fi
 
-  if [ $recreate_archives == "true" ]; then
-    log "Removing outdated archive metadata"
-    rm ${DB_DIR}/info.json ${DB_DIR}/backup.txt
-    [ -e ${JOURNAL_DIR}/backup.txt ] && rm ${JOURNAL_DIR}/backup.txt
+  if [ "$recreate_archives" == "true" ]; then
+    log "Removing metadata from snapshot archive"
+    rm "${DB_DIR}/info.json" "${DB_DIR}/backup.txt"
+    [ -e "${JOURNAL_DIR}/backup.txt" ] && rm "${JOURNAL_DIR}/backup.txt"
   fi
 }
 

--- a/stable/database/files/nuosm
+++ b/stable/database/files/nuosm
@@ -412,7 +412,7 @@ function loadFromSnapshot() {
       local ordinal="${POD_NAME##*-}"
       if [ -z "$archives" ] && [ "$ordinal" != 0 ]; then
         log "No archive snapshot found for $POD_NAME with non-0 ordinal $ordinal"
-        return 1
+        return 0
       fi
       die 1 "Did not find exactly 1 archive: ${archives}"
     fi

--- a/stable/database/templates/_helpers.tpl
+++ b/stable/database/templates/_helpers.tpl
@@ -905,3 +905,63 @@ true
 false
 {{- end -}}
 {{- end -}}
+
+{{/*
+Get spec of archive PVC or volumeClaimTemplate of SM statefulset.
+*/}}
+{{- define "database.archivePvcSpec" -}}
+{{- $ := index . 0 -}}
+{{- $includeDataSource := index . 1 -}}
+accessModes:
+{{- range $.Values.database.persistence.accessModes }}
+  - {{ . }}
+{{- end }}
+{{- if $.Values.database.persistence.storageClass }}
+{{- if eq "-" $.Values.database.persistence.storageClass }}
+storageClassName: ""
+{{- else }}
+storageClassName: {{ $.Values.database.persistence.storageClass }}
+{{- end }}
+{{- end }}
+{{- if eq (include "defaultfalse" $includeDataSource) "true" }}
+{{ include "database.archiveDataSource" $ }}
+{{- end }}
+{{- if $.Values.database.isManualVolumeProvisioning }}
+selector:
+  matchLabels:
+    database: {{ $.Values.database.name }}
+{{- end }}
+resources:
+  requests:
+    storage: {{ $.Values.database.persistence.size }}
+{{- end -}}
+
+{{/*
+Get spec of journal PVC or volumeClaimTemplate of SM statefulset.
+*/}}
+{{- define "database.journalPvcSpec" -}}
+{{- $ := index . 0 -}}
+{{- $includeDataSource := index . 1 -}}
+accessModes:
+{{- range $.Values.database.sm.noHotCopy.journalPath.persistence.accessModes }}
+  - {{ . }}
+{{- end }}
+{{- if $.Values.database.sm.noHotCopy.journalPath.persistence.storageClass }}
+{{- if eq "-" $.Values.database.sm.noHotCopy.journalPath.persistence.storageClass }}
+storageClassName: ""
+{{- else }}
+storageClassName: {{ $.Values.database.sm.noHotCopy.journalPath.persistence.storageClass }}
+{{- end }}
+{{- end }}
+{{- if eq (include "defaultfalse" $includeDataSource) "true" }}
+{{ include "database.journalDataSource" $ }}
+{{- end }}
+{{- if $.Values.database.isManualVolumeProvisioning }}
+selector:
+  matchLabels:
+    database: {{ $.Values.database.name }}
+{{- end }}
+resources:
+  requests:
+    storage: {{ $.Values.database.sm.noHotCopy.journalPath.persistence.size }}
+{{- end -}}

--- a/stable/database/templates/_helpers.tpl
+++ b/stable/database/templates/_helpers.tpl
@@ -861,7 +861,11 @@ Validate and render dataSourceRef.
     {{- end -}}
     {{- $namespace := default $.Release.Namespace $ref.namespace -}}
     {{- if not (lookup $apiVersion $ref.kind $namespace $ref.name) -}}
-      {{- fail (printf "Invalid data source: %s/%s/%s not found in namespace %s" $apiVersion $ref.kind $ref.name $namespace) -}}
+      {{- if and $.Release.IsUpgrade (eq (include "defaultfalse" $.Values.database.persistence.preprovisionVolumes) "true") -}}
+        {{- $dataSource = "" -}}
+      {{- else -}}
+        {{- fail (printf "Invalid data source: %s/%s/%s not found in namespace %s" $apiVersion $ref.kind $ref.name $namespace) -}}
+      {{- end -}}
     {{- end -}}
   {{- end -}}
   {{- print $dataSource -}}

--- a/stable/database/templates/persistentvolumeclaim.yaml
+++ b/stable/database/templates/persistentvolumeclaim.yaml
@@ -10,6 +10,8 @@ metadata:
   labels:
     {{- include "database.resourceLabels" . | nindent 4 }}
     {{- include "database.storageGroupLabels" . | nindent 4 }}
+  annotations:
+    "helm.sh/resource-policy": keep
 spec:
   {{- include "database.archivePvcSpec" (list . true) | nindent 2 }}
 {{- if eq (include "defaultfalse" .Values.database.sm.noHotCopy.journalPath.enabled) "true"}}
@@ -21,6 +23,8 @@ metadata:
   labels:
     {{- include "database.resourceLabels" . | nindent 4 }}
     {{- include "database.storageGroupLabels" . | nindent 4 }}
+  annotations:
+    "helm.sh/resource-policy": keep
 spec:
   {{- include "database.journalPvcSpec" (list . true) | nindent 2 }}
 {{- end }}

--- a/stable/database/templates/persistentvolumeclaim.yaml
+++ b/stable/database/templates/persistentvolumeclaim.yaml
@@ -1,3 +1,32 @@
+{{- if eq (include "defaultfalse" .Values.database.persistence.preprovisionVolumes) "true" }}
+{{- $sts := include "database.statefulset.name" (printf "sm-%s" (include "database.fullname" .)) -}}
+{{- range $i := until (int .Values.database.sm.noHotCopy.replicas) }}
+{{- with $ }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: archive-volume-{{ printf "%s-%d" $sts $i }}
+  labels:
+    {{- include "database.resourceLabels" . | nindent 4 }}
+    {{- include "database.storageGroupLabels" . | nindent 4 }}
+spec:
+  {{- include "database.archivePvcSpec" (list . true) | nindent 2 }}
+{{- if eq (include "defaultfalse" .Values.database.sm.noHotCopy.journalPath.enabled) "true"}}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: journal-volume-{{ printf "%s-%d" $sts $i }}
+  labels:
+    {{- include "database.resourceLabels" . | nindent 4 }}
+    {{- include "database.storageGroupLabels" . | nindent 4 }}
+spec:
+  {{- include "database.journalPvcSpec" (list . true) | nindent 2 }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
 {{- if eq (include "defaultfalse" .Values.database.te.logPersistence.enabled) "true" }}
 ---
 apiVersion: v1

--- a/stable/database/templates/statefulset.yaml
+++ b/stable/database/templates/statefulset.yaml
@@ -350,26 +350,8 @@ spec:
         {{- include "database.resourceLabels" . | nindent 8 }}
         {{- include "database.storageGroupLabels" . | nindent 8 }}
     spec:
-      accessModes:
-      {{- range .Values.database.persistence.accessModes }}
-        - {{ . }}
-      {{- end }}
-      {{- if .Values.database.persistence.storageClass }}
-      {{- if (eq "-" .Values.database.persistence.storageClass) }}
-      storageClassName: ""
-      {{- else }}
-      storageClassName: {{ .Values.database.persistence.storageClass }}
-      {{- end }}
-      {{- end }}
-      {{- include "database.archiveDataSource" . | nindent 6 }}
-      {{- if .Values.database.isManualVolumeProvisioning }}
-      selector:
-        matchLabels:
-          database: {{ .Values.database.name }}
-      {{- end }}
-      resources:
-        requests:
-          storage: {{ .Values.database.persistence.size }}
+      {{- $includeDataSource := eq (include "defaultfalse" .Values.database.persistence.preprovisionVolumes) "false" -}}
+      {{- include "database.archivePvcSpec" (list . $includeDataSource) | nindent 6 }}
   {{- if eq (include "defaultfalse" .Values.database.sm.noHotCopy.journalPath.enabled) "true"}}
   - metadata:
       name: journal-volume
@@ -377,26 +359,7 @@ spec:
         {{- include "database.resourceLabels" . | nindent 8 }}
         {{- include "database.storageGroupLabels" . | nindent 8 }}
     spec:
-      accessModes:
-      {{- range .Values.database.sm.noHotCopy.journalPath.persistence.accessModes }}
-        - {{ . }}
-      {{- end }}
-      {{- if .Values.database.sm.noHotCopy.journalPath.persistence.storageClass }}
-      {{- if (eq "-" .Values.database.sm.noHotCopy.journalPath.persistence.storageClass) }}
-      storageClassName: ""
-      {{- else }}
-      storageClassName: {{ .Values.database.sm.noHotCopy.journalPath.persistence.storageClass }}
-      {{- end }}
-      {{- end }}
-      {{- include "database.journalDataSource" . | nindent 6 }}
-      {{- if .Values.database.isManualVolumeProvisioning }}
-      selector:
-        matchLabels:
-          database: {{ .Values.database.name }}
-      {{- end }}
-      resources:
-        requests:
-          storage: {{ .Values.database.sm.noHotCopy.journalPath.persistence.size }}
+      {{- include "database.journalPvcSpec" (list . $includeDataSource) | nindent 6 }}
   {{- end }}
   {{- if eq (include "defaultfalse" .Values.database.sm.logPersistence.enabled) "true" }}
   - metadata:

--- a/stable/database/values.yaml
+++ b/stable/database/values.yaml
@@ -256,6 +256,10 @@ database:
     # Whether to validate that data sources for PVCs exist
     validateDataSources: true
 
+    # Whether to preprovision PVCs from data sources and omit the data source
+    # reference from the volumeClaimTemplate section of the statefulset.
+    preprovisionVolumes: false
+
   ## database-wide options.
   # These are applied using the --database-options on the startup command
   # change these to values appropriate for this database

--- a/test/minikube/minikube_long_restore_test.go
+++ b/test/minikube/minikube_long_restore_test.go
@@ -922,7 +922,7 @@ func TestCornerCaseKubernetesSnapshotRestore(t *testing.T) {
 	}
 
 	// Try to create a database from a snapshot
-	testDb := func(dbName string, archiveSnapshotName string, journalSnapshotName string, backupId string, shouldStart bool, verifyRestart bool) string {
+	testDb := func(t *testing.T, dbName string, archiveSnapshotName string, journalSnapshotName string, backupId string, shouldStart bool, verifyRestart bool) string {
 		retVal := ""
 
 		values := map[string]string{
@@ -1053,39 +1053,39 @@ func TestCornerCaseKubernetesSnapshotRestore(t *testing.T) {
 
 		// Test that sm can start from a snapshot with out a backup.txt if no backupId is supplied
 		t.Run("testArchiveNoBackupId", func(t *testing.T) {
-			testDb("noj-nobid", archiveNoBidSnapshotName, "", "", true, false)
+			testDb(t, "noj-nobid", archiveNoBidSnapshotName, "", "", true, false)
 		})
 
 		// Test that sm can start from a snapshot with a backup.txt containing the backupId
 		t.Run("testArchiveCorrectBackupId", func(t *testing.T) {
-			testDb("noj-gdbid", archiveBidSnapshotName, "", "123abc", true, true)
+			testDb(t, "noj-gdbid", archiveBidSnapshotName, "", "123abc", true, true)
 		})
 
 		// Test that sm can start from a snapshot with an arbitrary backup.txt if no backupId is supplied
 		t.Run("testArchiveIgnoredBackupId", func(t *testing.T) {
-			testDb("noj-ignbid", archiveBadBidSnapshotName, "", "", true, false)
+			testDb(t, "noj-ignbid", archiveBadBidSnapshotName, "", "", true, false)
 		})
 
 		// Test that we can clone an SM with the same domain and database names
 		t.Run("testArchiveRecreate", func(t *testing.T) {
-			testDb(sourceDb, archiveBidSnapshotName, "", "123abc", true, true)
+			testDb(t, sourceDb, archiveBidSnapshotName, "", "123abc", true, true)
 		})
 
 		// Test that sm won't start from a snapshot without a backup.txt if a backupId is supplied
 		t.Run("testNegativeArchiveNoBackupFile", func(t *testing.T) {
-			output := testDb("noj-misbid", archiveNoBidSnapshotName, "", "123abc", false, false)
+			output := testDb(t, "noj-misbid", archiveNoBidSnapshotName, "", "123abc", false, false)
 			require.Contains(t, output, "Incorrect backup id in archive")
 		})
 
 		// Test that sm won't start from a snapshot with a backup.txt containing the wrong backupId
 		t.Run("testNegativeArchiveWrongBackupId", func(t *testing.T) {
-			output := testDb("noj-badbid", archiveBadBidSnapshotName, "", "123abc", false, false)
+			output := testDb(t, "noj-badbid", archiveBadBidSnapshotName, "", "123abc", false, false)
 			require.Contains(t, output, "Incorrect backup id in archive")
 		})
 
 		// Test that sm won't start if there are multiple archives to restore from
 		t.Run("testNegativeMultipleArchives", func(t *testing.T) {
-			output := testDb("noj-2arch", extraArchiveSnapshotName, "", "123abc", false, false)
+			output := testDb(t, "noj-2arch", extraArchiveSnapshotName, "", "123abc", false, false)
 			require.Contains(t, output, "Did not find exactly 1 archive:")
 		})
 	})
@@ -1161,39 +1161,39 @@ func TestCornerCaseKubernetesSnapshotRestore(t *testing.T) {
 
 		// Test that sm can start from a journal with out a backup.txt if no backupId is supplied
 		t.Run("testJournalNoBackupId", func(t *testing.T) {
-			testDb("jor-nobid", archiveNeedsJournalNoBidSnapshotName, journalNoBidSnapshotName, "", true, false)
+			testDb(t, "jor-nobid", archiveNeedsJournalNoBidSnapshotName, journalNoBidSnapshotName, "", true, false)
 		})
 
 		// Test that sm can start from a journal with a backup.txt containing the backupId
 		t.Run("testJournalCorrectBackupId", func(t *testing.T) {
-			testDb("jor-gdbid", archiveBidSnapshotName, journalBidSnapshotName, "123abc", true, true)
+			testDb(t, "jor-gdbid", archiveBidSnapshotName, journalBidSnapshotName, "123abc", true, true)
 		})
 
 		// Test that sm can start from a journal with an arbitrary backup.txt if no backupId is supplied
 		t.Run("testJournalIgnoredBackupId", func(t *testing.T) {
-			testDb("jor-ignbid", archiveBadBidSnapshotName, journalBadBidSnapshotName, "", true, false)
+			testDb(t, "jor-ignbid", archiveBadBidSnapshotName, journalBadBidSnapshotName, "", true, false)
 		})
 
 		// Test that we can clone an SM with the same domain and database names
 		t.Run("testJournalRecreate", func(t *testing.T) {
-			testDb(sourceDb, archiveBidSnapshotName, journalBidSnapshotName, "123abc", true, true)
+			testDb(t, sourceDb, archiveBidSnapshotName, journalBidSnapshotName, "123abc", true, true)
 		})
 
 		// Test that sm won't start from a journal without a backup.txt if a backupId is supplied
 		t.Run("testNegativeJournalNoBackupFile", func(t *testing.T) {
-			output := testDb("jor-misbid", archiveBidSnapshotName, journalNoBidSnapshotName, "123abc", false, false)
+			output := testDb(t, "jor-misbid", archiveBidSnapshotName, journalNoBidSnapshotName, "123abc", false, false)
 			require.Contains(t, output, "Incorrect backup id in journal")
 		})
 
 		// Test that sm won't start from a journal with a backup.txt containing the wrong backupId
 		t.Run("testNegativeJournalWrongBackupFile", func(t *testing.T) {
-			output := testDb("jor-badbid", archiveBidSnapshotName, journalBadBidSnapshotName, "123abc", false, false)
+			output := testDb(t, "jor-badbid", archiveBidSnapshotName, journalBadBidSnapshotName, "123abc", false, false)
 			require.Contains(t, output, "Incorrect backup id in journal")
 		})
 
 		// Test that sm won't start if it cannot find a journal at the expected backup location
 		t.Run("testNegativeMissingJournal", func(t *testing.T) {
-			output := testDb("jor-mvjor", archiveBidSnapshotName, journalWrongPathSnapshotName, "123abc", false, false)
+			output := testDb(t, "jor-mvjor", archiveBidSnapshotName, journalWrongPathSnapshotName, "123abc", false, false)
 			require.Contains(t, output, "Did not find a journal snapshot at '/var/opt/nuodb/journal/nuodb/src-journ'")
 		})
 	})

--- a/test/testlib/template_utilities.go
+++ b/test/testlib/template_utilities.go
@@ -135,17 +135,16 @@ func GetVolumeClaim(vcp []v1.PersistentVolumeClaim, expectedName string) (*v1.Pe
 	return nil, false
 }
 
-func SplitAndRenderConfigMap(t *testing.T, output string, expectedNrObjects int) []v1.ConfigMap {
-	objects := make([]v1.ConfigMap, 0)
-
+func SplitAndRender[T any](t *testing.T, output string, expectedNrObjects int, kind string) []T {
+	objects := make([]T, 0)
 	parts := strings.Split(output, "---")
 	for _, part := range parts {
 		if len(part) == 0 {
 			continue
 		}
 
-		if strings.Contains(part, fmt.Sprintf("kind: %s", "ConfigMap")) {
-			var obj v1.ConfigMap
+		if strings.Contains(part, fmt.Sprintf("kind: %s", kind)) {
+			var obj T
 			helm.UnmarshalK8SYaml(t, part, &obj)
 
 			objects = append(objects, obj)
@@ -153,272 +152,63 @@ func SplitAndRenderConfigMap(t *testing.T, output string, expectedNrObjects int)
 	}
 
 	require.GreaterOrEqual(t, len(objects), expectedNrObjects)
-
 	return objects
+}
+
+func SplitAndRenderPersistentVolumeClaim(t *testing.T, output string, expectedNrObjects int) []v1.PersistentVolumeClaim {
+	return SplitAndRender[v1.PersistentVolumeClaim](t, output, expectedNrObjects, "PersistentVolumeClaim")
+}
+
+func SplitAndRenderConfigMap(t *testing.T, output string, expectedNrObjects int) []v1.ConfigMap {
+	return SplitAndRender[v1.ConfigMap](t, output, expectedNrObjects, "ConfigMap")
 }
 
 func SplitAndRenderCronJob(t *testing.T, output string, expectedNrObjects int) []v1beta1.CronJob {
-	objects := make([]v1beta1.CronJob, 0)
-
-	parts := strings.Split(output, "---")
-	for _, part := range parts {
-		if len(part) == 0 {
-			continue
-		}
-
-		if strings.Contains(part, fmt.Sprintf("kind: %s", "CronJob")) {
-			var obj v1beta1.CronJob
-			helm.UnmarshalK8SYaml(t, part, &obj)
-
-			objects = append(objects, obj)
-		}
-	}
-
-	require.GreaterOrEqual(t, len(objects), expectedNrObjects)
-
-	return objects
+	return SplitAndRender[v1beta1.CronJob](t, output, expectedNrObjects, "CronJob")
 }
 
 func SplitAndRenderDaemonSet(t *testing.T, output string, expectedNrObjects int) []appsv1.DaemonSet {
-	objects := make([]appsv1.DaemonSet, 0)
-
-	parts := strings.Split(output, "---")
-	for _, part := range parts {
-		if len(part) == 0 {
-			continue
-		}
-
-		if strings.Contains(part, fmt.Sprintf("kind: %s", "DaemonSet")) {
-			var obj appsv1.DaemonSet
-			helm.UnmarshalK8SYaml(t, part, &obj)
-
-			objects = append(objects, obj)
-		}
-	}
-
-	require.GreaterOrEqual(t, len(objects), expectedNrObjects)
-
-	return objects
+	return SplitAndRender[appsv1.DaemonSet](t, output, expectedNrObjects, "DaemonSet")
 }
 
 func SplitAndRenderJob(t *testing.T, output string, expectedNrObjects int) []batchv1.Job {
-	objects := make([]batchv1.Job, 0)
-
-	parts := strings.Split(output, "---")
-	for _, part := range parts {
-		if len(part) == 0 {
-			continue
-		}
-
-		if strings.Contains(part, fmt.Sprintf("kind: %s", "Job")) {
-			var obj batchv1.Job
-			helm.UnmarshalK8SYaml(t, part, &obj)
-
-			objects = append(objects, obj)
-		}
-	}
-
-	require.GreaterOrEqual(t, len(objects), expectedNrObjects)
-
-	return objects
+	return SplitAndRender[batchv1.Job](t, output, expectedNrObjects, "Job")
 }
 
 func SplitAndRenderDeployment(t *testing.T, output string, expectedNrObjects int) []appsv1.Deployment {
-	objects := make([]appsv1.Deployment, 0)
-
-	parts := strings.Split(output, "---")
-	for _, part := range parts {
-		if len(part) == 0 {
-			continue
-		}
-
-		if strings.Contains(part, fmt.Sprintf("kind: %s", "Deployment")) {
-			var obj appsv1.Deployment
-			helm.UnmarshalK8SYaml(t, part, &obj)
-
-			objects = append(objects, obj)
-		}
-	}
-
-	require.GreaterOrEqual(t, len(objects), expectedNrObjects)
-
-	return objects
+	return SplitAndRender[appsv1.Deployment](t, output, expectedNrObjects, "Deployment")
 }
 
 func SplitAndRenderReplicationController(t *testing.T, output string, expectedNrObjects int) []v1.ReplicationController {
-	objects := make([]v1.ReplicationController, 0)
-
-	parts := strings.Split(output, "---")
-	for _, part := range parts {
-		if len(part) == 0 {
-			continue
-		}
-
-		if strings.Contains(part, fmt.Sprintf("kind: %s", "ReplicationController")) {
-			var obj v1.ReplicationController
-			helm.UnmarshalK8SYaml(t, part, &obj)
-
-			objects = append(objects, obj)
-		}
-	}
-
-	require.GreaterOrEqual(t, len(objects), expectedNrObjects)
-
-	return objects
+	return SplitAndRender[v1.ReplicationController](t, output, expectedNrObjects, "ReplicationController")
 }
 
 func SplitAndRenderSecret(t *testing.T, output string, expectedNrObjects int) []v1.Secret {
-	objects := make([]v1.Secret, 0)
-
-	parts := strings.Split(output, "---")
-	for _, part := range parts {
-		if len(part) == 0 {
-			continue
-		}
-
-		if strings.Contains(part, fmt.Sprintf("kind: %s", "Secret")) {
-			var obj v1.Secret
-			helm.UnmarshalK8SYaml(t, part, &obj)
-
-			objects = append(objects, obj)
-		}
-	}
-
-	require.GreaterOrEqual(t, len(objects), expectedNrObjects)
-
-	return objects
+	return SplitAndRender[v1.Secret](t, output, expectedNrObjects, "Secret")
 }
 
 func SplitAndRenderService(t *testing.T, output string, expectedNrObjects int) []v1.Service {
-	objects := make([]v1.Service, 0)
-
-	parts := strings.Split(output, "---")
-	for _, part := range parts {
-		if len(part) == 0 {
-			continue
-		}
-
-		if strings.Contains(part, fmt.Sprintf("kind: %s", "Service")) {
-			var obj v1.Service
-			helm.UnmarshalK8SYaml(t, part, &obj)
-
-			objects = append(objects, obj)
-		}
-	}
-
-	require.GreaterOrEqual(t, len(objects), expectedNrObjects)
-
-	return objects
+	return SplitAndRender[v1.Service](t, output, expectedNrObjects, "Service")
 }
 
 func SplitAndRenderStatefulSet(t *testing.T, output string, expectedNrObjects int) []appsv1.StatefulSet {
-	objects := make([]appsv1.StatefulSet, 0)
-
-	parts := strings.Split(output, "---")
-	for _, part := range parts {
-		if len(part) == 0 {
-			continue
-		}
-
-		if strings.Contains(part, fmt.Sprintf("kind: %s", "StatefulSet")) {
-			var obj appsv1.StatefulSet
-			helm.UnmarshalK8SYaml(t, part, &obj)
-
-			objects = append(objects, obj)
-		}
-	}
-
-	require.GreaterOrEqual(t, len(objects), expectedNrObjects)
-
-	return objects
+	return SplitAndRender[appsv1.StatefulSet](t, output, expectedNrObjects, "StatefulSet")
 }
 
 func SplitAndRenderStorageClass(t *testing.T, output string, expectedNrObjects int) []storagev1.StorageClass {
-	objects := make([]storagev1.StorageClass, 0)
-
-	parts := strings.Split(output, "---")
-	for _, part := range parts {
-		if len(part) == 0 {
-			continue
-		}
-
-		if strings.Contains(part, fmt.Sprintf("kind: %s", "StorageClass")) {
-			var obj storagev1.StorageClass
-			helm.UnmarshalK8SYaml(t, part, &obj)
-
-			objects = append(objects, obj)
-		}
-	}
-
-	require.GreaterOrEqual(t, len(objects), expectedNrObjects)
-
-	return objects
+	return SplitAndRender[storagev1.StorageClass](t, output, expectedNrObjects, "StorageClass")
 }
 
 func SplitAndRenderRole(t *testing.T, output string, expectedNrObjects int) []rbacv1.Role {
-	objects := make([]rbacv1.Role, 0)
-
-	parts := strings.Split(output, "---")
-	for _, part := range parts {
-		if len(part) == 0 {
-			continue
-		}
-
-		if strings.Contains(part, fmt.Sprintf("kind: %s", "Role")) {
-			var obj rbacv1.Role
-			helm.UnmarshalK8SYaml(t, part, &obj)
-
-			objects = append(objects, obj)
-		}
-	}
-
-	require.GreaterOrEqual(t, len(objects), expectedNrObjects)
-
-	return objects
+	return SplitAndRender[rbacv1.Role](t, output, expectedNrObjects, "Role")
 }
 
 func SplitAndRenderServiceAccount(t *testing.T, output string, expectedNrObjects int) []v1.ServiceAccount {
-	objects := make([]v1.ServiceAccount, 0)
-
-	parts := strings.Split(output, "---")
-	for _, part := range parts {
-		if len(part) == 0 {
-			continue
-		}
-
-		if strings.Contains(part, fmt.Sprintf("kind: %s", "ServiceAccount")) {
-			var obj v1.ServiceAccount
-			helm.UnmarshalK8SYaml(t, part, &obj)
-
-			objects = append(objects, obj)
-		}
-	}
-
-	require.GreaterOrEqual(t, len(objects), expectedNrObjects)
-
-	return objects
+	return SplitAndRender[v1.ServiceAccount](t, output, expectedNrObjects, "ServiceAccount")
 }
 
 func SplitAndRenderIngress(t *testing.T, output string, expectedNrObjects int) []networkingv1.Ingress {
-	objects := make([]networkingv1.Ingress, 0)
-
-	parts := strings.Split(output, "---")
-	for _, part := range parts {
-		if len(part) == 0 {
-			continue
-		}
-
-		if strings.Contains(part, fmt.Sprintf("kind: %s", "Ingress")) {
-			var obj networkingv1.Ingress
-			helm.UnmarshalK8SYaml(t, part, &obj)
-
-			objects = append(objects, obj)
-		}
-	}
-
-	require.GreaterOrEqual(t, len(objects), expectedNrObjects)
-
-	return objects
+	return SplitAndRender[networkingv1.Ingress](t, output, expectedNrObjects, "Ingress")
 }
 
 func IsStatefulSetHotCopyEnabled(ss *appsv1.StatefulSet) bool {


### PR DESCRIPTION
- Add `database.persistence.preprovisionVolumes` value that allows PVCs for all non-hotcopy SMs to be preprovisioned. This allows the SM statefulset to be scaled in the absence of the volume snapshots used to restore the database, since they do not appear in the volumeClaimTemplates section when `preprovisionVolumes=true`.
- Fix bug in backup_hooks.py which was causing failures when a non-root user was configured in the pod security context. In that case, it is not necessary to change ownership and permissions on the backup.txt file, since the user is either the same as the nuodb user or root.
- Update nuosm to allow scaling of the SM statefulset in the absence of volume snapshots. Now SMs with non-0 ordinals can skip the existing backup ID check in the case where no archive snapshots are found.
- Fix a bug exposed by the relaxed backup ID check, which is that if an archive object and info.json file is created but the SM is not actually initialized (i.e. no state.dat file is created), then we were incorrectly checking the backup ID on the newly-created archive on restart and preventing the SM from starting.
- Add test coverage for snapshot restore.