### PR TITLE
Discard TE replicas if autoscaling is enabled

### DIFF
--- a/stable/database/README.md
+++ b/stable/database/README.md
@@ -317,7 +317,7 @@ The following tables list the configurable parameters of the `database` chart an
 | `te.logPersistence.accessModes` | Volume access modes enabled (must match capabilities of the storage class).  This is expected to be ReadWriteMany.  Not all storage providers support this mode. | `ReadWriteMany` |
 | `te.logPersistence.size` | Amount of disk space allocated for log storage | `60Gi` |
 | `te.logPersistence.storageClass` | Storage class for volume backing log storage.  This storage class must be pre-configured in the cluster | `-` |
-| `te.replicas` | TE replicas | `1` |
+| `te.replicas` | Number of Transaction Engine (TE) replicas. A non-zero value is discarded if TE autoscaling is enabled. | `1` |
 | `te.labels` | Labels given to the TEs started | `""` |
 | `te.engineOptions` | Additional NuoDB engine options | `""` |
 | `te.resources` | Labels to apply to all resources | `{}` |
@@ -336,12 +336,14 @@ The following tables list the configurable parameters of the `database` chart an
 | `te.autoscaling.hpa.enabled` | Whether to enable auto-scaling for TE deployment by using HPA resource. | `false` |
 | `te.autoscaling.hpa.targetCpuUtilization` | The target average CPU utilization value across all TE pods, represented as a percentage. | `80` |
 | `te.autoscaling.hpa.behavior` | Configures the scaling behavior of the target in both Up and Down directions. | `...` |
+| `te.autoscaling.hpa.annotations` | Custom annotations set on the HPA resource | `{}` |
 | `te.autoscaling.hpa.behavior.scaleUp.stabilizationWindowSeconds` | The number of seconds for which past recommendations should be considered while scaling up. | `300` |
 | `te.autoscaling.keda.enabled` | Whether to enable auto-scaling for TE deployment by using KEDA ScaledObject resource. | `false` |
 | `te.autoscaling.keda.pollingInterval` | The interval in seconds to check each trigger on. | `30` |
 | `te.autoscaling.keda.cooldownPeriod` | The period in seconds to wait after the last trigger reported active before scaling the resource back to 0. | `300` |
 | `te.autoscaling.keda.fallback` | The number of replicas to fall back to if a scaler is in an error state. See https://keda.sh/docs/latest/reference/scaledobject-spec/ | `{}` |
 | `te.autoscaling.keda.triggers` | List of triggers to activate scaling of the target resource. See https://keda.sh/docs/latest/scalers/ | `[]` |
+| `te.autoscaling.keda.annotations` | Custom annotations set on the ScaledObject resource | `{}` |
 | `automaticProtocolUpgrade.enabled` | Enable automatic database protocol upgrade and a Transaction Engine (TE) restart as an upgrade finalization step done by Kubernetes Aware Admin (KAA). Applicable for NuoDB major versions upgrade only. Requires NuoDB 4.2.3+ | `false` |
 | `automaticProtocolUpgrade.tePreferenceQuery` | LBQuery expression to select the TE that will be restarted after a successful database protocol upgrade. Defaults to random Transaction Engine (TE) in MONITORED state | `""` |
 | `resourceLabels` | Custom labels attached to the Kubernetes resources installed by this Helm chart. The labels are immutable and can't be changed with Helm upgrade | `{}` |

--- a/stable/database/templates/_helpers.tpl
+++ b/stable/database/templates/_helpers.tpl
@@ -1088,7 +1088,7 @@ Database name
 {{/*
 Returns true if TE replicas must be set on the Deployment. When TE autoscaling
 is enabled, it is recommended that the `spec.replicas` field is removed. The HPA
-will be implicitly deactivated if the decired replicas is set to 0 (zero). See
+will be implicitly deactivated if the desired replicas is set to 0 (zero). See
 https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#migrating-deployments-and-statefulsets-to-horizontal-autoscaling
 */}}
 {{- define "database.te.setReplicas" -}}

--- a/stable/database/templates/_helpers.tpl
+++ b/stable/database/templates/_helpers.tpl
@@ -1086,6 +1086,20 @@ Database name
 {{- end -}}
 
 {{/*
+Returns true if TE replicas must be set on the Deployment. When TE autoscaling
+is enabled, it is recommended that the `spec.replicas` field is removed. The HPA
+will be implicitly deactivated if the decired replicas is set to 0 (zero). See
+https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#migrating-deployments-and-statefulsets-to-horizontal-autoscaling
+*/}}
+{{- define "database.te.setReplicas" -}}
+{{- if or (eq (include "database.te.replicas" .) "0") (and (eq (include "database.hpa.enabled" .) "false") (eq (include "database.keda.enabled" .) "false")) -}}
+true
+{{- else -}}
+false
+{{- end -}}
+{{- end -}}
+
+{{/*
 Number of TE replicas to deploy.
 */}}
 {{- define "database.te.replicas" -}}

--- a/stable/database/templates/deployment.yaml
+++ b/stable/database/templates/deployment.yaml
@@ -17,7 +17,9 @@ metadata:
     component: te
   name: te-{{ template "database.fullname" . }}
 spec:
+  {{- if eq (include "database.te.setReplicas" .) "true" }}
   replicas: {{ include "database.te.replicas" . }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "database.selectorLabels" . | nindent 6 }}

--- a/stable/database/templates/hpa.yaml
+++ b/stable/database/templates/hpa.yaml
@@ -3,6 +3,8 @@ apiVersion: {{ include "database.hpa.apiVersion" . }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: te-{{ template "database.fullname" . }}
+  annotations:
+    {{- toYaml .Values.database.te.autoscaling.hpa.annotations | trim | nindent 4 }}
   labels:
     {{- include "database.resourceLabels" . | nindent 4 }}
 spec:

--- a/stable/database/templates/keda.yaml
+++ b/stable/database/templates/keda.yaml
@@ -3,6 +3,8 @@ apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:
   name: te-{{ template "database.fullname" . }}
+  annotations:
+    {{- toYaml .Values.database.te.autoscaling.keda.annotations | trim | nindent 4 }}
   labels:
     {{- include "database.resourceLabels" . | nindent 4 }}
 spec:

--- a/stable/database/values.yaml
+++ b/stable/database/values.yaml
@@ -693,7 +693,8 @@ database:
     dbServices: {}
       # enabled: false
 
-    # Number of transaction engines (TE) nodes.  Limit is 3 in CE version of NuoDB
+    # Number of Transaction Engine (TE) replicas. A non-zero value is discarded
+    # if TE autoscaling is enabled.
     replicas: 1
 
     ## resources
@@ -773,6 +774,9 @@ database:
             # considered while scaling up.
             stabilizationWindowSeconds: 300
 
+        # Custom annotations set on the HPA resource
+        annotations: {}
+
       # Configuration for the ScaledObject resource managed by KEDA.
       keda:
         # Whether to enable auto-scaling for TE deployment by using KEDA
@@ -793,6 +797,9 @@ database:
         # List of triggers to activate scaling of the target resource. See:
         # https://keda.sh/docs/latest/scalers/
         triggers: []
+
+        # Custom annotations set on the ScaledObject resource
+        annotations: {}
 
   # These annotations will pass through to the pod as supplied, useful for integrating 3rd party products such as Vault.
   podAnnotations: {}


### PR DESCRIPTION
**Changes**

This change discards a non-zero TE replica value if autoscaling is enabled
based on recommendations in [Kubernetes docs](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#migrating-deployments-and-statefulsets-to-horizontal-autoscaling). It also exposes the 
annotations for HPA and ScaledObject resources.

**Testing**
- integration tests
- manual testing