### PR TITLE
Allow HTTP requests to be dispatched to scripts

### DIFF
--- a/stable/database/README.md
+++ b/stable/database/README.md
@@ -232,6 +232,11 @@ The following tables list the configurable parameters of the `database` chart an
 | `backupHooks.resources` | Kubernetes resource requests and limits set on the backup hook sidecar container | `{}` |
 | `backupHooks.freezeMode` | The freeze mode to be used when executing backup hooks. Supported modes are `hotsnap`, `fsfreeze` and `suspend`. Defaults to `hostsnap` if empty | `""` |
 | `backupHooks.timeout` | Timeout in seconds after which the archive will be automatically unfrozen | `30` |
+| `backupHooks.customHandlers` | Custom handlers to register on HTTP server in sidecar | `[]` |
+| `backupHooks.customHandlers[*].method` | The HTTP request method to match on | |
+| `backupHooks.customHandlers[*].path` | The HTTP request path to match on, which may contain path parameters in the form `{param_name}` | |
+| `backupHooks.customHandlers[*].script` | The script to invoke when handling the matched request, which may reference path parameters, query parameters, or the request payload (as `$payload`) | |
+| `backupHooks.customHandlers[*].statusMappings` | Mapping of script exit codes to HTTP status codes | |
 | `snapshotRestore.backupId` | The backup ID being restored, which is set to enable restore from data sources | `""` |
 | `snapshotRestore.snapshotNameTemplate` | The template used to resolve the names of snapshots to use as data sources for the archive and journal PVCs. The template can reference `backupId` and `volumeType`, which is one of `archive`, `journal`. | `{{.backupId}}-{{.volumeType}}` |
 | `ephemeralVolume.enabled` | Whether to create a generic ephemeral volume rather than emptyDir for any storage that does not outlive the pod | `false` |

--- a/stable/database/README.md
+++ b/stable/database/README.md
@@ -235,7 +235,7 @@ The following tables list the configurable parameters of the `database` chart an
 | `backupHooks.customHandlers` | Custom handlers to register on HTTP server in sidecar | `[]` |
 | `backupHooks.customHandlers[*].method` | The HTTP request method to match on | |
 | `backupHooks.customHandlers[*].path` | The HTTP request path to match on, which may contain path parameters in the form `{param_name}` | |
-| `backupHooks.customHandlers[*].script` | The script to invoke when handling the matched request, which may reference path parameters, query parameters, or the request payload (as `$payload`) | |
+| `backupHooks.customHandlers[*].script` | The script to invoke when handling the matched request, which may reference path parameters, query parameters, or the request payload (as `$payload`). If the same variable name appears as a query and path parameter, or a path parameter appears named `$payload`, the path parameter takes precedence. | |
 | `backupHooks.customHandlers[*].statusMappings` | Mapping of script exit codes to HTTP status codes | |
 | `snapshotRestore.backupId` | The backup ID being restored, which is set to enable restore from data sources | `""` |
 | `snapshotRestore.snapshotNameTemplate` | The template used to resolve the names of snapshots to use as data sources for the archive and journal PVCs. The template can reference `backupId` and `volumeType`, which is one of `archive`, `journal`. | `{{.backupId}}-{{.volumeType}}` |

--- a/stable/database/files/backup_hooks.py
+++ b/stable/database/files/backup_hooks.py
@@ -26,6 +26,7 @@ MODE_HOTSNAP = "hotsnap"
 MODE_FSFREEZE = "fsfreeze"
 MODE_SUSPEND = "suspend"
 
+
 def from_dir(base_dir, *args):
     if base_dir is None:
         return None
@@ -85,7 +86,9 @@ def get_nuodb_process_info():
                         if len(parts) == 2 and parts[0] == b"sid":
                             sid = parts[1]
                     if not sid:
-                        raise RuntimeError("Unable to find start ID for nuodb process PID " + pid)
+                        raise RuntimeError(
+                            "Unable to find start ID for nuodb process PID " + pid
+                        )
                     processes.append({"pid": pid, "sid": sid.decode("utf-8")})
         except FileNotFoundError:
             # Process may have exited
@@ -94,6 +97,7 @@ def get_nuodb_process_info():
     if len(processes) > 1:
         LOGGER.warning("Multiple nuodb processes found: %s", processes)
     return processes
+
 
 def check_thread_suspended(pid, tid):
     try:
@@ -167,8 +171,18 @@ def freeze_archive(backup_id, processes, unfreeze=False, timeout=None):
                 extra_args += ["--timeout", "{}s".format(timeout)]
         try:
             subprocess.check_output(
-                ["nuocmd", action, "archiving", "--start-id", sid, "--pause-id", backup_id] + extra_args,
-                stderr=subprocess.STDOUT)
+                [
+                    "nuocmd",
+                    action,
+                    "archiving",
+                    "--start-id",
+                    sid,
+                    "--pause-id",
+                    backup_id,
+                ]
+                + extra_args,
+                stderr=subprocess.STDOUT,
+            )
         except subprocess.CalledProcessError as e:
             # HotSnap supports timeout and will automatic resume. Check the
             # error message to find out if the automatic resume kicked in
@@ -189,6 +203,7 @@ def freeze_archive(backup_id, processes, unfreeze=False, timeout=None):
     else:
         raise RuntimeError("Unsupported freeze mode '{}'".format(FREEZE_MODE))
 
+
 def pre_backup(backup_id, payload):
     # Check that backup ID was specified
     if not backup_id:
@@ -206,11 +221,18 @@ def pre_backup(backup_id, payload):
         # Check if the SM process was restarted which will invalidate the
         # previous pre-backup operation using HotSnap.
         stored_start_id = get_start_id()
-        if FREEZE_MODE != MODE_FSFREEZE and stored_start_id and processes[0]["sid"] != stored_start_id:
+        if (
+            FREEZE_MODE != MODE_FSFREEZE
+            and stored_start_id
+            and processes[0]["sid"] != stored_start_id
+        ):
             # Remote the backup files from the previous pre-backup operation
-            LOGGER.warning("Unexpected start ID: current=%s, stored=%s. " +
-                            "SM process restarted while executing backup ID %s", 
-                            processes[0]["sid"], stored_start_id, get_backup_id())
+            LOGGER.warning(
+                "Unexpected start ID: current=%s, stored=%s. SM process restarted while executing backup ID %s.",
+                processes[0]["sid"],
+                stored_start_id,
+                get_backup_id(),
+            )
             remove_backup_files()
         else:
             raise UserError(
@@ -252,18 +274,28 @@ def pre_backup(backup_id, payload):
         freeze_archive(backup_id, processes, timeout=timeout)
 
     # Cancel backup operation after specified timeout
+    schedule_cancellation(backup_id, timeout)
+
+
+def schedule_cancellation(backup_id, timeout):
     if timeout and timeout > 0:
+
         def cancel_backup():
             try:
                 current_backup_id = get_backup_id()
                 if current_backup_id and current_backup_id == backup_id:
-                    LOGGER.warning("Canceling backup with ID %s. Timeout after %ds", 
-                                    backup_id, timeout)
+                    LOGGER.warning(
+                        "Canceling backup with ID %s. Timeout after %ds.",
+                        backup_id,
+                        timeout,
+                    )
                     post_backup(backup_id, query={})
             except ArchivingNotPausedError:
                 # Suppress this error during backup cancellation
                 pass
+
         Timer(timeout, cancel_backup).start()
+
 
 def post_backup(backup_id, query):
     # Check that backup ID was specified
@@ -271,7 +303,7 @@ def post_backup(backup_id, query):
         raise UserError("Backup ID not specified")
 
     # Check backup ID to make sure it matches current backup
-    force = query is not None and query.get("force") == True
+    force = query is not None and query.get("force") in [True, "true"]
     current_backup_id = get_backup_id()
     if current_backup_id != backup_id:
         msg = "Unexpected backup ID: current={}, supplied={}".format(
@@ -301,6 +333,7 @@ def post_backup(backup_id, query):
     # Delete backup metadata files
     remove_backup_files()
 
+
 def remove_backup_files():
     if os.path.exists(ARCHIVE_BACKUP_ID_FILE):
         os.remove(ARCHIVE_BACKUP_ID_FILE)
@@ -311,15 +344,18 @@ def remove_backup_files():
     if os.path.exists(BACKUP_START_ID_FILE):
         os.remove(BACKUP_START_ID_FILE)
 
+
 def get_backup_id():
     if os.path.exists(ARCHIVE_BACKUP_ID_FILE):
         with open(ARCHIVE_BACKUP_ID_FILE, "r") as f:
             return f.read().strip()
 
+
 def get_start_id():
     if os.path.exists(BACKUP_START_ID_FILE):
         with open(BACKUP_START_ID_FILE, "r") as f:
             return f.read().strip()
+
 
 def get_backup_timeout(payload):
     if payload is not None and payload.get("timeout") is not None:
@@ -330,12 +366,14 @@ def get_backup_timeout(payload):
     if FREEZE_TIMEOUT:
         return int(FREEZE_TIMEOUT)
 
+
 class ArchivingNotPausedError(subprocess.CalledProcessError):
     def __init__(self, e):
         super().__init__(e.returncode, e.cmd, e.output, e.stderr)
 
     def __str__(self):
         return self.output.decode("utf-8").strip()
+
 
 class HttpError(RuntimeError):
     def __init__(self, status, message):
@@ -381,13 +419,9 @@ def get_payload(environ):
     if content_length:
         content_length = int(content_length)
 
-    # If content length is non-0, read payload and decode as JSON
+    # If content length is non-0, read payload
     if content_length:
-        content = environ.get("wsgi.input").read(content_length).decode("utf-8")
-        try:
-            return json.loads(content)
-        except json.decoder.JSONDecodeError as e:
-            raise UserError("Unable to decode request payload: " + str(e))
+        return environ.get("wsgi.input").read(content_length).decode("utf-8")
 
 
 def get_query_params(query_str):
@@ -400,97 +434,253 @@ def get_query_params(query_str):
             raise UserError(
                 "Multiple values specified for query parameter '{}'".format(key)
             )
-        # Try to decode value as some token other than string, otherwise fall
-        # back to string
-        try:
-            as_map[key] = json.loads(values[0])
-        except json.decoder.JSONDecodeError:
-            as_map[key] = values[0]
+        as_map[key] = values[0]
     return as_map
 
 
-def dispatch_request(environ):
-    # Parse URL and make sure it contains at least one path component
-    uri = wsgiref.util.request_uri(environ)
-    parsed = urllib.parse.urlparse(uri)
-    path = parsed.path
-    if path.startswith("/"):
-        path = path[1:]
-    components = path.split("/")
-    if not components:
-        raise UserError("No path provided")
+def normalize_path(path):
+    return path[1:] if path.startswith("/") else path
 
+
+class ScriptHandler(object):
+
+    DEFAULT_STATUS_MAPPING = {
+        "0": 200,
+        "*": 400,
+    }
+
+    def __init__(self, **kwargs):
+        self.method = kwargs["method"]
+        self.path = kwargs["path"]
+        self.script = kwargs["script"]
+        self.status_mappings = dict(self.DEFAULT_STATUS_MAPPING)
+        if "statusMappings" in kwargs:
+            self.status_mappings.update(kwargs["statusMappings"])
+        self.path_params = {}
+
+    def matches(self, method, path_components):
+        # Check that method matches
+        if method != self.method:
+            return False
+
+        # Check that path matches and extract path parameters
+        handler_components = normalize_path(self.path).split("/")
+        for i in range(0, len(path_components)):
+            # If we have more path components in request than in handler path,
+            # then request does not match
+            if i >= len(handler_components):
+                return False
+            # If handler path component is a parameter, extract value from
+            # request path
+            handler_component = handler_components[i]
+            if handler_component.startswith("{") and handler_component.endswith("}"):
+                self.path_params[handler_component[1:-1]] = path_components[i]
+                continue
+            # If handler path component is literal, check that it matches
+            if path_components[i] != handler_component:
+                return False
+
+        # Check that there are no remaining handler path components
+        return i + 1 == len(handler_components)
+
+    def execute(self, query_params, payload):
+        # Build environment variables to supply for script invocation
+        env = dict(os.environ)
+        if query_params:
+            env.update(query_params)
+        if payload:
+            env.update(payload=payload)
+        env.update(self.path_params)
+        # Run script and capture output. Combine both stdout and stderr into
+        # one stream, which should be in JSON format.
+        proc = subprocess.run(
+            self.script,
+            shell=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            env=env,
+        )
+        # Map exit code to HTTP status
+        return self.map_status(proc), proc.stdout
+
+    def map_status(self, proc):
+        status = self.status_mappings.get(str(proc.returncode))
+        if not status:
+            status = self.status_mappings["*"]
+        for http_status in http.HTTPStatus:
+            if str(http_status.value) == str(status):
+                return http_status
+        raise RuntimeError(
+            "No HTTP status for mapping from {} to {}".format(proc.returncode, status)
+        )
+
+
+def read_handler_config(handler_config):
+    if not handler_config:
+        return []
+    if not os.path.exists(handler_config):
+        LOGGER.info("Ignoring non-existent handler config %s", handler_config)
+        return []
+    try:
+        handlers = []
+        with open(handler_config) as f:
+            config_data = json.loads(f.read())
+            # Account for `handlers` property being absent or explicitly
+            # `null`, since this is how Helm renders the config if no custom
+            # handlers are specified
+            handlers_list = config_data.get("handlers")
+            if handlers_list:
+                for handler in handlers_list:
+                    handlers.append(ScriptHandler(**handler))
+        return handlers
+    except Exception:
+        LOGGER.exception("Unable to process handler config %s", handler_config)
+        return []
+
+
+class RequestInfo(object):
+    def __init__(self, environ):
+        self.method = environ.get("REQUEST_METHOD")
+        # Parse URL and make sure it contains at least one path component
+        uri = wsgiref.util.request_uri(environ)
+        self.parsed = urllib.parse.urlparse(uri)
+        self.components = normalize_path(self.parsed.path).split("/")
+        if not self.components:
+            raise UserError("No path provided")
+        # Decode query parameters and payload
+        self.query_params = get_query_params(self.parsed.query)
+        self.payload = get_payload(environ)
+
+
+def handle_method(req):
     # Find a handler that matches the request
-    req_method = environ.get("REQUEST_METHOD")
-    found_handler = False
     for method, path_prefix, handler in REGISTERED_HANDLERS:
-        if req_method == method and components[0] == path_prefix:
+        if req.method == method and req.components[0] == path_prefix:
             # Make sure the correct number of parameters were supplied by
             # inspecting method signature
-            args = components[1:]
+            args = req.components[1:]
             pos_args = inspect.getfullargspec(handler).args
             # If `payload` is in the method signature, then read the request
-            # payload and pass it at the corresponding index
+            # payload as JSON and pass it at the corresponding index
             if "payload" in pos_args:
-                args.insert(pos_args.index("payload"), get_payload(environ))
+                try:
+                    decoded_payload = json.loads(req.payload) if req.payload else None
+                    args.insert(pos_args.index("payload"), decoded_payload)
+                except json.JSONDecodeError as e:
+                    raise UserError("Unable to decode request payload: " + str(e))
             # If `query` is in the method signature, then parse the query
             # parameters as a dictionary and pass them at the corresponding
             # index
             if "query" in pos_args:
-                args.insert(pos_args.index("query"), get_query_params(parsed.query))
+                args.insert(pos_args.index("query"), req.query_params)
             if len(args) != len(pos_args):
                 msg = "{} parameter(s) expected but {} supplied in request {}".format(
-                    len(pos_args), len(args), parsed.path
+                    len(pos_args), len(args), req.parsed.path
                 )
                 if "payload" in pos_args or "query" in pos_args:
                     msg += ", including payload and query parameters"
                 raise UserError(msg)
             # Request is valid. Send it to handler.
             handler(*args)
-            found_handler = True
-            break
+            return
 
-    # Make sure a handler was found
-    if not found_handler:
-        raise UserError("No handler found for path " + parsed.path)
+    # Handler was not found
+    raise UserError("No handler found for path " + req.parsed.path)
 
 
-def create_response(start_response, status, json_response):
+def create_response(start_response, status, data=None):
     status_str = "{0.value} {0.phrase}".format(status)
-    headers = [("Content-Type", "application/json")]
+    headers = []
+    if isinstance(data, bytes):
+        # If data can be decoded as JSON, use application/json
+        try:
+            json.loads(data)
+            headers.append(("Content-Type", "application/json"))
+        except json.JSONDecodeError:
+            headers.append(("Content-Type", "text/plain"))
+    else:
+        # Encode data as JSON
+        data = json.dumps(data, indent=4).encode("utf-8") + b"\n"
+        headers.append(("Content-Type", "application/json"))
     start_response(status_str, headers)
-    return [json.dumps(json_response, indent=4).encode("utf-8"), b"\n"]
+    return [data]
 
 
-def hooks_handler(environ, start_response):
-    status = http.HTTPStatus.OK
-    json_response = dict(success=True)
-    try:
-        dispatch_request(environ)
-    except Exception as e:
-        status, json_response = create_error(e)
-    return create_response(start_response, status, json_response)
+class HooksHandler(object):
+    def __init__(self, handler_config=None):
+        self.handlers = read_handler_config(handler_config)
+        self.log_handlers()
+
+    def log_handlers(self, indent=4):
+        # Log all built-in handlers
+        builtin_handlers = []
+        for method, path_prefix, handler in REGISTERED_HANDLERS:
+            path = path_prefix
+            for arg in inspect.getfullargspec(handler).args:
+                if arg not in ["payload", "query"]:
+                    path += "/{" + arg + "}"
+            builtin_handlers.append(
+                "{}{} /{}".format(indent * " ", method, normalize_path(path))
+            )
+        LOGGER.info("Built-in handlers:\n%s", "\n".join(builtin_handlers))
+        # Log all custom handlers, if there are any
+        custom_handlers = []
+        for handler in self.handlers:
+            custom_handlers.append(
+                "{}{} /{}".format(
+                    indent * " ", handler.method, normalize_path(handler.path)
+                )
+            )
+        if custom_handlers:
+            LOGGER.info("Custom handlers:\n%s", "\n".join(custom_handlers))
+
+    def handle(self, environ):
+        try:
+            # Dispatch to matching script handler
+            req = RequestInfo(environ)
+            for handler in self.handlers:
+                if handler.matches(req.method, req.components):
+                    return handler.execute(req.query_params, req.payload)
+            # Dispatch to matching built-in handler
+            handle_method(req)
+            return http.HTTPStatus.OK, dict(success=True)
+        except Exception as e:
+            return create_error(e)
+
+    def __call__(self, environ, start_response):
+        status, json_response = self.handle(environ)
+        return create_response(start_response, status, json_response)
 
 
-def start_server(port):
+def start_server(port, handler_config):
+    hooks_handler = HooksHandler(handler_config)
     with simple_server.make_server("", port, hooks_handler) as httpd:
         LOGGER.info("Starting backup hooks server on port %s", port)
         httpd.serve_forever()
+
 
 def verify_prerequisites():
     if FREEZE_MODE == MODE_HOTSNAP:
         if which("nuocmd") is None:
             raise RuntimeError("'nuocmd' command not found")
         try:
-            subprocess.run(["nuocmd", "pause", "archiving", "-h"], 
-                           check=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+            subprocess.run(
+                ["nuocmd", "pause", "archiving", "-h"],
+                check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+            )
         except subprocess.CalledProcessError as e:
             if e.returncode == 2:
-                raise RuntimeError("'nuocmd pause archiving' command not supported") from e
+                raise RuntimeError(
+                    "'nuocmd pause archiving' command not supported"
+                ) from e
             raise RuntimeError(
-                "'nuocmd pause archiving' command failed: " + e.output("utf-8")) from e
+                "'nuocmd pause archiving' command failed: " + e.output("utf-8")
+            ) from e
     elif FREEZE_MODE == MODE_FSFREEZE and which("fsfreeze") is None:
         raise RuntimeError("'fsfreeze' command not found")
+
 
 if __name__ == "__main__":
     # Create CLI parser for direct invocation
@@ -499,6 +689,7 @@ if __name__ == "__main__":
     # Register server subcommand
     subparser = subparsers.add_parser("server")
     subparser.add_argument("--port", type=int, default=80)
+    subparser.add_argument("--handler-config", default="/etc/nuodb/handlers.json")
     # Register pre-hook subcommand
     subparser = subparsers.add_parser("pre-hook")
     subparser.add_argument("--backup-id", required=True)
@@ -509,12 +700,12 @@ if __name__ == "__main__":
     subparser.add_argument("--backup-id", required=True)
     subparser.add_argument("--force", action="store_true")
 
-    verify_prerequisites()
-
     # Parse arguments and invoke correct handler
     args = parser.parse_args(sys.argv[1:])
+    if args.subcommand:
+        verify_prerequisites()
     if args.subcommand == "server":
-        start_server(args.port)
+        start_server(args.port, args.handler_config)
     if args.subcommand == "pre-hook":
         # read opaque data and pass it to pre-hook
         opaque = None

--- a/stable/database/templates/configmap.yaml
+++ b/stable/database/templates/configmap.yaml
@@ -44,6 +44,10 @@ metadata:
   name: {{ template "database.fullname" . }}-backup-hooks
 data:
 {{ (.Files.Glob "files/backup_hooks.py").AsConfig | indent 2 }}
+  handlers.json: |
+    {
+      "handlers": {{ .Values.database.backupHooks.customHandlers | toJson }}
+    }
 {{- end }}
 ---
 apiVersion: v1

--- a/stable/database/templates/statefulset.yaml
+++ b/stable/database/templates/statefulset.yaml
@@ -308,6 +308,9 @@ spec:
         - name: backup-hooks
           mountPath: /backup_hooks.py
           subPath: backup_hooks.py
+        - name: backup-hooks
+          mountPath: /etc/nuodb/handlers.json
+          subPath: handlers.json
         - name: archive-volume
           mountPath: /mnt/archive
         {{- if eq (include "defaultfalse" .Values.database.sm.noHotCopy.journalPath.enabled) "true" }}

--- a/stable/database/templates/statefulset.yaml
+++ b/stable/database/templates/statefulset.yaml
@@ -26,13 +26,11 @@ spec:
   template:
     metadata:
       annotations:
-      {{- if .Values.database.configFiles }}
-        {{- with .Values.database.configFiles }}
-        checksum/config: {{ toYaml . | sha256sum }}
-        {{- end }}
-      {{- else }}
-        checksum/config: "0"
+      {{- $configChecksum := "0" -}}
+      {{- if (or .Values.database.configFiles .Values.database.backupHooks.enabled) }}
+        {{- $configChecksum = (dict "configFiles" .Values.database.configFiles "customHandlers" .Values.database.backupHooks.customHandlers | toYaml | sha256sum) }}
       {{- end }}
+        checksum/config: {{ $configChecksum }}
       {{- include "database.tlsConfigAnnotations" . | nindent 8 }}
       {{- if .Values.database.podAnnotations }}
 {{ toYaml .Values.database.podAnnotations | trim | indent 8 }}

--- a/stable/database/templates/statefulset.yaml
+++ b/stable/database/templates/statefulset.yaml
@@ -26,11 +26,11 @@ spec:
   template:
     metadata:
       annotations:
-      {{- $configChecksum := "0" -}}
       {{- if (or .Values.database.configFiles .Values.database.backupHooks.enabled) }}
-        {{- $configChecksum = (dict "configFiles" .Values.database.configFiles "customHandlers" .Values.database.backupHooks.customHandlers | toYaml | sha256sum) }}
-      {{- end }}
-        checksum/config: {{ $configChecksum }}
+        checksum/config: {{ dict "configFiles" .Values.database.configFiles "customHandlers" .Values.database.backupHooks.customHandlers | toYaml | sha256sum }}
+      {{- else }}
+        checksum/config: "0"
+      {{- end -}}
       {{- include "database.tlsConfigAnnotations" . | nindent 8 }}
       {{- if .Values.database.podAnnotations }}
 {{ toYaml .Values.database.podAnnotations | trim | indent 8 }}

--- a/stable/database/values.schema.json
+++ b/stable/database/values.schema.json
@@ -33,6 +33,44 @@
                         "timeout": {
                             "type": "number",
                             "minimum": 1
+                        },
+                        "customHandlers": {
+                            "type": "array",
+                            "items": {
+                                "properties": {
+                                    "method": {
+                                        "type": "string",
+                                        "enum": [
+                                            "GET",
+                                            "POST",
+                                            "PUT",
+                                            "PATCH",
+                                            "DELETE"
+                                        ]
+                                    },
+                                    "path": {
+                                        "type": "string",
+                                        "pattern": "^/?(([a-zA-Z_0-9-]+|[{][a-zA-Z_][a-zA-Z_0-9]*[}])/)*([a-zA-Z_0-9-]+|[{][a-zA-Z_][a-zA-Z_0-9]*[}])$"
+                                    },
+                                    "script": {
+                                        "type": "string"
+                                    },
+                                    "statusMappings": {
+                                        "type": "object",
+                                        "pattern": "^([0-9]+|[*])$",
+                                        "additionalProperties": {
+                                            "type": "integer",
+                                            "minimum": 200,
+                                            "maximum": 599
+                                        }
+                                    }
+                                },
+                                "required": [
+                                    "method",
+                                    "path",
+                                    "script"
+                                ]
+                            }
                         }
                     }
                 }

--- a/stable/database/values.yaml
+++ b/stable/database/values.yaml
@@ -377,6 +377,35 @@ database:
     # Timeout in seconds until the SM is automatically unfrozen.
     timeout: 30
 
+    # Register scripts to be invoked on HTTP requests. Path parameters can
+    # appear in the request path, which are exported as environment variables
+    # available within the script. Query parameters are also made available as
+    # environment variables. If a request payload is supplied, it can be
+    # referenced using the `${payload}` variable. A mapping can also be defined
+    # from process exit codes to HTTP status codes. See the examples below.
+    customHandlers: []
+
+    #customHandlers:
+    #- method: GET
+    #  path: /backup-id
+    #  script: |
+    #    [ -e "$NUODB_ARCHIVE_DIR/backup.txt" ] || exit 1
+    #    cat "$NUODB_ARCHIVE_DIR/backup.txt"
+    #- method: GET
+    #  path: /pid/{command}
+    #  script: |
+    #    pgrep -x "$command"
+    #  statusMappings:
+    #    "1": 404
+    #- method: POST
+    #  path: /operation/{script}/execute
+    #  script: |
+    #    "$script" $payload
+    #  statusMappings:
+    #    "0": 200
+    #    "1": 400
+    #    "*": 500
+
   sm:
     ## Enable persistent log volumes to retain logs when an external logging solution is not used.
     logPersistence:

--- a/test/integration/template_database_test.go
+++ b/test/integration/template_database_test.go
@@ -2962,8 +2962,9 @@ func TestDatabaseStatefulSetBackupHooksSidecar(t *testing.T) {
 		var backupHooksCm *v1.ConfigMap
 		output = helm.RenderTemplate(t, options, helmChartPath, "release-name", []string{"templates/configmap.yaml"})
 		for _, cm := range testlib.SplitAndRenderConfigMap(t, output, 6) {
-			if strings.Contains(cm.Name, "backup-hooks") {
+			if strings.HasSuffix(cm.Name, "backup-hooks") {
 				backupHooksCm = &cm
+				break
 			}
 		}
 		assert.NotNil(t, backupHooksCm)
@@ -3029,8 +3030,9 @@ func TestDatabaseStatefulSetBackupHooksSidecar(t *testing.T) {
 		var backupHooksCm *v1.ConfigMap
 		output = helm.RenderTemplate(t, options, helmChartPath, "release-name", []string{"templates/configmap.yaml"})
 		for _, cm := range testlib.SplitAndRenderConfigMap(t, output, 6) {
-			if strings.Contains(cm.Name, "backup-hooks") {
+			if strings.HasSuffix(cm.Name, "backup-hooks") {
 				backupHooksCm = &cm
+				break
 			}
 		}
 		assert.NotNil(t, backupHooksCm)


### PR DESCRIPTION
This change adds the ability to register custom handlers for the HTTP server in the backup hooks sidecar container. Each handler has a method, path, and script, which is executed on incoming reqeusts with matching method and path. Any path or query parameters extracted from the URL can be referenced as environment variables in the script, as well as the request payload.