### PR TITLE
Chart values to set admin labels and admin affinity labels

### DIFF
--- a/stable/admin/README.md
+++ b/stable/admin/README.md
@@ -230,6 +230,7 @@ The following tables list the configurable parameters for the `admin` option of 
 | `tde.storagePasswordsDir` | Transparent Data Encryption storage passwords mount path | `/etc/nuodb/tde` |
 | `evicted.servers` | A list of evicted servers excluded from RAFT consensus. Used during disaster recovery. | `[]` |
 | `resourceLabels` | Custom labels attached to the Kubernetes resources installed by this Helm chart. The labels are immutable and can't be changed with Helm upgrade | `{}` |
+| `labels` | Admin labels to apply to each Admin Process. Supported starting from NuoDB image version 6.0.3 | `{}`|
 
 For example, when using GlusterFS storage class, you would supply the following parameter:
 

--- a/stable/admin/README.md
+++ b/stable/admin/README.md
@@ -230,7 +230,7 @@ The following tables list the configurable parameters for the `admin` option of 
 | `tde.storagePasswordsDir` | Transparent Data Encryption storage passwords mount path | `/etc/nuodb/tde` |
 | `evicted.servers` | A list of evicted servers excluded from RAFT consensus. Used during disaster recovery. | `[]` |
 | `resourceLabels` | Custom labels attached to the Kubernetes resources installed by this Helm chart. The labels are immutable and can't be changed with Helm upgrade | `{}` |
-| `labels` | Admin labels to apply to each Admin Process. Supported starting from NuoDB image version 6.0.3 | `{}`|
+| `adminLabels` | Admin labels to apply to each Admin Process. Supported starting from NuoDB image version 6.0.3 | `{}`|
 
 For example, when using GlusterFS storage class, you would supply the following parameter:
 

--- a/stable/admin/templates/statefulset.yaml
+++ b/stable/admin/templates/statefulset.yaml
@@ -171,7 +171,7 @@ spec:
           {{- range $opt, $val := .Values.admin.options}}
           - "{{$opt}}={{$val}}" 
           {{- end }}
-          {{- range $label, $val := .Values.admin.labels}}
+          {{- range $label, $val := .Values.admin.adminLabels}}
           - "adminLabels.labels/{{$label}}={{$val}}"
           {{- end }}
         {{- include "sc.containerSecurityContext" . | indent 8 }}

--- a/stable/admin/templates/statefulset.yaml
+++ b/stable/admin/templates/statefulset.yaml
@@ -171,6 +171,9 @@ spec:
           {{- range $opt, $val := .Values.admin.options}}
           - "{{$opt}}={{$val}}" 
           {{- end }}
+          {{- range $label, $val := .Values.admin.labels}}
+          - "adminLabels.labels/{{$label}}={{$val}}"
+          {{- end }}
         {{- include "sc.containerSecurityContext" . | indent 8 }}
         {{- if eq (include "defaulttrue" .Values.admin.livenessProbe.enabled) "true" }}
         livenessProbe:

--- a/stable/database/README.md
+++ b/stable/database/README.md
@@ -150,6 +150,7 @@ The following tables list the configurable admin parameters for a database and t
 | `tlsClientPEM.key` | TLS client PEM secret key | `nil` |
 | `tde.secrets` | Transparent Data Encryption secret names used for different databases | `{}` |
 | `tde.storagePasswordsDir` | Transparent Data Encryption storage passwords mount path | `/etc/nuodb/tde` |
+| `affinityLabels` | List of AP label keys to check for affinity with the engine process, ordered by precedence; the AP with the earliest label key, whose value matches the corresponding engine label, will be chosen to manage the engine process. For example, specifying "zone region" means "find an AP in the same 'zone' and, if there are none, select one in the same 'region'". Supported starting from NuoDB image version 6.0.3 | `"node zone region"` |
 
 #### admin.configFiles.*
 

--- a/stable/database/templates/deployment.yaml
+++ b/stable/database/templates/deployment.yaml
@@ -97,6 +97,10 @@ spec:
           - "300"
           - "--servers-ready-timeout"
           - "300"
+          {{- if .Values.admin.affinityLabels}}
+          - "--admin-affinity-label-keys"
+          - "{{ .Values.admin.affinityLabels }}"
+          {{- end }}
           - "--options"
           - "mem {{ .Values.database.te.resources.requests.memory}} {{- range $opt, $val := .Values.database.te.engineOptions }} {{$opt}} {{$val}} {{- end}}"
           {{- include "database.teLabels" . | indent 10 }}

--- a/stable/database/templates/statefulset.yaml
+++ b/stable/database/templates/statefulset.yaml
@@ -109,6 +109,10 @@ spec:
     {{- if .Values.database.isRestore }}
           - "--restored"
     {{- end }}
+          {{- if .Values.admin.affinityLabels}}
+          - "--admin-affinity-label-keys"
+          - "{{ .Values.admin.affinityLabels }}"
+          {{- end }}
           - "--options"
           - "mem {{ .Values.database.sm.resources.requests.memory}} {{ include "opt.key-values" .Values.database.sm.engineOptions }}"
     {{- $labels := printf "%s %s" (include "database.storageGroup.label" .) (include "opt.key-values" .Values.database.sm.labels) -}}
@@ -513,6 +517,10 @@ spec:
           - "nuosm"
           - "--servers-ready-timeout"
           - "300"
+          {{- if .Values.admin.affinityLabels}}
+          - "--admin-affinity-label-keys"
+          - "{{ .Values.admin.affinityLabels }}"
+          {{- end }}
           - "--options"
           - "mem {{ .Values.database.sm.resources.requests.memory}} {{- if and (eq (include "defaulttrue" .Values.database.sm.hotCopy.enableBackups) "true") (eq (include "defaultfalse" .Values.database.sm.hotCopy.journalBackup.enabled) "true") }} journal-hot-copy enable {{- end }} {{- include "opt.key-values" .Values.database.sm.engineOptions}}"
           - "--labels"

--- a/test/integration/template_admin_test.go
+++ b/test/integration/template_admin_test.go
@@ -1616,8 +1616,8 @@ func TestAdminStatefulSetAdminLabels(t *testing.T) {
 
 	options := &helm.Options{
 		SetValues: map[string]string{
-			"admin.labels.host": "host1",
-			"admin.labels.zone": "us-east-1",
+			"admin.adminLabels.host": "host1",
+			"admin.adminLabels.zone": "us-east-1",
 		},
 	}
 

--- a/test/minikube/minikube_long_admin_test.go
+++ b/test/minikube/minikube_long_admin_test.go
@@ -62,6 +62,10 @@ func TestKubernetesBasicAdminThreeReplicas(t *testing.T) {
 
 func TestDatabaseAdminAffinityLabels(t *testing.T) {
 	testlib.SkipTestOnNuoDBVersionCondition(t, "< 6.0.3")
+	if os.Getenv("NUODB_LICENSE") != "ENTERPRISE" && os.Getenv("NUODB_LICENSE_CONTENT") == "" {
+		t.Skip("Cannot test multiple SMs without the Enterprise Edition")
+	}
+
 	testlib.AwaitTillerUp(t)
 	defer testlib.VerifyTeardown(t)
 
@@ -77,6 +81,8 @@ func TestDatabaseAdminAffinityLabels(t *testing.T) {
 	options.KubectlOptions = kubectlOptions
 	admin := fmt.Sprintf("%s-nuodb-cluster0", helmChartReleaseName)
 	admin0 := fmt.Sprintf("%s-0", admin)
+
+	testlib.ApplyLicense(t, namespaceName, admin0, testlib.ENTERPRISE)
 
 	testlib.VerifyAdminLabels(t, namespaceName, admin0,
 		map[string]string{

--- a/test/minikube/minikube_long_admin_test.go
+++ b/test/minikube/minikube_long_admin_test.go
@@ -117,9 +117,9 @@ func TestDatabaseAdminAffinityLabels(t *testing.T) {
 		require.Equal(t, 1, testlib.GetStringOccurrenceInLog(t, namespaceName, process.Hostname,
 			"Looking for admin with labels matching: host zone", &v12.PodLogOptions{}))
 
-		expectedAffinityLog := fmt.Sprintf("Selecting among admins ['%s'] with matching label zone=us-east-1", admin0)
+		expectedAffinityLog := fmt.Sprintf("Preferring APs %s due to matching label zone=us-east-1", admin0)
 		require.Equal(t, 1, testlib.GetStringOccurrenceInLog(t, namespaceName, process.Hostname,
-			expectedAffinityLog, &v12.PodLogOptions{}))
+			expectedAffinityLog, &v12.PodLogOptions{}), "Did not find expected log message %s", expectedAffinityLog)
 
 	}
 }

--- a/test/minikube/minikube_long_admin_test.go
+++ b/test/minikube/minikube_long_admin_test.go
@@ -117,7 +117,7 @@ func TestDatabaseAdminAffinityLabels(t *testing.T) {
 		require.Equal(t, 1, testlib.GetStringOccurrenceInLog(t, namespaceName, process.Hostname,
 			"Looking for admin with labels matching: host zone", &v12.PodLogOptions{}))
 
-		expectedAffinityLog := fmt.Sprintf("Marking admin %s as an affinity server (matching zone=us-east-1)", admin0)
+		expectedAffinityLog := fmt.Sprintf("Selecting among admins ['%s'] with matching label zone=us-east-1", admin0)
 		require.Equal(t, 1, testlib.GetStringOccurrenceInLog(t, namespaceName, process.Hostname,
 			expectedAffinityLog, &v12.PodLogOptions{}))
 

--- a/test/testlib/minikube_utilities.go
+++ b/test/testlib/minikube_utilities.go
@@ -1328,18 +1328,6 @@ func GetNodesInternalAddresses(t *testing.T) map[string]string {
 	return addresses
 }
 
-// GetNodeNames fetches the names of all nodes in the kubernetes cluster.
-func GetNodeNames(t *testing.T) []string {
-	var addresses []string
-	options := k8s.NewKubectlOptions("", "", "")
-	nodes := k8s.GetNodes(t, options)
-	require.True(t, len(nodes) > 0)
-	for _, node := range nodes {
-		addresses = append(addresses, node.Name)
-	}
-	return addresses
-}
-
 func GetNamespaces(t *testing.T) []corev1.Namespace {
 	clientset, err := k8s.GetKubernetesClientE(t)
 	require.NoError(t, err)


### PR DESCRIPTION
- Add a chart value for setting Admin Lables
- Add a chart value for setting `admin-affinity-label-keys` for database processes