### PR TITLE
Tighten semver parsing for nuosql version

### DIFF
--- a/test/minikube/minikube_external_access_test.go
+++ b/test/minikube/minikube_external_access_test.go
@@ -73,10 +73,9 @@ func getNuoSQLVersion(t *testing.T) *semver.Version {
 	} else {
 		require.NoError(t, err)
 	}
-	match := regexp.MustCompile("NuoDB Client build (.*)").FindStringSubmatch(string(out))
+	match := regexp.MustCompile("NuoDB Client build ([0-9]+[.][0-9]+[.][0-9]+)").FindStringSubmatch(string(out))
 	require.NotNil(t, match, out)
-	// strip comment from semantic version
-	versionStr := strings.Split(match[1], "-")[0]
+	versionStr := match[1]
 	version, err := semver.NewVersion(versionStr)
 	require.NoError(t, err)
 	return version

--- a/test/minikube/minikube_external_access_test.go
+++ b/test/minikube/minikube_external_access_test.go
@@ -73,11 +73,11 @@ func getNuoSQLVersion(t *testing.T) *semver.Version {
 	} else {
 		require.NoError(t, err)
 	}
-	match := regexp.MustCompile("NuoDB Client build ([0-9]+[.][0-9]+[.][0-9]+)").FindStringSubmatch(string(out))
+	match := regexp.MustCompile("NuoDB Client build ([0-9]+[.][0-9]+[.][0-9]+)(|[.-].*)").FindStringSubmatch(string(out))
 	require.NotNil(t, match, out)
 	versionStr := match[1]
 	version, err := semver.NewVersion(versionStr)
-	require.NoError(t, err)
+	require.NoError(t, err, version)
 	return version
 }
 


### PR DESCRIPTION
This change tightens the parsing of the nuosql version to account for any non-numerical suffix that is not delimited by a dash (`-`). For example, development versions on release branches have the form `<major>.<minor>.<patch>.<comment>-<build num>-<SHA>-<arch>`. The `<comment>` part of the version was not being stripped away and screwed up the semver parsing.