### PR TITLE
Supply restricted `node-port` range to database processes

### DIFF
--- a/stable/admin/templates/statefulset.yaml
+++ b/stable/admin/templates/statefulset.yaml
@@ -160,6 +160,7 @@ spec:
           {{- end }}
           {{- end }}
           - "--"
+          - "portRange=48006,48006"
           {{- if .Values.admin.tde }}
           {{- if and .Values.admin.tde.storagePasswordsDir (ne .Values.admin.tde.storagePasswordsDir "/etc/nuodb/tde") }}
           - "tdeMonitor.storagePasswordsDir={{ .Values.admin.tde.storagePasswordsDir }}"

--- a/test/minikube/minikube_base_database_test.go
+++ b/test/minikube/minikube_base_database_test.go
@@ -119,22 +119,26 @@ func verifyDBService(t *testing.T, namespaceName string, podName string, service
 	}
 }
 
-func verifyPodLabeling(t *testing.T, namespaceName string, adminPod string) {
+func verifyProcessOptionsAndLabels(t *testing.T, namespaceName string, adminPod string) {
 	objects, err := testlib.GetDatabaseProcessesE(t, namespaceName, adminPod, "demo")
 	require.NoError(t, err)
 
 	for _, obj := range objects {
-		val, ok := obj.Labels["cloud"]
+		val, ok := obj.Options["node-port"]
 		require.True(t, ok)
-		require.True(t, val == LABEL_CLOUD)
+		require.Equal(t, "48006,48006", val)
+
+		val, ok = obj.Labels["cloud"]
+		require.True(t, ok)
+		require.Equal(t, LABEL_CLOUD, val)
 
 		val, ok = obj.Labels["region"]
 		require.True(t, ok)
-		require.True(t, val == LABEL_REGION)
+		require.Equal(t, LABEL_REGION, val)
 
 		val, ok = obj.Labels["zone"]
 		require.True(t, ok)
-		require.True(t, val == LABEL_ZONE)
+		require.Equal(t, LABEL_ZONE, val)
 	}
 
 }
@@ -183,7 +187,7 @@ func TestKubernetesBasicDatabase(t *testing.T) {
 	t.Run("verifySecret", func(t *testing.T) { verifySecret(t, namespaceName) })
 	t.Run("verifyDBClusterService", func(t *testing.T) { verifyDBService(t, namespaceName, admin0, clusterServiceName, false) })
 	t.Run("verifyNuoSQL", func(t *testing.T) { verifyNuoSQL(t, namespaceName, admin0, "demo") })
-	t.Run("verifyPodLabeling", func(t *testing.T) { verifyPodLabeling(t, namespaceName, admin0) })
+	t.Run("verifyProcessOptionsAndLabels", func(t *testing.T) { verifyProcessOptionsAndLabels(t, namespaceName, admin0) })
 }
 
 func TestSmVolumePermissionChange(t *testing.T) {


### PR DESCRIPTION
Only port 48006 is exposed on database pods, but database processes are supplied the default `node-port` value 48006, which actually defines a range of ports starting at 48006 with no upper bound (except the maximum port value allowed by the operating system).

This change specifies the `portRange` for the APs to be `48006,48006` (the `node-port` value is based on the `portRange` AP property), so that the specific port that is exposed on database pods is what the processes listen on. If for some reason, a process cannot listen on that port, then it should just crash and be rescheduled.

Previously, if a process was unable to listen on 48006, it would try 48007, and so on, which is unreachable and prevents any of its peers in the database from connecting to it.