### PR TITLE
Relax and sharpen version string checks for NuoDB binaries

### DIFF
--- a/test/minikube/minikube_external_access_test.go
+++ b/test/minikube/minikube_external_access_test.go
@@ -71,7 +71,7 @@ func getNuoSQLVersion(t *testing.T) *semver.Version {
 	} else {
 		require.NoError(t, err)
 	}
-	match := regexp.MustCompile("NuoDB Client build (.*)").FindStringSubmatch(string(out))
+	match := regexp.MustCompile(`\bbuild\s+([0-9][^\s]+)`).FindStringSubmatch(string(out))
 	require.NotNil(t, match, string(out))
 	versionStr := normalizeNuoSQLVersion(match[1])
 	version, err := semver.NewVersion(versionStr)

--- a/test/testlib/nuodb_database_utilities.go
+++ b/test/testlib/nuodb_database_utilities.go
@@ -660,7 +660,7 @@ func GetNuoDBVersion(t *testing.T, namespaceName string, options *helm.Options) 
 		"--image-pull-policy=IfNotPresent", "--",
 		"nuodb", "--version")
 	require.NoError(t, err, "Unable to check NuoDB version in helper pod")
-	match := regexp.MustCompile("NuoDB Server build (.*)").FindStringSubmatch(output)
+	match := regexp.MustCompile(`\bbuild\s+([0-9][^\s]+)`).FindStringSubmatch(output)
 	require.NotNil(t, match, "Unable to match NuoDB version from output")
 	nuoDBVersionMap[options.SetValues["nuodb.image.tag"]] = match[1]
 	return match[1]


### PR DESCRIPTION
Rather than relying on the complete string match when extracting the release from the --version output, test only against the "build" part. Require versions to start with a number, or don't match. Releases must be a single word so stop matching at whitespace.