### PR TITLE
Allow override of tolerations

### DIFF
--- a/stable/admin/templates/_helpers.tpl
+++ b/stable/admin/templates/_helpers.tpl
@@ -608,3 +608,10 @@ Any additional annotations to add to services.
 Extension point that can be overriden by an embedding chart.
 */}}
 {{- end }}
+
+{{/*
+Set tolerations for the service pods.
+*/}}
+{{- define "admin.tolerations"}}
+{{ toYaml .Values.admin.tolerations }}
+{{- end }}

--- a/stable/admin/templates/statefulset.yaml
+++ b/stable/admin/templates/statefulset.yaml
@@ -61,7 +61,7 @@ spec:
 {{- end }}
       {{- if .Values.admin.tolerations }}
       tolerations:
-{{ toYaml .Values.admin.tolerations | trim | indent 8 }}
+{{ include "admin.tolerations" . | trim | indent 8 }}
       {{- end }}
       terminationGracePeriodSeconds: 15
       {{- if eq (include "defaulttrue" .Values.admin.initContainers.runInitDisk) "true" }}

--- a/stable/database/templates/_helpers.tpl
+++ b/stable/database/templates/_helpers.tpl
@@ -1318,3 +1318,17 @@ Arguments:
 {{- end -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Set tolerations for the database SM pods.
+*/}}
+{{- define "database.sm.tolerations"}}
+{{ toYaml .Values.database.sm.tolerations }}
+{{- end }}
+
+{{/*
+Set tolerations for the database TE pods.
+*/}}
+{{- define "database.te.tolerations"}}
+{{ toYaml .Values.database.te.tolerations }}
+{{- end }}

--- a/stable/database/templates/deployment.yaml
+++ b/stable/database/templates/deployment.yaml
@@ -64,7 +64,7 @@ spec:
 {{- end }}
       {{- if .Values.database.te.tolerations }}
       tolerations:
-{{ toYaml .Values.database.te.tolerations | trim | indent 8 }}
+{{ include "database.te.tolerations" . | trim | indent 8 }}
       {{- end }}
       {{- if eq (include "defaulttrue" .Values.database.initContainers.runInitDisk) "true" }}
       initContainers:

--- a/stable/database/templates/statefulset.yaml
+++ b/stable/database/templates/statefulset.yaml
@@ -62,7 +62,7 @@ spec:
 {{- end }}
       {{- if .Values.database.sm.tolerations }}
       tolerations:
-{{ toYaml .Values.database.sm.tolerations | trim | indent 8 }}
+{{ include "database.sm.tolerations" . | trim | indent 8 }}
       {{- end }}
       {{- include "database.sm.shareProcessNamespace" . | indent 6 -}}
       {{- if eq (include "defaulttrue" .Values.database.initContainers.runInitDisk) "true" }}


### PR DESCRIPTION
Add extension points to helm charts so that we can override tolerations logic in the 3DS helm charts.

See: http://nuocrucible/cru/CR-26956