### PR TITLE
Generate unique names for ClusterRoles and CRBindings

### DIFF
--- a/stable/admin/templates/_helpers.tpl
+++ b/stable/admin/templates/_helpers.tpl
@@ -526,3 +526,16 @@ trusted-certificate" command which doesn't require AP restart.
 checksum/tls-passwords: {{ sha256sum $passwords }}
 {{- end }}
 {{- end -}}
+
+{{/*
+Create a cluster unique app name.
+*/}}
+{{- define "admin.fullclustername" -}}
+{{- $name := include "admin.fullname" . -}}
+{{- $ns := default .Release.Namespace .Values.admin.namespace | trunc 50 | trimSuffix "-" -}}
+{{- if contains $name $ns -}}
+  {{- printf "%s" $name -}}
+{{- else -}}
+  {{- printf "%s-%s" $name $ns -}}
+{{- end -}}
+{{- end -}}

--- a/stable/admin/templates/role.yaml
+++ b/stable/admin/templates/role.yaml
@@ -33,7 +33,8 @@ rules:
   - get
   - create
   - update
-{{- if eq (include "defaulttrue" .Values.nuodb.addClusterRoleBinding) "true" }}
+{{- if and (eq (include "defaulttrue" .Values.nuodb.addClusterRoleBinding) "true")
+      (not (lookup "rbac.authorization.k8s.io/v1" "ClusterRole" "" "nuodb-kube-inspector")) }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/stable/admin/templates/role.yaml
+++ b/stable/admin/templates/role.yaml
@@ -40,7 +40,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ $namespace }}-{{ $adminName }}-nuodb-kube-inspector
+  name: {{ include "admin.fullclustername" . }}-kube-inspector
 rules:
 - apiGroups:
   - ""

--- a/stable/admin/templates/role.yaml
+++ b/stable/admin/templates/role.yaml
@@ -34,13 +34,13 @@ rules:
   - create
   - update
 {{- if eq (include "defaulttrue" .Values.nuodb.addClusterRoleBinding) "true" }}
-{{- $namespace := default .Release.Namespace .Values.admin.namespace -}}
-{{- $release := .Release.Name }}
+{{- $namespace := default .Release.Namespace .Values.admin.namespace  | trunc 50 | trimSuffix "-" -}}
+{{- $adminName := include "admin.fullname" . }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ $namespace }}-{{ $release }}-nuodb-kube-inspector
+  name: {{ $namespace }}-{{ $adminName }}-nuodb-kube-inspector
 rules:
 - apiGroups:
   - ""

--- a/stable/admin/templates/role.yaml
+++ b/stable/admin/templates/role.yaml
@@ -33,13 +33,14 @@ rules:
   - get
   - create
   - update
-{{- if and (eq (include "defaulttrue" .Values.nuodb.addClusterRoleBinding) "true")
-      (not (lookup "rbac.authorization.k8s.io/v1" "ClusterRole" "" "nuodb-kube-inspector")) }}
+{{- if eq (include "defaulttrue" .Values.nuodb.addClusterRoleBinding) "true" }}
+{{- $namespace := default .Release.Namespace .Values.admin.namespace -}}
+{{- $release := .Release.Name }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: nuodb-kube-inspector
+  name: nuodb-kube-inspector-{{ $namespace }}-{{ $release }}
 rules:
 - apiGroups:
   - ""

--- a/stable/admin/templates/role.yaml
+++ b/stable/admin/templates/role.yaml
@@ -40,7 +40,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: nuodb-kube-inspector-{{ $namespace }}-{{ $release }}
+  name: {{ $namespace }}-{{ $release }}-nuodb-kube-inspector
 rules:
 - apiGroups:
   - ""

--- a/stable/admin/templates/rolebinding.yaml
+++ b/stable/admin/templates/rolebinding.yaml
@@ -17,10 +17,10 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: nuodb-kube-inspector-{{ $namespace }}-{{ $release }}
+  name: {{ $namespace }}-{{ $release }}-nuodb-kube-inspector
 roleRef:
   kind: ClusterRole
-  name: nuodb-kube-inspector-{{ $namespace }}-{{ $release }}
+  name: {{ $namespace }}-{{ $release }}-nuodb-kube-inspector
   apiGroup: rbac.authorization.k8s.io
 subjects:
 - kind: ServiceAccount

--- a/stable/admin/templates/rolebinding.yaml
+++ b/stable/admin/templates/rolebinding.yaml
@@ -10,7 +10,8 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ default "nuodb" .Values.nuodb.serviceAccount }}
-{{- if eq (include "defaulttrue" .Values.nuodb.addClusterRoleBinding) "true" }}
+{{- if and (eq (include "defaulttrue" .Values.nuodb.addClusterRoleBinding) "true")
+      (not (lookup "rbac.authorization.k8s.io/v1" "ClusterRoleBinding" "" "nuodb-kube-inspector")) }}}}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/stable/admin/templates/rolebinding.yaml
+++ b/stable/admin/templates/rolebinding.yaml
@@ -10,16 +10,17 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ default "nuodb" .Values.nuodb.serviceAccount }}
-{{- if and (eq (include "defaulttrue" .Values.nuodb.addClusterRoleBinding) "true")
-      (not (lookup "rbac.authorization.k8s.io/v1" "ClusterRoleBinding" "" "nuodb-kube-inspector")) }}}}
+{{- if eq (include "defaulttrue" .Values.nuodb.addClusterRoleBinding) "true" }}
+{{- $namespace := default .Release.Namespace .Values.admin.namespace -}}
+{{- $release := .Release.Name }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: nuodb-kube-inspector
+  name: nuodb-kube-inspector-{{ $namespace }}-{{ $release }}
 roleRef:
   kind: ClusterRole
-  name: nuodb-kube-inspector
+  name: nuodb-kube-inspector-{{ $namespace }}-{{ $release }}
   apiGroup: rbac.authorization.k8s.io
 subjects:
 - kind: ServiceAccount

--- a/stable/admin/templates/rolebinding.yaml
+++ b/stable/admin/templates/rolebinding.yaml
@@ -11,16 +11,16 @@ subjects:
 - kind: ServiceAccount
   name: {{ default "nuodb" .Values.nuodb.serviceAccount }}
 {{- if eq (include "defaulttrue" .Values.nuodb.addClusterRoleBinding) "true" }}
-{{- $namespace := default .Release.Namespace .Values.admin.namespace -}}
-{{- $release := .Release.Name }}
+{{- $namespace := default .Release.Namespace .Values.admin.namespace | trunc 50 | trimSuffix "-" -}}
+{{- $adminName := include "admin.fullname" . }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ $namespace }}-{{ $release }}-nuodb-kube-inspector
+  name: {{ $namespace }}-{{ $adminName }}-nuodb-kube-inspector
 roleRef:
   kind: ClusterRole
-  name: {{ $namespace }}-{{ $release }}-nuodb-kube-inspector
+  name: {{ $namespace }}-{{ $adminName }}-nuodb-kube-inspector
   apiGroup: rbac.authorization.k8s.io
 subjects:
 - kind: ServiceAccount

--- a/stable/admin/templates/rolebinding.yaml
+++ b/stable/admin/templates/rolebinding.yaml
@@ -17,10 +17,10 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ $namespace }}-{{ $adminName }}-nuodb-kube-inspector
+  name: {{ include "admin.fullclustername" . }}-kube-inspector
 roleRef:
   kind: ClusterRole
-  name: {{ $namespace }}-{{ $adminName }}-nuodb-kube-inspector
+  name: {{ include "admin.fullclustername" . }}-kube-inspector
   apiGroup: rbac.authorization.k8s.io
 subjects:
 - kind: ServiceAccount

--- a/test/integration/template_admin_test.go
+++ b/test/integration/template_admin_test.go
@@ -1570,7 +1570,7 @@ func TestClusterRole(t *testing.T) {
 
 		// Verify that nuodb-kube-inspector ClusterRole is created
 		for _, obj := range testlib.SplitAndRenderClusterRole(t, output, 1) {
-			assert.Equal(t, "nuodb-kube-inspector-ns-name-release-name", obj.Name)
+			assert.Equal(t, "ns-name-release-name-nuodb-kube-inspector", obj.Name)
 
 			for _, rule := range obj.Rules {
 				isNode := false
@@ -1590,10 +1590,10 @@ func TestClusterRole(t *testing.T) {
 
 		// Verify that nuodb-kube-inspector ClusterRoleBinding is created
 		for _, obj := range testlib.SplitAndRenderClusterClusterRoleBinding(t, output, 1) {
-			assert.Equal(t, "nuodb-kube-inspector-ns-name-release-name", obj.Name)
+			assert.Equal(t, "ns-name-release-name-nuodb-kube-inspector", obj.Name)
 			// Verify that it is binding to the correct role
 			assert.Equal(t, "ClusterRole", obj.RoleRef.Kind)
-			assert.Equal(t, "nuodb-kube-inspector-ns-name-release-name", obj.RoleRef.Name)
+			assert.Equal(t, "ns-name-release-name-nuodb-kube-inspector", obj.RoleRef.Name)
 			// Verify that it is binding to the correct user
 			subjects := obj.Subjects
 			assert.Equal(t, 1, len(subjects))

--- a/test/integration/template_admin_test.go
+++ b/test/integration/template_admin_test.go
@@ -1561,47 +1561,62 @@ func TestClusterRole(t *testing.T) {
 	helmChartPath := testlib.ADMIN_HELM_CHART_PATH
 
 	t.Run("testEnabled", func(t *testing.T) {
-		output := helm.RenderTemplate(t, &helm.Options{
-			SetValues: map[string]string{
-				"admin.fullnameOverride": "full-name",
+		options := []*helm.Options{
+			{
+				SetValues: map[string]string{
+					"admin.fullnameOverride": "full-name",
+				},
+				KubectlOptions: &k8s.KubectlOptions{
+					Namespace: "ns-name",
+				},
 			},
-			KubectlOptions: &k8s.KubectlOptions{
-				Namespace: "ns-name",
+			// Override namespace name
+			{
+				SetValues: map[string]string{
+					"admin.fullnameOverride": "full-name",
+					"admin.namespace":        "ns-name",
+				},
+				KubectlOptions: &k8s.KubectlOptions{
+					Namespace: "default",
+				},
 			},
-		}, helmChartPath,
-			"release-name", []string{"templates/role.yaml", "templates/rolebinding.yaml"})
-
-		// Verify that nuodb-kube-inspector ClusterRole is created
-		for _, obj := range testlib.SplitAndRenderClusterRole(t, output, 1) {
-			assert.Equal(t, "ns-name-full-name-nuodb-kube-inspector", obj.Name)
-
-			for _, rule := range obj.Rules {
-				isNode := false
-				for _, resource := range rule.Resources {
-					if resource == "nodes" {
-						isNode = true
-						break
-					}
-				}
-				if !isNode {
-					continue
-				}
-
-				assert.Contains(t, rule.Verbs, "get")
-			}
 		}
+		for _, option := range options {
+			output := helm.RenderTemplate(t, option, helmChartPath,
+				"release-name", []string{"templates/role.yaml", "templates/rolebinding.yaml"})
 
-		// Verify that nuodb-kube-inspector ClusterRoleBinding is created
-		for _, obj := range testlib.SplitAndRenderClusterClusterRoleBinding(t, output, 1) {
-			assert.Equal(t, "ns-name-full-name-nuodb-kube-inspector", obj.Name)
-			// Verify that it is binding to the correct role
-			assert.Equal(t, "ClusterRole", obj.RoleRef.Kind)
-			assert.Equal(t, "ns-name-full-name-nuodb-kube-inspector", obj.RoleRef.Name)
-			// Verify that it is binding to the correct user
-			subjects := obj.Subjects
-			assert.Equal(t, 1, len(subjects))
-			assert.Equal(t, "ServiceAccount", subjects[0].Kind)
-			assert.Equal(t, "nuodb", subjects[0].Name)
+			// Verify that nuodb-kube-inspector ClusterRole is created
+			for _, obj := range testlib.SplitAndRenderClusterRole(t, output, 1) {
+				assert.Equal(t, "full-name-ns-name-kube-inspector", obj.Name)
+
+				for _, rule := range obj.Rules {
+					isNode := false
+					for _, resource := range rule.Resources {
+						if resource == "nodes" {
+							isNode = true
+							break
+						}
+					}
+					if !isNode {
+						continue
+					}
+
+					assert.Contains(t, rule.Verbs, "get")
+				}
+			}
+
+			// Verify that nuodb-kube-inspector ClusterRoleBinding is created
+			for _, obj := range testlib.SplitAndRenderClusterClusterRoleBinding(t, output, 1) {
+				assert.Equal(t, "full-name-ns-name-kube-inspector", obj.Name)
+				// Verify that it is binding to the correct role
+				assert.Equal(t, "ClusterRole", obj.RoleRef.Kind)
+				assert.Equal(t, "full-name-ns-name-kube-inspector", obj.RoleRef.Name)
+				// Verify that it is binding to the correct user
+				subjects := obj.Subjects
+				assert.Equal(t, 1, len(subjects))
+				assert.Equal(t, "ServiceAccount", subjects[0].Kind)
+				assert.Equal(t, "nuodb", subjects[0].Name)
+			}
 		}
 	})
 

--- a/test/integration/template_admin_test.go
+++ b/test/integration/template_admin_test.go
@@ -1562,6 +1562,9 @@ func TestClusterRole(t *testing.T) {
 
 	t.Run("testEnabled", func(t *testing.T) {
 		output := helm.RenderTemplate(t, &helm.Options{
+			SetValues: map[string]string{
+				"admin.fullnameOverride": "full-name",
+			},
 			KubectlOptions: &k8s.KubectlOptions{
 				Namespace: "ns-name",
 			},
@@ -1570,7 +1573,7 @@ func TestClusterRole(t *testing.T) {
 
 		// Verify that nuodb-kube-inspector ClusterRole is created
 		for _, obj := range testlib.SplitAndRenderClusterRole(t, output, 1) {
-			assert.Equal(t, "ns-name-release-name-nuodb-kube-inspector", obj.Name)
+			assert.Equal(t, "ns-name-full-name-nuodb-kube-inspector", obj.Name)
 
 			for _, rule := range obj.Rules {
 				isNode := false
@@ -1590,10 +1593,10 @@ func TestClusterRole(t *testing.T) {
 
 		// Verify that nuodb-kube-inspector ClusterRoleBinding is created
 		for _, obj := range testlib.SplitAndRenderClusterClusterRoleBinding(t, output, 1) {
-			assert.Equal(t, "ns-name-release-name-nuodb-kube-inspector", obj.Name)
+			assert.Equal(t, "ns-name-full-name-nuodb-kube-inspector", obj.Name)
 			// Verify that it is binding to the correct role
 			assert.Equal(t, "ClusterRole", obj.RoleRef.Kind)
-			assert.Equal(t, "ns-name-release-name-nuodb-kube-inspector", obj.RoleRef.Name)
+			assert.Equal(t, "ns-name-full-name-nuodb-kube-inspector", obj.RoleRef.Name)
 			// Verify that it is binding to the correct user
 			subjects := obj.Subjects
 			assert.Equal(t, 1, len(subjects))


### PR DESCRIPTION
To avoid conflicts between multiple admin deployments, generate unique names for ClusterRole and ClusterRoleBinding by prepending the namespace and helm release name.