### PR TITLE
Enable and test NuoDocker topology discovery

### DIFF
--- a/stable/admin/README.md
+++ b/stable/admin/README.md
@@ -108,6 +108,7 @@ The following tables list the configurable parameters for the `nuodb` option:
 | `serviceAccount` | The name of the service account used by NuoDB Pods | `nuodb` |
 | `addServiceAccount` | Whether to create a new service account for NuoDB containers | `true` |
 | `addRoleBinding` | Whether to add role and role-binding giving `serviceAccount` access to Kubernetes APIs (Pods, PersistentVolumes, PersistentVolumeClaims, StatefulSets) | `true` |
+| `addClusterRoleBinding` | If `addRoleBinding` is enabled, add addition cluster wide role and role-binding giving `serviceAccount` access to Cluster wide Kubernetes APIs (read access to Nodes) | `true` |
 
 The `registry` option can be used to connect to private image repositories, such as Artifactory.
 

--- a/stable/admin/README.md
+++ b/stable/admin/README.md
@@ -108,7 +108,7 @@ The following tables list the configurable parameters for the `nuodb` option:
 | `serviceAccount` | The name of the service account used by NuoDB Pods | `nuodb` |
 | `addServiceAccount` | Whether to create a new service account for NuoDB containers | `true` |
 | `addRoleBinding` | Whether to add role and role-binding giving `serviceAccount` access to Kubernetes APIs (Pods, PersistentVolumes, PersistentVolumeClaims, StatefulSets) | `true` |
-| `addClusterRoleBinding` | If `addRoleBinding` is enabled, add addition cluster wide role and role-binding giving `serviceAccount` access to Cluster wide Kubernetes APIs (read access to Nodes) | `true` |
+| `addClusterRoleBinding` | If `addRoleBinding` is enabled, add addition cluster role and cluster role-binding giving `serviceAccount` access to Cluster wide Kubernetes APIs (read access to Nodes) | `true` |
 
 The `registry` option can be used to connect to private image repositories, such as Artifactory.
 

--- a/stable/admin/README.md
+++ b/stable/admin/README.md
@@ -108,7 +108,7 @@ The following tables list the configurable parameters for the `nuodb` option:
 | `serviceAccount` | The name of the service account used by NuoDB Pods | `nuodb` |
 | `addServiceAccount` | Whether to create a new service account for NuoDB containers | `true` |
 | `addRoleBinding` | Whether to add role and role-binding giving `serviceAccount` access to Kubernetes APIs (Pods, PersistentVolumes, PersistentVolumeClaims, StatefulSets) | `true` |
-| `addClusterRoleBinding` | If `addRoleBinding` is enabled, add addition cluster role and cluster role-binding giving `serviceAccount` access to Cluster wide Kubernetes APIs (read access to Nodes) | `true` |
+| `addClusterRoleBinding` | If `addRoleBinding` is enabled, also add cluster role and cluster role-binding giving `serviceAccount` access to Cluster wide Kubernetes APIs (read access to Nodes) | `true` |
 
 The `registry` option can be used to connect to private image repositories, such as Artifactory.
 

--- a/stable/admin/templates/role.yaml
+++ b/stable/admin/templates/role.yaml
@@ -33,4 +33,18 @@ rules:
   - get
   - create
   - update
+{{- if eq (include "defaulttrue" .Values.nuodb.addClusterRoleBinding) "true" }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: nuodb-kube-inspector
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+{{- end }}
 {{- end }}

--- a/stable/admin/templates/rolebinding.yaml
+++ b/stable/admin/templates/rolebinding.yaml
@@ -10,4 +10,19 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ default "nuodb" .Values.nuodb.serviceAccount }}
+{{- if eq (include "defaulttrue" .Values.nuodb.addClusterRoleBinding) "true" }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: nuodb-kube-inspector
+roleRef:
+  kind: ClusterRole
+  name: nuodb-kube-inspector
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: {{ default "nuodb" .Values.nuodb.serviceAccount }}
+  namespace: {{ default .Release.Namespace .Values.admin.namespace }}
+{{- end }}
 {{- end }}

--- a/test/integration/template_admin_test.go
+++ b/test/integration/template_admin_test.go
@@ -1554,3 +1554,43 @@ func TestAdminLicenseFromSecret(t *testing.T) {
 		assert.Contains(t, obj.Spec.Template.Spec.Containers[0].Args, "licenseFilePath=/etc/nuodb/license/nuodb.lic")
 	}
 }
+
+func TestClusterRole(t *testing.T) {
+	// Path to the helm chart we will test
+	helmChartPath := testlib.ADMIN_HELM_CHART_PATH
+
+	t.Run("testEnabled", func(t *testing.T) {
+		output := helm.RenderTemplate(t, &helm.Options{}, helmChartPath,
+			"release-name", []string{"templates/role.yaml", "templates/rolebinding.yaml"})
+
+		// Verify that nuodb-kube-inspector ClusterRole is created
+		for _, obj := range testlib.SplitAndRenderClusterRole(t, output, 1) {
+			assert.Equal(t, "nuodb-kube-inspector", obj.Name)
+		}
+
+		// Verify that nuodb-kube-inspector ClusterRoleBinding is created
+		for _, obj := range testlib.SplitAndRenderClusterClusterRoleBinding(t, output, 1) {
+			assert.Equal(t, "nuodb-kube-inspector", obj.Name)
+			// Verify that it is binding to the correct role
+			assert.Equal(t, "ClusterRole", obj.RoleRef.Kind)
+			assert.Equal(t, "nuodb-kube-inspector", obj.RoleRef.Name)
+			// Verify that it is binding to the correct user
+			subjects := obj.Subjects
+			assert.Equal(t, 1, len(subjects))
+			assert.Equal(t, "ServiceAccount", subjects[0].Kind)
+			assert.Equal(t, "nuodb", subjects[0].Name)
+		}
+	})
+
+	t.Run("testDisabled", func(t *testing.T) {
+		output := helm.RenderTemplate(t, &helm.Options{SetValues: map[string]string{
+			"nuodb.addClusterRoleBinding": "false",
+		}}, helmChartPath, "release-name", []string{"templates/role.yaml", "templates/rolebinding.yaml"})
+
+		// Verify that a ClusterRole is not created
+		assert.Empty(t, testlib.SplitAndRenderClusterRole(t, output, 0))
+
+		// Verify that a ClusterRoleBinding is not created
+		assert.Empty(t, testlib.SplitAndRenderClusterClusterRoleBinding(t, output, 0))
+	})
+}

--- a/test/integration/template_admin_test.go
+++ b/test/integration/template_admin_test.go
@@ -1566,6 +1566,21 @@ func TestClusterRole(t *testing.T) {
 		// Verify that nuodb-kube-inspector ClusterRole is created
 		for _, obj := range testlib.SplitAndRenderClusterRole(t, output, 1) {
 			assert.Equal(t, "nuodb-kube-inspector", obj.Name)
+
+			for _, rule := range obj.Rules {
+				isNode := false
+				for _, resource := range rule.Resources {
+					if resource == "nodes" {
+						isNode = true
+						break
+					}
+				}
+				if !isNode {
+					continue
+				}
+
+				assert.Contains(t, rule.Verbs, "get")
+			}
 		}
 
 		// Verify that nuodb-kube-inspector ClusterRoleBinding is created

--- a/test/minikube/minikube_kaa_additions_test.go
+++ b/test/minikube/minikube_kaa_additions_test.go
@@ -140,9 +140,12 @@ func TestKubernetesTopologyDiscover(t *testing.T) {
 	admin := fmt.Sprintf("%s-nuodb-cluster0", helmChartReleaseName)
 	admin0 := fmt.Sprintf("%s-0", admin)
 
-	testlib.VerifyLables(t, namespaceName, admin0, "hostname", currentNodes)
-	testlib.VerifyLables(t, namespaceName, admin0, "zone", currentZones)
-	testlib.VerifyLables(t, namespaceName, admin0, "region", currentRegions)
+	testlib.VerifyLabels(t, namespaceName, admin0,
+		map[string][]string{
+			"node":   currentNodes,
+			"zone":   currentZones,
+			"region": currentRegions,
+		})
 
 	dbName := "db"
 	options.SetValues = map[string]string{
@@ -162,10 +165,10 @@ func TestKubernetesTopologyDiscover(t *testing.T) {
 	processes, err := testlib.GetDatabaseProcessesE(t, namespaceName, admin0, dbName)
 	require.NoError(t, err)
 	for _, process := range processes {
-		require.Contains(t, currentNodes, process.Labels["hostname"])
+		require.Contains(t, currentNodes, process.Labels["node"])
 		require.Contains(t, currentZones, process.Labels["zone"])
 		require.Contains(t, currentRegions, process.Labels["region"])
 		require.Equal(t, 1, testlib.GetStringOccurrenceInLog(t, namespaceName, process.Hostname,
-			"Looking for admin with labels matching: hostname, zone, region", &v12.PodLogOptions{}))
+			"Looking for admin with labels matching: node, zone, region", &v12.PodLogOptions{}))
 	}
 }

--- a/test/minikube/minikube_kaa_additions_test.go
+++ b/test/minikube/minikube_kaa_additions_test.go
@@ -1,3 +1,4 @@
+//go:build short
 // +build short
 
 package minikube
@@ -18,6 +19,7 @@ import (
 	"github.com/ghodss/yaml"
 
 	"github.com/gruntwork-io/terratest/modules/helm"
+	"github.com/gruntwork-io/terratest/modules/k8s"
 	rbacv1 "k8s.io/api/rbac/v1"
 )
 
@@ -118,4 +120,52 @@ func TestKaaRolebindingDisabled(t *testing.T) {
 	require.True(t, len(config.StatefulSets) == 0)
 	require.True(t, len(config.Volumes) == 0)
 	require.True(t, len(config.Pods) == 0)
+}
+
+func TestKubernetesTopologyDiscover(t *testing.T) {
+	testlib.SkipTestOnNuoDBVersionCondition(t, "< 6.0.3")
+	testlib.AwaitTillerUp(t)
+	defer testlib.VerifyTeardown(t)
+
+	currentRegions := testlib.LabelNodesIfMissing(t, "topology.kubernetes.io/region", "test-region")
+	currentZones := testlib.LabelNodesIfMissing(t, "topology.kubernetes.io/zone", "test-zone")
+	currentNodes := testlib.GetNodeNames(t)
+
+	defer testlib.Teardown(testlib.TEARDOWN_ADMIN)
+
+	options := helm.Options{}
+	helmChartReleaseName, namespaceName := testlib.StartAdmin(t, &options, 1, "")
+	kubectlOptions := k8s.NewKubectlOptions("", "", namespaceName)
+	options.KubectlOptions = kubectlOptions
+	admin := fmt.Sprintf("%s-nuodb-cluster0", helmChartReleaseName)
+	admin0 := fmt.Sprintf("%s-0", admin)
+
+	testlib.VerifyLables(t, namespaceName, admin0, "hostname", currentNodes)
+	testlib.VerifyLables(t, namespaceName, admin0, "zone", currentZones)
+	testlib.VerifyLables(t, namespaceName, admin0, "region", currentRegions)
+
+	dbName := "db"
+	options.SetValues = map[string]string{
+		"database.sm.resources.requests.cpu":    testlib.MINIMAL_VIABLE_ENGINE_CPU,
+		"database.sm.resources.requests.memory": testlib.MINIMAL_VIABLE_ENGINE_MEMORY,
+		"database.te.resources.requests.cpu":    testlib.MINIMAL_VIABLE_ENGINE_CPU,
+		"database.te.resources.requests.memory": testlib.MINIMAL_VIABLE_ENGINE_MEMORY,
+		"database.sm.noHotCopy.replicas":        "1",
+		"database.sm.hotCopy.replicas":          "0",
+		"database.name":                         dbName,
+	}
+
+	defer testlib.Teardown(testlib.TEARDOWN_DATABASE)
+
+	testlib.StartDatabase(t, namespaceName, admin0, &options)
+
+	processes, err := testlib.GetDatabaseProcessesE(t, namespaceName, admin0, dbName)
+	require.NoError(t, err)
+	for _, process := range processes {
+		require.Contains(t, currentNodes, process.Labels["hostname"])
+		require.Contains(t, currentZones, process.Labels["zone"])
+		require.Contains(t, currentRegions, process.Labels["region"])
+		require.Equal(t, 1, testlib.GetStringOccurrenceInLog(t, namespaceName, process.Hostname,
+			"Looking for admin with labels matching: hostname, zone, region", &v12.PodLogOptions{}))
+	}
 }

--- a/test/minikube/minikube_kaa_additions_test.go
+++ b/test/minikube/minikube_kaa_additions_test.go
@@ -172,6 +172,6 @@ func TestKubernetesTopologyDiscover(t *testing.T) {
 		require.Equal(t, currentZones[node], process.Labels["zone"])
 		require.Equal(t, currentRegions[node], process.Labels["region"])
 		require.Equal(t, 1, testlib.GetStringOccurrenceInLog(t, namespaceName, process.Hostname,
-			"Looking for admin with labels matching: node, zone, region", &v12.PodLogOptions{}))
+			"Looking for admin with labels matching: node zone region", &v12.PodLogOptions{}))
 	}
 }

--- a/test/testlib/NuoDBServer.go
+++ b/test/testlib/NuoDBServer.go
@@ -36,6 +36,7 @@ type NuoDBServer struct {
 	PeerMemberState string              `json:"peerMemberState"`
 	PeerState       string              `json:"peerState"`
 	Version         string              `json:"version"`
+	Labels          map[string]string   `json:"labels"`
 }
 
 func UnmarshalDomainServers(s string) (err error, servers map[string]NuoDBServer) {

--- a/test/testlib/nuodb_admin_utilities.go
+++ b/test/testlib/nuodb_admin_utilities.go
@@ -304,14 +304,14 @@ func AwaitServerState(t *testing.T, namespace string, adminPod string,
 	}, timeout)
 }
 
-// VerifyLabels checks if adminPod in namespace has all the label values in expectedLabelValues
-func VerifyLabels(t *testing.T, namespace string, adminPod string, expectedLabelValues map[string][]string) {
+// VerifyAdminLabels checks if adminPod in namespace has all the label values in expectedLabelValues
+func VerifyAdminLabels(t *testing.T, namespace string, adminPod string, expectedLabelValues map[string]string) {
 	admins, err := GetDomainServersE(t, namespace, adminPod)
 	require.NoError(t, err)
 	require.Contains(t, admins, adminPod)
 
 	labels := admins[adminPod].Labels
-	for label, expectedValues := range expectedLabelValues {
-		require.Contains(t, expectedValues, labels[label])
+	for label, expectedValue := range expectedLabelValues {
+		require.Equal(t, expectedValue, labels[label])
 	}
 }

--- a/test/testlib/template_utilities.go
+++ b/test/testlib/template_utilities.go
@@ -203,6 +203,14 @@ func SplitAndRenderRole(t *testing.T, output string, expectedNrObjects int) []rb
 	return SplitAndRender[rbacv1.Role](t, output, expectedNrObjects, "Role")
 }
 
+func SplitAndRenderClusterRole(t *testing.T, output string, expectedNrObjects int) []rbacv1.ClusterRole {
+	return SplitAndRender[rbacv1.ClusterRole](t, output, expectedNrObjects, "ClusterRole")
+}
+
+func SplitAndRenderClusterClusterRoleBinding(t *testing.T, output string, expectedNrObjects int) []rbacv1.ClusterRoleBinding {
+	return SplitAndRender[rbacv1.ClusterRoleBinding](t, output, expectedNrObjects, "ClusterRoleBinding")
+}
+
 func SplitAndRenderServiceAccount(t *testing.T, output string, expectedNrObjects int) []v1.ServiceAccount {
 	return SplitAndRender[v1.ServiceAccount](t, output, expectedNrObjects, "ServiceAccount")
 }


### PR DESCRIPTION
I am adding new logic to NuoDocker to add admin labels, process labels, and admin affinity based on topology labels on the kubernetes node. This functionality requires new permissions for the Service Account (gated behind `nuodb.addClusterRoleBinding` chart value). Also, this functionality cannot be easily tested in existing NuoDocker test suite, so add an integration test to this repo.