### PR TITLE
Do not use terratest library to create K8s client

### DIFF
--- a/test/minikube/minikube_base_admin_test.go
+++ b/test/minikube/minikube_base_admin_test.go
@@ -87,8 +87,7 @@ func TestKubernetesAdminLicenseSecret(t *testing.T) {
 		},
 	}
 	kubectlOptions := k8s.NewKubectlOptions("", "", namespaceName)
-
-	clientset, err := k8s.GetKubernetesClientFromOptionsE(t, kubectlOptions)
+	clientset, err := testlib.GetKubernetesClientFromOptionsE(t, kubectlOptions)
 	require.NoError(t, err)
 	clientset.CoreV1().Secrets(namespaceName).Create(ctx, secret, metav1.CreateOptions{})
 

--- a/test/minikube/minikube_networkpolicy_test.go
+++ b/test/minikube/minikube_networkpolicy_test.go
@@ -28,7 +28,7 @@ func TestConnectivityWithNetworkPolicy(t *testing.T) {
 
 	// Create network policy that limits connectivity to group=nuodb
 	kubeOptions := k8s.NewKubectlOptions("", "", namespace)
-	client, err := k8s.GetKubernetesClientFromOptionsE(t, kubeOptions)
+	client, err := testlib.GetKubernetesClientFromOptionsE(t, kubeOptions)
 	require.NoError(t, err)
 	ctx := context.Background()
 	networkPolicy := getNetworkPolicy(namespace)

--- a/test/minikube/minikube_priority_class_test.go
+++ b/test/minikube/minikube_priority_class_test.go
@@ -125,7 +125,7 @@ func TestPriorityClass(t *testing.T) {
 
 func createPriorityClass(t *testing.T, name string, value int32, description string) {
 	options := k8s.NewKubectlOptions("", "", "")
-	client, err := k8s.GetKubernetesClientFromOptionsE(t, options)
+	client, err := testlib.GetKubernetesClientFromOptionsE(t, options)
 	require.NoError(t, err)
 
 	var priorityClass schedulingv1.PriorityClass
@@ -138,7 +138,7 @@ func createPriorityClass(t *testing.T, name string, value int32, description str
 
 func deletePriorityClass(t *testing.T, name string) {
 	options := k8s.NewKubectlOptions("", "", "")
-	client, err := k8s.GetKubernetesClientFromOptionsE(t, options)
+	client, err := testlib.GetKubernetesClientFromOptionsE(t, options)
 	require.NoError(t, err)
 
 	err = client.SchedulingV1().PriorityClasses().Delete(context.TODO(), name, metav1.DeleteOptions{})

--- a/test/testlib/multicluster_utilities.go
+++ b/test/testlib/multicluster_utilities.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/gruntwork-io/terratest/modules/helm"
 	"github.com/gruntwork-io/terratest/modules/k8s"
-	"github.com/nuodb/nuodb-helm-charts/v3/test/testlib"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -311,7 +310,7 @@ func getDnsConfigSnippet(t *testing.T, context context.Context) string {
 
 func updateDnsConfig(t *testing.T, ctx context.Context, kubectlOptions *k8s.KubectlOptions, dnsConfigSnippet string) {
 	// Create K8s client and get configmap for CoreDNS
-	clientset, err := testlib.GetKubernetesClientFromOptionsE(t, kubectlOptions)
+	clientset, err := GetKubernetesClientFromOptionsE(t, kubectlOptions)
 	require.NoError(t, err, "Unable to create K8s client")
 	cm, err := clientset.CoreV1().ConfigMaps(COREDNS_NS).Get(ctx, COREDNS_CM, metav1.GetOptions{})
 	require.NoError(t, err, "Unable to get CoreDNS configmap")

--- a/test/testlib/multicluster_utilities.go
+++ b/test/testlib/multicluster_utilities.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/gruntwork-io/terratest/modules/helm"
 	"github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/nuodb/nuodb-helm-charts/v3/test/testlib"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -310,7 +311,7 @@ func getDnsConfigSnippet(t *testing.T, context context.Context) string {
 
 func updateDnsConfig(t *testing.T, ctx context.Context, kubectlOptions *k8s.KubectlOptions, dnsConfigSnippet string) {
 	// Create K8s client and get configmap for CoreDNS
-	clientset, err := k8s.GetKubernetesClientFromOptionsE(t, kubectlOptions)
+	clientset, err := testlib.GetKubernetesClientFromOptionsE(t, kubectlOptions)
 	require.NoError(t, err, "Unable to create K8s client")
 	cm, err := clientset.CoreV1().ConfigMaps(COREDNS_NS).Get(ctx, COREDNS_CM, metav1.GetOptions{})
 	require.NoError(t, err, "Unable to get CoreDNS configmap")


### PR DESCRIPTION
This change is to avoid the useless logging generated by the terratest library.