### PR TITLE
Support static NuoDB collector configuration

### DIFF
--- a/stable/admin/templates/_sidecar.tpl
+++ b/stable/admin/templates/_sidecar.tpl
@@ -56,8 +56,13 @@ Also, we can't use a single if because lazy evaluation is not an option
   {{- include "admin.sc.containerSecurityContext" . | indent 2 }}
   volumeMounts:
   - mountPath: /etc/telegraf/telegraf.d/dynamic/
+    {{- if eq (include "defaulttrue" .Values.nuocollector.watcher.enabled ) "true" }}
     name: eph-volume
     subPath: telegraf
+    {{- else }}
+    name: nuocollector-config
+    readOnly: true
+    {{- end }}
   - mountPath: /var/log/nuodb
     {{- if eq (include "defaultfalse" .Values.admin.logPersistence.enabled) "true" }}
     name: log-volume
@@ -65,6 +70,7 @@ Also, we can't use a single if because lazy evaluation is not an option
     name: eph-volume
     subPath: log
     {{- end }}
+{{- if eq (include "defaulttrue" .Values.nuocollector.watcher.enabled ) "true" }}
 - name: nuocollector-config
   image: {{ template "nuocollector.watcher" . }}
   imagePullPolicy: {{ $.Values.nuocollector.watcher.pullPolicy }}
@@ -92,6 +98,7 @@ Also, we can't use a single if because lazy evaluation is not an option
     name: eph-volume
     subPath: log
     {{- end }}
+{{- end }}
 shareProcessNamespace: true
 {{- end }}
 {{- end }}

--- a/stable/admin/templates/statefulset.yaml
+++ b/stable/admin/templates/statefulset.yaml
@@ -275,6 +275,19 @@ spec:
             - key: {{ .Values.admin.license.key }}
               path: nuodb.lic
       {{- end }}
+      {{- if eq (include "defaulttrue" .Values.nuocollector.watcher.enabled ) "false" }}
+      - name: nuocollector-config
+        projected:
+          defaultMode: 0440
+          sources:
+          {{- range $pluginName, $content := .Values.nuocollector.plugins.admin }}
+          - configMap:
+              name: nuocollector-{{ template "admin.fullname" $ }}-{{ $pluginName }}
+              items:
+              - key: {{ $pluginName }}.conf
+                path: {{ $pluginName }}.conf
+          {{- end }}
+      {{- end }}
       - name: nuoadmin
         configMap:
           name: {{ template "admin.fullname" . }}-nuoadmin

--- a/stable/admin/values.yaml
+++ b/stable/admin/values.yaml
@@ -440,6 +440,10 @@ nuocollector:
     tag: 2.0.0
     pullPolicy: IfNotPresent
   watcher:
+    # Whether to enable NuoDB Collector configuration watcher. If disabled,
+    # decired output plugins must be defined during the installation of the
+    # NuoDB Helm Charts release
+    enabled: true
     registry: ghcr.io
     repository: nuodb/nuodb-sidecar
     tag: latest

--- a/stable/admin/values.yaml
+++ b/stable/admin/values.yaml
@@ -441,7 +441,7 @@ nuocollector:
     pullPolicy: IfNotPresent
   watcher:
     # Whether to enable NuoDB Collector configuration watcher. If disabled,
-    # decired output plugins must be defined during the installation of the
+    # desired output plugins must be defined during the installation of the
     # NuoDB Helm Charts release
     enabled: true
     registry: ghcr.io

--- a/stable/database/templates/deployment.yaml
+++ b/stable/database/templates/deployment.yaml
@@ -227,6 +227,9 @@ spec:
             name: {{ template "database.fullname" . }}-readinessprobe
             defaultMode: 0777
         {{- include "database.tlsVolume" . | nindent 8 }}
+        {{- if eq (include "defaulttrue" .Values.nuocollector.watcher.enabled ) "false" }}
+        {{- include "nuocollector.volume" . | nindent 8 }}
+        {{- end }}
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler

--- a/stable/database/templates/statefulset.yaml
+++ b/stable/database/templates/statefulset.yaml
@@ -376,6 +376,9 @@ spec:
       {{- end }}
       {{- end }}
       {{- end }}
+      {{- if eq (include "defaulttrue" .Values.nuocollector.watcher.enabled ) "false" }}
+      {{- include "nuocollector.volume" . | nindent 6 }}
+      {{- end }}
       {{- include "database.sm.extraVolumes" . | nindent 6  }}
   volumeClaimTemplates:
   - metadata:
@@ -729,6 +732,9 @@ spec:
       {{- end }}
       {{- end }}
       {{- end }}
+      {{- end }}
+      {{- if eq (include "defaulttrue" .Values.nuocollector.watcher.enabled ) "false" }}
+      {{- include "nuocollector.volume" . | nindent 6 }}
       {{- end }}
       {{- include "database.sm.extraVolumes" . | nindent 6  }}
   volumeClaimTemplates:

--- a/stable/database/values.yaml
+++ b/stable/database/values.yaml
@@ -854,6 +854,10 @@ nuocollector:
     tag: 2.0.0
     pullPolicy: IfNotPresent
   watcher:
+    # Whether to enable NuoDB Collector configuration watcher. If disabled,
+    # decired output plugins must be defined during the installation of the
+    # NuoDB Helm Charts release
+    enabled: true
     registry: ghcr.io
     repository: nuodb/nuodb-sidecar
     tag: 1.0.3

--- a/stable/database/values.yaml
+++ b/stable/database/values.yaml
@@ -855,7 +855,7 @@ nuocollector:
     pullPolicy: IfNotPresent
   watcher:
     # Whether to enable NuoDB Collector configuration watcher. If disabled,
-    # decired output plugins must be defined during the installation of the
+    # desired output plugins must be defined during the installation of the
     # NuoDB Helm Charts release
     enabled: true
     registry: ghcr.io


### PR DESCRIPTION
**Changes**

This change enables the NuoDB collector to be configured with plugins
statically by mounting ConfigMap resources directly in the container. It is
useful for deployments where it is not needed to pull the Telegraf plugins
dynamically (i.e. all plugins are known at the Helm release installation time).
The immediate benefit of such a configuration is disabling the NuoDB collector
config watcher sidecar, to reduce the overall cost at scale and minimize
the load on the Kubernetes API server.

The plugin configuration changes are automatically propagated inside the
container by kubelet, however, Telegraf must be started with `--watch-config`
option. See https://docs.influxdata.com/telegraf/v1/commands/

**Testing**
- integration tests
- E2E tests