### PR TITLE
Address test flakiness on Bamboo builds

### DIFF
--- a/test/minikube/minikube_long_restore_test.go
+++ b/test/minikube/minikube_long_restore_test.go
@@ -961,6 +961,7 @@ func TestCornerCaseKubernetesSnapshotRestore(t *testing.T) {
 				testlib.DeletePod(t, namespaceName, "pod/"+smPod)
 				testlib.AwaitNrReplicasScheduled(t, namespaceName, smPod, 1)
 				testlib.AwaitPodUp(t, namespaceName, smPod, 90*time.Second)
+				testlib.AwaitDatabaseUp(t, namespaceName, admin0, dbName, 2)
 
 				output, err = testlib.RunSQL(t, namespaceName, admin0, dbName, "SELECT id FROM testtbl")
 				require.NoError(t, err, output)


### PR DESCRIPTION
This change fixes certain tests that have become flaky when run on internal Bamboo servers.