### PR TITLE
Change readiness probes to accelerate process start-up

### DIFF
--- a/stable/database/README.md
+++ b/stable/database/README.md
@@ -288,7 +288,12 @@ The following tables list the configurable parameters of the `database` chart an
 | `sm.nodeSelector` | Node selector rules for NuoDB SM | `{}` |
 | `sm.tolerations` | Tolerations for NuoDB SM | `[]` |
 | `sm.topologySpreadConstraints` | Topology spread constraints for NuoDB SM | `[]` |
-| `sm.readinessTimeoutSeconds` | SM readiness probe timeout, sometimes needs adjusting depending on environment and pod resources | `5` |
+| `sm.otherOptions` | Additional key/value Docker options | `{}` |
+| `sm.readinessProbe.initialDelaySeconds` | The initial delay in seconds for the readiness probe. | `5` |
+| `sm.readinessProbe.periodSeconds` | The period in seconds for the readiness probe. | `5` |
+| `sm.readinessProbe.failureThreshold` | The number of times that the readiness probe must fail before the container is marked as unready. | `3` |
+| `sm.readinessProbe.successThreshold` | The number of times that the readiness probe must success before the container is marked as ready. | `1` |
+| `sm.readinessProbe.timeoutSeconds` | The timeout in seconds for an invocation of the readiness probe. | `5` |
 | `sm.storageGroup.enabled` | Enable Table Partitions and Storage Groups (TPSG) for all SMs in this database Helm release | `false` |
 | `sm.storageGroup.name` | The name of the storage group. Only alphanumeric and underscore (`_`) characters are allowed. By default the Helm release name is used | `{{ .Release.Name }}` |
 | `te.enablePod` | Create deployment for TEs. By default, the TE Deployment is disabled if TP/SG is enabled and this is a "secondary" release. | `nil` |
@@ -316,8 +321,11 @@ The following tables list the configurable parameters of the `database` chart an
 | `te.tolerations` | Tolerations for NuoDB TE | `[]` |
 | `te.topologySpreadConstraints` | Topology spread constraints for NuoDB TE | `[]` |
 | `te.otherOptions` | Additional key/value Docker options | `{}` |
-| `sm.otherOptions` | Additional key/value Docker options | `{}` |
-| `te.readinessTimeoutSeconds` | TE readiness probe timeout, sometimes needs adjusting depending on environment and pod resources | `5` |
+| `te.readinessProbe.initialDelaySeconds` | The initial delay in seconds for the readiness probe. | `5` |
+| `te.readinessProbe.periodSeconds` | The period in seconds for the readiness probe. | `5` |
+| `te.readinessProbe.failureThreshold` | The number of times that the readiness probe must fail before the container is marked as unready. | `3` |
+| `te.readinessProbe.successThreshold` | The number of times that the readiness probe must success before the container is marked as ready. | `1` |
+| `te.readinessProbe.timeoutSeconds` | The timeout in seconds for an invocation of the readiness probe. | `5` |
 | `automaticProtocolUpgrade.enabled` | Enable automatic database protocol upgrade and a Transaction Engine (TE) restart as an upgrade finalization step done by Kubernetes Aware Admin (KAA). Applicable for NuoDB major versions upgrade only. Requires NuoDB 4.2.3+ | `false` |
 | `automaticProtocolUpgrade.tePreferenceQuery` | LBQuery expression to select the TE that will be restarted after a successful database protocol upgrade. Defaults to random Transaction Engine (TE) in MONITORED state | `""` |
 | `resourceLabels` | Custom labels attached to the Kubernetes resources installed by this Helm chart. The labels are immutable and can't be changed with Helm upgrade | `{}` |

--- a/stable/database/files/nuosm
+++ b/stable/database/files/nuosm
@@ -16,8 +16,6 @@
 : ${NUODB_DOMAIN:="nuodb"}
 : ${DB_NAME:="demo"}
 
-liveness_req="/nuodb/nuosm/liveness"
-
 DB_DIR=${NUODB_ARCHIVEDIR}
 DB_PARENTDIR=$(dirname ${DB_DIR})
 
@@ -277,7 +275,7 @@ function perform_restore() {
   if [ -n "$restore_requested" ] && [ "$myArchive" -ne "-1" ]; then
     # complete restore request for this archive in retry loop because there
     # could be concurrent requests due to all archives restored at the same time
-    retry 5 completeRestoreRequest "$myArchive"
+    retry 10 completeRestoreRequest "$myArchive"
     retval=$?
     if [ $retval -ne 0 ]; then
       $undo
@@ -295,27 +293,49 @@ function perform_restore() {
 }
 
 #=======================================
-# function - retry the provided function
-#
-# Retry the passed function with arguments until succees or max retry count is
-# reached.
+# function - retry the supplied command until it succeeds or the supplied
+# timeout (in seconds) expires.
 #
 function retry() {
-  local max="$1"
+  # Calculate deadline from timeout
+  local timeout="$1"
+  local start="$(date -u '+%s')"
+  local deadline="$((start + timeout))"
   shift
-  local count=0
+
+  # Start with 1 second interval and increase exponentially
   local rc=0
-  while [ "$count" -lt "$max" ]; do
-    [ $count -gt 0 ] && log "'$*' exited with code $rc - retrying ..."
-    "$@"
-    rc=$?
-    if [ $rc -eq 0 ]; then
-      return $rc
+  local interval=1
+  local failures=0
+  while true; do
+    # Execute command and check exit code
+    out="$("$@" 2>&1)"
+    rc="$?"
+    if [ "$rc" -eq 0 ]; then
+      return 0
     fi
-    count=$(( count + 1 ))
-    sleep 1
+
+    # Check that timeout did not expire and that we have executed the command
+    # more than once, in case the execution time of the initial command
+    # invocation consumed the entire timeout.
+    failures="$((failures + 1))"
+    if [ "$deadline" -le "$(date -u '+%s')" ] && [ "$failures" -gt 1 ]; then
+      log "'$*' failed with exit code $rc and output [$out] after $timeout seconds and $failures tries"
+      return "$rc"
+    fi
+
+    # Sleep for polling interval and calculate next interval
+    log "'$*' failed with exit code $rc and output [$out] - retrying in $interval seconds..."
+    sleep "$interval"
+    interval="$((interval * 2))"
+
+    # Clamp interval to 10 seconds or seconds until the timeout expires
+    [ "$interval" -lt 10 ] || interval=10
+    local current="$(date -u '+%s')"
+    local remaining="$((deadline - current))"
+    [ "$interval" -lt "$remaining" ] || interval="$remaining"
+    [ "$interval" -ge 1 ] || interval=1
   done
-  return $rc
 }
 
 #=======================================
@@ -511,11 +531,10 @@ if [ "$SNAPSHOT_RESTORED" == "true" ]; then
   loadFromSnapshot
 fi
 
-# Retry the first request against the admin layer to make sure that Raft
-# commands can be committed and fail fast on error
-retry 3 nuocmd get value --key "$liveness_req" 2>&1
-if [ $? -ne 0 ]; then
-  die 1 "NuoDB Admin layer liveness check failed"
+# Perform a consistent read of an arbitrary KV-store entry in a polling loop to
+# confirm Raft leadership before proceeding with SM start-up.
+if ! retry 60 nuocmd get value --key nuodb/nuosm/readiness; then
+  die 1 "NuoDB Admin readiness check failed"
 fi
 
 [ -f "$DB_DIR/info.json" ] && myArchive=$(sed -e 's|.*"id":\s*\([0-9]\+\).*|\1|' "$DB_DIR/info.json")

--- a/stable/database/files/nuosm
+++ b/stable/database/files/nuosm
@@ -299,8 +299,8 @@ function perform_restore() {
 function retry() {
   # Calculate deadline from timeout
   local timeout="$1"
-  local start="$(date -u '+%s')"
-  local deadline="$((start + timeout))"
+  local current="$(date -u '+%s')"
+  local deadline="$((current + timeout))"
   shift
 
   # Start with 1 second interval and increase exponentially
@@ -319,22 +319,22 @@ function retry() {
     # more than once, in case the execution time of the initial command
     # invocation consumed the entire timeout.
     failures="$((failures + 1))"
-    if [ "$deadline" -le "$(date -u '+%s')" ] && [ "$failures" -gt 1 ]; then
+    current="$(date -u '+%s')"
+    if [ "$deadline" -le "$current" ] && [ "$failures" -gt 1 ]; then
       log "'$*' failed with exit code $rc and output [$out] after $timeout seconds and $failures tries"
       return "$rc"
     fi
+
+    # Clamp interval to 10 seconds or seconds until the timeout expires
+    [ "$interval" -lt 10 ] || interval=10
+    local remaining="$((deadline - current))"
+    [ "$interval" -lt "$remaining" ] || interval="$remaining"
+    [ "$interval" -ge 1 ] || interval=1
 
     # Sleep for polling interval and calculate next interval
     log "'$*' failed with exit code $rc and output [$out] - retrying in $interval seconds..."
     sleep "$interval"
     interval="$((interval * 2))"
-
-    # Clamp interval to 10 seconds or seconds until the timeout expires
-    [ "$interval" -lt 10 ] || interval=10
-    local current="$(date -u '+%s')"
-    local remaining="$((deadline - current))"
-    [ "$interval" -lt "$remaining" ] || interval="$remaining"
-    [ "$interval" -ge 1 ] || interval=1
   done
 }
 

--- a/stable/database/templates/deployment.yaml
+++ b/stable/database/templates/deployment.yaml
@@ -187,7 +187,11 @@ spec:
             command: [ "readinessprobe" ]
           failureThreshold: {{ default 3 .Values.database.te.readinessProbe.failureThreshold }}
           successThreshold: {{ default 1 .Values.database.te.readinessProbe.successThreshold }}
-          timeoutSeconds: {{ default 5 .Values.database.te.readinessProbe.timeoutSeconds }}
+          {{- if .Values.database.te.readinessProbe.timeoutSeconds }}
+          timeoutSeconds: {{ .Values.database.te.readinessProbe.timeoutSeconds }}
+          {{- else }}
+          timeoutSeconds: {{ default 5 .Values.database.te.readinessTimeoutSeconds }}
+          {{- end }}
       {{- include "nuodb.sidecar.collector" (list . .Values.database.te) | nindent 6 }}
       {{- include "nuodb.imagePullSecrets" . | indent 6 }}
       {{- include "database.te.shareProcessNamespace" . | indent 6 }}

--- a/stable/database/templates/deployment.yaml
+++ b/stable/database/templates/deployment.yaml
@@ -181,14 +181,13 @@ spec:
           readOnly: true
         {{- end }}
         readinessProbe:
-          initialDelaySeconds: 10
-          periodSeconds: 5
+          initialDelaySeconds: {{ default 5 .Values.database.te.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ default 5 .Values.database.te.readinessProbe.periodSeconds }}
           exec:
             command: [ "readinessprobe" ]
-          failureThreshold: 54
-          # the TE becomes unready if it does not start within 5 minutes = 30s + 5s*54
-          successThreshold: 2
-          timeoutSeconds: {{ default 5 .Values.database.te.readinessTimeoutSeconds }}
+          failureThreshold: {{ default 3 .Values.database.te.readinessProbe.failureThreshold }}
+          successThreshold: {{ default 1 .Values.database.te.readinessProbe.successThreshold }}
+          timeoutSeconds: {{ default 5 .Values.database.te.readinessProbe.timeoutSeconds }}
       {{- include "nuodb.sidecar.collector" (list . .Values.database.te) | nindent 6 }}
       {{- include "nuodb.imagePullSecrets" . | indent 6 }}
       {{- include "database.te.shareProcessNamespace" . | indent 6 }}

--- a/stable/database/templates/statefulset.yaml
+++ b/stable/database/templates/statefulset.yaml
@@ -253,14 +253,13 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         readinessProbe:
-          initialDelaySeconds: 10
-          periodSeconds: 15
+          initialDelaySeconds: {{ default 5 .Values.database.sm.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ default 5 .Values.database.sm.readinessProbe.periodSeconds }}
           exec:
             command: [ "readinessprobe" ]
-          failureThreshold: 58
-          # the SM becomes unready if it does not start within 15 minutes = 30s + 15s*58
-          successThreshold: 2
-          timeoutSeconds: {{ default 5 .Values.database.sm.readinessTimeoutSeconds }}
+          failureThreshold: {{ default 3 .Values.database.sm.readinessProbe.failureThreshold }}
+          successThreshold: {{ default 1 .Values.database.sm.readinessProbe.successThreshold }}
+          timeoutSeconds: {{ default 5 .Values.database.sm.readinessProbe.timeoutSeconds }}
       {{- if eq (include "defaultfalse" .Values.database.backupHooks.enabled) "true" }}
       - name: backup-hooks
         image: {{ include "backupHooks.image" . }}
@@ -665,14 +664,13 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         readinessProbe:
-          initialDelaySeconds: 10
-          periodSeconds: 15
+          initialDelaySeconds: {{ default 5 .Values.database.sm.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ default 5 .Values.database.sm.readinessProbe.periodSeconds }}
           exec:
             command: [ "readinessprobe" ]
-          failureThreshold: 58
-          # the SM becomes unready if it does not start within 15 minutes = 30s + 15s*58
-          successThreshold: 2
-          timeoutSeconds: {{ default 5 .Values.database.sm.readinessTimeoutSeconds }}
+          failureThreshold: {{ default 3 .Values.database.sm.readinessProbe.failureThreshold }}
+          successThreshold: {{ default 1 .Values.database.sm.readinessProbe.successThreshold }}
+          timeoutSeconds: {{ default 5 .Values.database.sm.readinessProbe.timeoutSeconds }}
       {{- include "nuodb.sidecar.collector" (list . .Values.database.sm) | nindent 6 }}
       {{- include "nuodb.imagePullSecrets" . | indent 6 }}
       volumes:

--- a/stable/database/templates/statefulset.yaml
+++ b/stable/database/templates/statefulset.yaml
@@ -259,7 +259,11 @@ spec:
             command: [ "readinessprobe" ]
           failureThreshold: {{ default 3 .Values.database.sm.readinessProbe.failureThreshold }}
           successThreshold: {{ default 1 .Values.database.sm.readinessProbe.successThreshold }}
-          timeoutSeconds: {{ default 5 .Values.database.sm.readinessProbe.timeoutSeconds }}
+          {{- if .Values.database.sm.readinessProbe.timeoutSeconds }}
+          timeoutSeconds: {{ .Values.database.sm.readinessProbe.timeoutSeconds }}
+          {{- else }}
+          timeoutSeconds: {{ default 5 .Values.database.sm.readinessTimeoutSeconds }}
+          {{- end }}
       {{- if eq (include "defaultfalse" .Values.database.backupHooks.enabled) "true" }}
       - name: backup-hooks
         image: {{ include "backupHooks.image" . }}
@@ -670,7 +674,11 @@ spec:
             command: [ "readinessprobe" ]
           failureThreshold: {{ default 3 .Values.database.sm.readinessProbe.failureThreshold }}
           successThreshold: {{ default 1 .Values.database.sm.readinessProbe.successThreshold }}
-          timeoutSeconds: {{ default 5 .Values.database.sm.readinessProbe.timeoutSeconds }}
+          {{- if .Values.database.sm.readinessProbe.timeoutSeconds }}
+          timeoutSeconds: {{ .Values.database.sm.readinessProbe.timeoutSeconds }}
+          {{- else }}
+          timeoutSeconds: {{ default 5 .Values.database.sm.readinessTimeoutSeconds }}
+          {{- end }}
       {{- include "nuodb.sidecar.collector" (list . .Values.database.sm) | nindent 6 }}
       {{- include "nuodb.imagePullSecrets" . | indent 6 }}
       volumes:

--- a/stable/database/values.yaml
+++ b/stable/database/values.yaml
@@ -529,6 +529,9 @@ database:
     # keystore: "/etc/nuodb/keys/nuoadmin.p12"
     otherOptions: {}
 
+    # Deprecated: Use readinessProbe.timeoutSeconds instead
+    readinessTimeoutSeconds: 5
+
     # Configuration for readiness probe, which controls ready status and whether
     # the pod has traffic from Services dispatched to it.
     readinessProbe:
@@ -541,8 +544,9 @@ database:
       successThreshold: 1
 
       # The readiness probe for engines only inspects the /proc filesystem, so
-      # it should not take longer than 5 seconds.
-      timeoutSeconds: 5
+      # it should not take longer than 5 seconds. This is commented out to
+      # enable fall-back to the deprecated readinessTimeoutSeconds value.
+      #timeoutSeconds: 5
 
     # Table Partitions and Storage Groups (TP/SG) is the mechanism by which a
     # version of an SQL table row is stored only on a subset of Storage Managers
@@ -644,6 +648,9 @@ database:
     # keystore: "/etc/nuodb/keys/nuoadmin.p12"
     otherOptions: {}
 
+    # Deprecated: Use readinessProbe.timeoutSeconds instead
+    readinessTimeoutSeconds: 5
+
     # Configuration for readiness probe, which controls ready status and whether
     # the pod has traffic from Services dispatched to it.
     readinessProbe:
@@ -656,8 +663,9 @@ database:
       successThreshold: 1
 
       # The readiness probe for engines only inspects the /proc filesystem, so
-      # it should not take longer than 5 seconds.
-      timeoutSeconds: 5
+      # it should not take longer than 5 seconds. This is commented out to
+      # enable fall-back to the deprecated readinessTimeoutSeconds value.
+      #timeoutSeconds: 5
 
 
   # These annotations will pass through to the pod as supplied, useful for integrating 3rd party products such as Vault.

--- a/stable/database/values.yaml
+++ b/stable/database/values.yaml
@@ -529,8 +529,20 @@ database:
     # keystore: "/etc/nuodb/keys/nuoadmin.p12"
     otherOptions: {}
 
-    #Some clusters require longer readiness probe timeouts
-    readinessTimeoutSeconds: 5
+    # Configuration for readiness probe, which controls ready status and whether
+    # the pod has traffic from Services dispatched to it.
+    readinessProbe:
+
+      # By default, use 5-second delay/period and mark container as not ready
+      # after three failures.
+      initialDelaySeconds: 5
+      periodSeconds: 5
+      failureThreshold: 3
+      successThreshold: 1
+
+      # The readiness probe for engines only inspects the /proc filesystem, so
+      # it should not take longer than 5 seconds.
+      timeoutSeconds: 5
 
     # Table Partitions and Storage Groups (TP/SG) is the mechanism by which a
     # version of an SQL table row is stored only on a subset of Storage Managers
@@ -632,8 +644,21 @@ database:
     # keystore: "/etc/nuodb/keys/nuoadmin.p12"
     otherOptions: {}
 
-    # Some clusters require longer readiness probe timeouts
-    readinessTimeoutSeconds: 5
+    # Configuration for readiness probe, which controls ready status and whether
+    # the pod has traffic from Services dispatched to it.
+    readinessProbe:
+
+      # By default, use 5-second delay/period and mark container as not ready
+      # after three failures.
+      initialDelaySeconds: 5
+      periodSeconds: 5
+      failureThreshold: 3
+      successThreshold: 1
+
+      # The readiness probe for engines only inspects the /proc filesystem, so
+      # it should not take longer than 5 seconds.
+      timeoutSeconds: 5
+
 
   # These annotations will pass through to the pod as supplied, useful for integrating 3rd party products such as Vault.
   podAnnotations: {}


### PR DESCRIPTION
This change accelerates process start-up by making two improvements:

1. Lower the period for the readiness probe used by SMs from 15 seconds to 5 seconds and reduce the failure threshold from 2 to 1. There is no need to wait for two successes since the readiness probe checks the process state, which is verifying an explicit state transition as opposed to inferring readiness based on some transient indicator of health, e.g. issuing a basic client request. Once an SM or TE achieves Running state, it does not change until it shuts down. This is an argument for replacing the readiness probe to a startup probe, to avoid doing pointless readiness checks every 5 seconds for the life of the process, but that is left for future work.
2. Wait longer for AP readiness in nuosm. There is a basic readiness check that verifies that the APs have elected a Raft leader, and this was only performing 3 iterations before giving up, which would lead to the SMs entering CrashLoopBackOff, delaying database creation. This change replaces the polling loop with one that is based on a timeout and polls for 1 minute with an exponentially increasing polling interval to reduce the amount of logging noise.