### PR TITLE
Require root user for fsfreeze

### DIFF
--- a/stable/database/templates/_helpers.tpl
+++ b/stable/database/templates/_helpers.tpl
@@ -172,15 +172,35 @@ Get security context runAsUser and runAsGroup
 {{- if eq (include "defaultfalse" .Values.database.securityContext.enabled) "true" }}
 runAsUser: {{ default 1000 .Values.database.securityContext.runAsUser }}
 runAsGroup: 0
-  {{- if and (or (eq (include "defaulttrue" .Values.database.initContainers.runInitDisk) "false") (eq (include "defaulttrue" .Values.database.initContainers.runInitDiskAsRoot) "false")) (ne (toString (default 1000 .Values.database.securityContext.runAsUser)) "0") }}
-runAsNonRoot: true
-  {{- end }}
+{{- if ne (toString (default 1000 .Values.database.securityContext.runAsUser)) "0" }}
+{{- include "sc.runAsNonRoot" . }}
+{{- end }}
 {{- else if eq (include "defaultfalse" .Values.database.securityContext.runAsNonRootGroup) "true" }}
 runAsUser: 1000
 runAsGroup: 1000
-  {{- if or (eq (include "defaulttrue" .Values.database.initContainers.runInitDisk) "false") (eq (include "defaulttrue" .Values.database.initContainers.runInitDiskAsRoot) "false") }}
+{{- include "sc.runAsNonRoot" . }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Get security context runAsNonRoot
+*/}}
+{{- define "sc.runAsNonRoot" -}}
+{{- $runAsNonRoot := true -}}
+{{- if and
+       (eq (include "defaulttrue" .Values.database.initContainers.runInitDisk) "true")
+       (eq (include "defaulttrue" .Values.database.initContainers.runInitDiskAsRoot) "true") }}
+  {{- $runAsNonRoot = false -}}
+{{- else if .Values.database.backupHooks -}}
+  {{- if and
+         (eq (include "defaultfalse" .Values.database.backupHooks.enabled) "true")
+         (eq (include "defaultfalse" .Values.database.backupHooks.useSuspend) "false")
+         (eq (include "defaultfalse" .Values.database.sm.noHotCopy.journalPath.enabled) "true") -}}
+    {{- $runAsNonRoot = false -}}
+  {{- end -}}
+{{- end -}}
+{{- if $runAsNonRoot }}
 runAsNonRoot: true
-  {{- end }}
 {{- end }}
 {{- end -}}
 

--- a/stable/database/templates/statefulset.yaml
+++ b/stable/database/templates/statefulset.yaml
@@ -285,6 +285,8 @@ spec:
             (not (eq (include "defaultfalse" .Values.database.backupHooks.useSuspend) "true")) }}
         securityContext:
           privileged: true
+          runAsUser: 0
+          runAsGroup: 0
         {{- else }}
         {{- include "sc.containerSecurityContext" . | indent 8 }}
         {{- end }}


### PR DESCRIPTION
This change sets `runAsUser=0` and `runAsGroup=0` on the backup-hooks sidecar container and suppresses `runAsNonRoot=true` on the pod security context if fsfreeze is required.