### PR TITLE
Fixed two issues in TestKubernetesUpgradeFullDatabase

### DIFF
--- a/test/minikube/minikube_rolling_upgrade_test.go
+++ b/test/minikube/minikube_rolling_upgrade_test.go
@@ -242,7 +242,17 @@ func TestKubernetesUpgradeFullDatabase(t *testing.T) {
 			// start two TEs so that we can supply TE preference query
 			options.SetValues["database.te.replicas"] = "2"
 			helm.Upgrade(t, &options, testlib.DATABASE_HELM_CHART_PATH, databaseHelmChartReleaseName)
-			testlib.AwaitDatabaseUp(t, namespaceName, admin0, opt.DbName, 3)
+
+			testlib.Await(t, func() bool {
+				// It is possible that the database will (briefly) have 3 processes while the upgrade is in progress
+				// so we need to check that both the database is in the expected state and that there are not
+				// leftover pods.
+				err := k8s.RunKubectlE(t, kubectlOptions, "exec", admin0, "--", "nuocmd", "check", "database",
+					"--db-name", opt.DbName, "--check-running", "--check-liveness", "20",
+					"--num-processes", strconv.Itoa(3))
+				return err == nil && len(testlib.GetPodNames(t, namespaceName, databaseHelmChartReleaseName)) == 3
+			}, 300*time.Second)
+
 			// find the startId of the second TE
 			var toShutdownStartId int64 = -1
 			toShutdownPod := ""


### PR DESCRIPTION
`TestKubernetesUpgradeFullDatabase/verifyProtocolVersion` was failing on NuoDB 5.1, because there is no protocol upgrade between 5.0 and 5.1. Change the test to only run on 6.0 and newer.

While I was investigating the issue, I found a race condition in the test. The the protocol upgrade is scaling up the TE count to 2 and upgrading the database version in a single Helm update. It assumes that if there the database has 2 TEs and is healthy, the upgrade is done, but it can also occur part way through the upgrade if one of the new TEs becomes running before the admin sees the second new TE.