### PR TITLE
Crossport engine memory limit changes from ds-nuodb to GitHub

### DIFF
--- a/stable/database/templates/deployment.yaml
+++ b/stable/database/templates/deployment.yaml
@@ -105,7 +105,7 @@ spec:
           - "{{ .Values.admin.affinityLabels }}"
           {{- end }}
           - "--options"
-          - "mem $(MEMORY_REQUEST) {{- range $opt, $val := .Values.database.te.engineOptions }} {{$opt}} {{$val}} {{- end}}"
+          - "mem $(ENGINE_MEMORY) {{- range $opt, $val := .Values.database.te.engineOptions }} {{$opt}} {{$val}} {{- end}}"
           {{- include "database.teLabels" . | indent 10 }}
     {{- include "database.otherOptions" .Values.database.te.otherOptions | indent 10 }}
     {{- include "database.sc.containerSecurityContext" . | indent 8 }}
@@ -127,11 +127,11 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
-          - name: MEMORY_REQUEST
+          - name: ENGINE_MEMORY
             valueFrom:
               resourceFieldRef:
                 containerName: engine
-                resource: requests.memory
+                resource: limits.memory
           - { name: DB_NAME,             value: {{ ( include "database.dbName" . ) | quote }} }
           - { name: NUOCMD_API_SERVER,   value: "{{ template "admin.address" . }}:8888" }
           - { name: PEER_ADDRESS,        value: "{{ template "admin.address" . }}" }

--- a/stable/database/templates/statefulset.yaml
+++ b/stable/database/templates/statefulset.yaml
@@ -113,7 +113,7 @@ spec:
           - "{{ .Values.admin.affinityLabels }}"
           {{- end }}
           - "--options"
-          - "mem $(MEMORY_REQUEST) {{ include "opt.key-values" .Values.database.sm.engineOptions }}"
+          - "mem $(ENGINE_MEMORY) {{ include "opt.key-values" .Values.database.sm.engineOptions }}"
     {{- $labels := printf "%s %s" (include "database.storageGroup.label" .) (include "opt.key-values" .Values.database.sm.labels) -}}
     {{- if trim $labels }}
           - "--labels"
@@ -144,11 +144,11 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        - name: MEMORY_REQUEST
+        - name: ENGINE_MEMORY
           valueFrom:
             resourceFieldRef:
               containerName: engine
-              resource: requests.memory
+              resource: limits.memory
         - name: DB_NAME
           valueFrom:
             secretKeyRef:
@@ -559,7 +559,7 @@ spec:
           - "{{ .Values.admin.affinityLabels }}"
           {{- end }}
           - "--options"
-          - "mem $(MEMORY_REQUEST) {{- if and (eq (include "defaulttrue" .Values.database.sm.hotCopy.enableBackups) "true") (eq (include "defaultfalse" .Values.database.sm.hotCopy.journalBackup.enabled) "true") }} journal-hot-copy enable {{- end }} {{- include "opt.key-values" .Values.database.sm.engineOptions}}"
+          - "mem $(ENGINE_MEMORY) {{- if and (eq (include "defaulttrue" .Values.database.sm.hotCopy.enableBackups) "true") (eq (include "defaultfalse" .Values.database.sm.hotCopy.journalBackup.enabled) "true") }} journal-hot-copy enable {{- end }} {{- include "opt.key-values" .Values.database.sm.engineOptions}}"
           - "--labels"
           - "role hotcopy backup {{ include "hotcopy.groupPrefix" . }} {{ include "database.storageGroup.label" . }} {{- include "opt.key-values" .Values.database.sm.labels }}"
 {{- with .Values.database.options}}
@@ -587,11 +587,11 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        - name: MEMORY_REQUEST
+        - name: ENGINE_MEMORY
           valueFrom:
             resourceFieldRef:
               containerName: engine
-              resource: requests.memory
+              resource: limits.memory
         - name: DB_NAME
           valueFrom:
             secretKeyRef:

--- a/test/integration/template_resources_test.go
+++ b/test/integration/template_resources_test.go
@@ -102,11 +102,11 @@ func TestResourcesDatabaseDefaults(t *testing.T) {
 		assert.EqualValues(t, 8, (*containers)[0].Resources.Limits.Cpu().ScaledValue(0))
 		assert.EqualValues(t, 16*1024*1024*1024, (*containers)[0].Resources.Limits.Memory().ScaledValue(0))
 
-		assert.True(t, testlib.ArgContains((*containers)[0].Args, "mem $(MEMORY_REQUEST)"))
-		assert.True(t, testlib.EnvContainsValueFrom((*containers)[0].Env, "MEMORY_REQUEST", &v1.EnvVarSource{
+		assert.True(t, testlib.ArgContains((*containers)[0].Args, "mem $(ENGINE_MEMORY)"))
+		assert.True(t, testlib.EnvContainsValueFrom((*containers)[0].Env, "ENGINE_MEMORY", &v1.EnvVarSource{
 			ResourceFieldRef: &v1.ResourceFieldSelector{
 				ContainerName: (*containers)[0].Name,
-				Resource:      "requests.memory",
+				Resource:      "limits.memory",
 			},
 		}))
 


### PR DESCRIPTION
Crossport several minor changes to engine memory from `ds-nuodb` to this repo:
 - Set max engine memory to `limits.memory` from `requests.memory`.
 - Change the name of the environment variable containing this setting from `MEMORY_REQUEST` to `ENGINE_MEMORY`. Technically, this is a change in behavior, but this variable was only added in version 3.11, so renaming it is very unlikely to break anything.

Testing:
https://app.circleci.com/pipelines/github/nuodb/nuodb-helm-charts?branch=kontaras%2Fengine-memory-limit-crossport

https://app.circleci.com/pipelines/github/nuodb/nuodb-control-plane/6765/workflows/71c98daf-7b34-4878-95e4-c5a160879339