### PR TITLE
Don't test protocol upgrade for NuoDB 5.x

### DIFF
--- a/test/minikube/minikube_rolling_upgrade_test.go
+++ b/test/minikube/minikube_rolling_upgrade_test.go
@@ -233,7 +233,7 @@ func TestKubernetesUpgradeFullDatabase(t *testing.T) {
 		verifyAllProcessesRunning(t, namespaceName, admin0, 2)
 	})
 
-	testlib.RunOnNuoDBVersionCondition(t, ">4.2.2", func(version *semver.Version) {
+	testlib.RunOnNuoDBVersionCondition(t, ">6.0.0", func(version *semver.Version) {
 		// check that KAA will upgrade database protocol version and restart TE
 		// automatically
 		t.Run("verifyProtocolVersion", func(t *testing.T) {

--- a/test/minikube/minikube_rolling_upgrade_test.go
+++ b/test/minikube/minikube_rolling_upgrade_test.go
@@ -233,6 +233,8 @@ func TestKubernetesUpgradeFullDatabase(t *testing.T) {
 		verifyAllProcessesRunning(t, namespaceName, admin0, 2)
 	})
 
+	// In order to have a protocol upgrade, there has to be a protocol change between
+	// OLD_RELEASE and the version under test.
 	testlib.RunOnNuoDBVersionCondition(t, ">6.0.0", func(version *semver.Version) {
 		// check that KAA will upgrade database protocol version and restart TE
 		// automatically


### PR DESCRIPTION
Split from https://github.com/nuodb/nuodb-helm-charts/pull/374

We bumped the before version for upgrade tests to be 5.0, so there is now no protocol upgrade when upgrading to 5.0-dev or 5.1. Bumping the minimum database version for protocol upgrade tests to 6.0.