### PR TITLE
Remove 4.1.x backwards compatibility test

### DIFF
--- a/test/minikube/minikube_rolling_upgrade_test.go
+++ b/test/minikube/minikube_rolling_upgrade_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/gruntwork-io/terratest/modules/helm"
 	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/gruntwork-io/terratest/modules/random"
-	"github.com/gruntwork-io/terratest/modules/shell"
 	"github.com/stretchr/testify/require"
 
 	v12 "k8s.io/api/core/v1"

--- a/test/testlib/tls.go
+++ b/test/testlib/tls.go
@@ -32,11 +32,7 @@ spec:
 `
 
 func createTLSGeneratorPod(t *testing.T, namespaceName string, timeout time.Duration) string {
-	// 4.2.2 has Java 11.0.12, which uses default algorithms for signatures
-	// and encryption of private keys that are not available in Java 8, used
-	// by NuoDB up to 4.0.7; to avoid breaking rolling upgrade tests, fix
-	// version at 4.2.1
-	image := "docker.io/nuodb/nuodb-ce:4.2.1"
+	image := "docker.io/nuodb/nuodb-ce:5.0"
 
 	podName := "tls-generator-" + strings.ToLower(random.UniqueId())
 	podTemplateString := fmt.Sprintf(TLS_GENERATOR_POD_TEMPLATE,


### PR DESCRIPTION
This change removes a test that was exercising backwards compatibility with versions of `nuocmd` that do not have `nuocmd check server` (singular), which are no longer relevant now that 4.x versions have been removed from docker.io/nuodb/nuodb-ce.