### PR TITLE
Pin haproxy-ingress to last known working version

### DIFF
--- a/test/testlib/haproxy_utilities.go
+++ b/test/testlib/haproxy_utilities.go
@@ -21,6 +21,7 @@ func StartHAProxyIngress(t *testing.T, options *helm.Options, namespaceName stri
 
 	defaultOptions := helm.Options{
 		SetValues: map[string]string{
+			"controller.image.tag":                 "1.10.11",
 			"controller.replicaCount":              "1",
 			"controller.service.type":              "NodePort",
 			"controller.ingressClass":              helmChartReleaseName,


### PR DESCRIPTION
TestKubernetesIngress started failing when haproxy-ingress 1.11.0 was released. This change pins the version to 1.10.11, which is version when the tests were previously passing.