### PR TITLE
Misc changes to support BOaaS (external backup manager)

### DIFF
--- a/stable/database/README.md
+++ b/stable/database/README.md
@@ -232,6 +232,7 @@ The following tables list the configurable parameters of the `database` chart an
 | `backupHooks.resources` | Kubernetes resource requests and limits set on the backup hook sidecar container | `{}` |
 | `backupHooks.freezeMode` | The freeze mode to be used when executing backup hooks. Supported modes are `hotsnap`, `fsfreeze` and `suspend`. Defaults to `hostsnap` if empty | `""` |
 | `backupHooks.timeout` | Timeout in seconds after which the archive will be automatically unfrozen | `30` |
+| `backupHooks.port` | The container port to expose the HTTP server on. | `8000` |
 | `backupHooks.customHandlers` | Custom handlers to register on HTTP server in sidecar | `[]` |
 | `backupHooks.customHandlers[*].method` | The HTTP request method to match on | |
 | `backupHooks.customHandlers[*].path` | The HTTP request path to match on, which may contain path parameters in the form `{param_name}` | |

--- a/stable/database/files/nuosm
+++ b/stable/database/files/nuosm
@@ -148,46 +148,48 @@ function perform_restore() {
 
   log "Restoring $restore_source; existing archive directores: $( ls -l $DB_PARENTDIR )"
 
-  # work out available space
-  archSize="$(du -s $DB_DIR | grep -o '^ *[0-9]\+')"
-  archSpace="$(df --output=avail $DB_DIR | grep -o ' *[0-9]\+')"
-
-  if [ $(( archSpace > archSize * 2)) ]; then
-    saveName="${DB_DIR}-save-$( date +%Y%m%dT%H%M%S )"
-    undo="mv $saveName $DB_DIR"
-    mv $DB_DIR $saveName
-
-    retval=$?
-    if [ $retval -ne 0 ]; then
-      $undo
-      error="Error moving archive in preparation for restore"
-      return $retval
-    fi
-  else
-    tarfile="${DB_DIR}-$( date +%Y%m%dT%H%M%S ).tar.gz"
-    tar czf $tarfile -C $DB_PARENTDIR $(basename $DB_DIR)
-
-    retval=$?
-    if [ $retval -ne 0 ]; then
-      rm -rf $tarfile
-      error="Restore: unable to save existing archive to TAR file"
-      return $retval
-    fi
-
+  if [ "$restore_type" != "snapshot" ]; then
+    # work out available space
+    archSize="$(du -s $DB_DIR | grep -o '^ *[0-9]\+')"
     archSpace="$(df --output=avail $DB_DIR | grep -o ' *[0-9]\+')"
-    if [ $(( archSize + 1024000 > archSpace )) ]; then
-      rm -rf $tarfile
-      error="Insufficient space for restore after archive has been saved to TAR."
-      return 1
+
+    if [ $(( archSpace > archSize * 2)) ]; then
+      saveName="${DB_DIR}-save-$( date +%Y%m%dT%H%M%S )"
+      undo="mv $saveName $DB_DIR"
+      mv $DB_DIR $saveName
+
+      retval=$?
+      if [ $retval -ne 0 ]; then
+        $undo
+        error="Error moving archive in preparation for restore"
+        return $retval
+      fi
+    else
+      tarfile="${DB_DIR}-$( date +%Y%m%dT%H%M%S ).tar.gz"
+      tar czf $tarfile -C $DB_PARENTDIR $(basename $DB_DIR)
+
+      retval=$?
+      if [ $retval -ne 0 ]; then
+        rm -rf $tarfile
+        error="Restore: unable to save existing archive to TAR file"
+        return $retval
+      fi
+
+      archSpace="$(df --output=avail $DB_DIR | grep -o ' *[0-9]\+')"
+      if [ $(( archSize + 1024000 > archSpace )) ]; then
+        rm -rf $tarfile
+        error="Insufficient space for restore after archive has been saved to TAR."
+        return 1
+      fi
+
+      undo="tar xf $tarfile -C $DB_PARENTDIR"
+      rm -rf $DB_DIR
     fi
 
-    undo="tar xf $tarfile -C $DB_PARENTDIR"
-    rm -rf $DB_DIR
+    mkdir $DB_DIR
+
+    log "(restore) recreated $DB_DIR; atoms=$( ls -l $DB_DIR/*.atm 2>/dev/null | wc -l)"
   fi
-
-  mkdir $DB_DIR
-
-  log "(restore) recreated $DB_DIR; atoms=$( ls -l $DB_DIR/*.atm 2>/dev/null | wc -l)"
 
   # restore request is a URL - so retrieve the backup using curl
   if isUrl "$restore_source"; then
@@ -252,7 +254,26 @@ function perform_restore() {
       log "removing $download_dir"
       rm -rf $download_dir
     fi
-
+  elif [ "$restore_type" == "snapshot" ]; then
+    # the archive content has been restored from a snapshot so load it and leave
+    # the metadata so that the archive object can be re-created
+    loadFromSnapshot "true"
+    if [ ! -f "${DB_DIR}/restored.txt" ]; then
+      log "Calling nuodocker to re-create metadata for archive=$DB_DIR"
+      status="$(nuodocker restore archive \
+        --origin-dir $DB_DIR \
+        "${journal_flags[@]}" \
+        --restore-dir $DB_DIR \
+        --db-name $DB_NAME \
+        --clean-metadata 2>&1)"
+      retval=$?
+      log "$status"
+    fi
+    # create restored.txt file to signal that archive metadata has been
+    # re-created; this is needed if completing the restore request fail and the
+    # SM container restarts; the file is removed by the pre-backup hook before
+    # performing new snapshot
+    [ $retval -eq 0 ] && echo "$BACKUP_ID" > "${DB_DIR}/restored.txt"
   else
     # log "Calling nuoarchive to restore $restore_source into $DB_DIR"
     log "Calling nuodocker to restore $restore_source into $DB_DIR"
@@ -285,6 +306,12 @@ function perform_restore() {
     log "Restore request for archiveId=${myArchive} marked as completed"
   else
     purgeArchive "$myArchive"
+  fi
+
+  if [ "$restore_type" == "snapshot" ]; then
+    log "Removing metadata from snapshot archive"
+    rm -f "${DB_DIR}/backup.txt"
+    rm -f "${JOURNAL_DIR}/backup.txt"
   fi
 
   [ -n "$NUODB_DEBUG" ] && ls -l $DB_DIR
@@ -420,6 +447,7 @@ function checkBackupId() {
 # function - Looks for a previous archive and journal and imports it
 #
 function loadFromSnapshot() {
+  local leave_metadata=${1:-"false"}
   local recreate_archives="false"
 
   if [ ! -f "$DB_DIR/info.json" ] && [ ! -f "$DB_DIR/restored.txt" ]; then
@@ -460,6 +488,7 @@ function loadFromSnapshot() {
         fi
       fi
 
+      log "Moving external journal from ${expected_journal} to ${JOURNAL_DIR}"
       rm -rf "${JOURNAL_DIR}"
       mv "${expected_journal}" "${JOURNAL_DIR}"
 
@@ -486,7 +515,7 @@ function loadFromSnapshot() {
     fi
   fi
 
-  if [ "$recreate_archives" == "true" ]; then
+  if [ "$recreate_archives" == "true" ] && [ "$leave_metadata" == "false" ]; then
     # Create restored.txt to signal that snapshot preparation is complete. This
     # is needed in the absence of info.json, which is not created for the
     # restored archive object until later.
@@ -537,7 +566,7 @@ if ! retry 60 nuocmd get value --key nuodb/nuosm/readiness; then
   die 1 "NuoDB Admin readiness check failed"
 fi
 
-[ -f "$DB_DIR/info.json" ] && myArchive=$(sed -e 's|.*"id":\s*\([0-9]\+\).*|\1|' "$DB_DIR/info.json")
+[ -f "$DB_DIR/info.json" ] && [ ! -f "$DB_DIR/backup.txt" ] && myArchive=$(sed -e 's|.*"id":\s*\([0-9]\+\).*|\1|' "$DB_DIR/info.json")
 trace "checking archive raft metadata"
 [ -z "$myArchive" ] && myArchive=$( nuocmd show archives \
   --db-name $DB_NAME \
@@ -576,12 +605,20 @@ if [ "$myArchive" -ne "-1" ]; then
       # restore chart doesn't have notion of stream|backupset
       # `nuodocker restore archive` works with both
       restore_type="backupset"
+      if [ "$restore_source" == ":snapshot" ]; then
+        # the archive content has been restored in-place from a snapshot by an
+        # external backup manager (not by NuoDB Helm charts or NuoDB operator);
+        # we will get here only if the Kubernetes Aware Admin (KAA) is disabled
+        # since otherwise the archive metadata will be removed by KAA when the
+        # PVC is re-created with a snapshot reference
+        restore_type="snapshot"
+      fi
       [ -z "$restore_credentials_encoded" ] && restore_credentials_encoded="$(printf "%s" "${DATABASE_RESTORE_CREDENTIALS:-:}" | base64 -w 0)"
       [ -z "$strip_levels" ] && strip_levels=${DATABASE_RESTORE_STRIP_LEVELS:-1}
 
       log "Archive restore will be performed for archiveId=${myArchive}, source=${restore_source}, type=${restore_type}, strip=${strip_levels}"
       trace "performing restore for archiveId=${myArchive}"
-      if isRestoreSourceAvailable "$restore_source"; then
+      if isRestoreSourceAvailable "$restore_source" || [ "$restore_type" == "snapshot" ]; then
         perform_restore || die $? "$error"
       else
         error="Backupset $restore_source cannot be found in $NUODB_BACKUPDIR"

--- a/stable/database/templates/statefulset.yaml
+++ b/stable/database/templates/statefulset.yaml
@@ -280,6 +280,11 @@ spec:
         - containerPort: {{ .Values.database.backupHooks.port }}
           protocol: TCP
         env:
+          - name: DB_NAME
+            valueFrom:
+              secretKeyRef:
+                name: {{ template "database.secretName" . }}
+                key: database-name
           - name: FREEZE_MODE
             value: {{ include "backupHooks.freezeMode" . | quote }}
           {{- if .Values.database.backupHooks.timeout }}

--- a/stable/database/templates/statefulset.yaml
+++ b/stable/database/templates/statefulset.yaml
@@ -275,9 +275,9 @@ spec:
         imagePullPolicy: {{ default "" .Values.database.backupHooks.image.pullPolicy }}
         args:
           - nuodb-operations
-          - --port=8000
+          - --port={{ .Values.database.backupHooks.port }}
         ports:
-        - containerPort: 8000
+        - containerPort: {{ .Values.database.backupHooks.port }}
           protocol: TCP
         env:
           - name: FREEZE_MODE

--- a/stable/database/values.yaml
+++ b/stable/database/values.yaml
@@ -377,6 +377,9 @@ database:
     # Timeout in seconds until the SM is automatically unfrozen.
     timeout: 30
 
+    # The container port to expose the HTTP server on
+    port: 8080
+
     # Register scripts to be invoked on HTTP requests. Path parameters can
     # appear in the request path, which are exported as environment variables
     # available within the script. Query parameters are also made available as

--- a/stable/database/values.yaml
+++ b/stable/database/values.yaml
@@ -378,7 +378,7 @@ database:
     timeout: 30
 
     # The container port to expose the HTTP server on
-    port: 8080
+    port: 8000
 
     # Register scripts to be invoked on HTTP requests. Path parameters can
     # appear in the request path, which are exported as environment variables


### PR DESCRIPTION
**Changes**

This change adds support for database in-place restore done using snapshots.  A
special `:snapshot` restore source signals that the database data has been
restored from snapshots by an external backup manager (e.g. BOaaS). Expose the
backup hooks port as Helm value.

**Testing**
- regrestion testing