### PR TITLE
[DBAAS-869] Mount the log volume on the operations sidecar so it can access cores

### DIFF
--- a/stable/database/templates/deployment.yaml
+++ b/stable/database/templates/deployment.yaml
@@ -214,6 +214,8 @@ spec:
               secretKeyRef:
                 name: {{ template "database.secretName" . }}
                 key: database-name
+          - name: NUODB_CORES_DIR
+            value: "/mnt/log"
           {{- include "database.te.operationsSidecar.env" . | indent 10 }}
         resources:
         {{- ( include "database.te.operationsSidecar.resources" . ) | trim | nindent 10 }}
@@ -222,6 +224,13 @@ spec:
         - name: operations
           mountPath: /etc/nuodb/handlers.json
           subPath: handlers.json
+        - mountPath: /mnt/log
+          {{- if eq (include "defaultfalse" .Values.database.te.logPersistence.enabled) "true" }}
+          name: log-volume
+          {{- else }}
+          name: eph-volume
+          subPath: log
+          {{- end }}
         {{- with .Values.database.te.operationsSidecar.volumeMounts }}
         {{- toYaml . | trim | nindent 8 }}
         {{- end }}

--- a/stable/database/templates/deployment.yaml
+++ b/stable/database/templates/deployment.yaml
@@ -214,7 +214,7 @@ spec:
               secretKeyRef:
                 name: {{ template "database.secretName" . }}
                 key: database-name
-          - name: NUODB_CORES_DIR
+          - name: NUODB_LOGDIR
             value: "/mnt/log"
           {{- include "database.te.operationsSidecar.env" . | indent 10 }}
         resources:

--- a/stable/database/templates/statefulset.yaml
+++ b/stable/database/templates/statefulset.yaml
@@ -307,7 +307,7 @@ spec:
           - name: NUODB_JOURNAL_DIR
             value: {{ printf "/mnt/journal/%s/%s" ( include "admin.domainName" . ) ( include "database.dbName" . ) }}
           {{- end }}
-          - name: NUODB_CORES_DIR
+          - name: NUODB_LOGDIR
             value: "/mnt/log"
           {{- if eq (include "backupHooks.freezeMode" . ) "hotsnap" }}
           - { name: NUOCMD_API_SERVER,   value: "{{ template "admin.address" . }}:8888" }

--- a/stable/database/templates/statefulset.yaml
+++ b/stable/database/templates/statefulset.yaml
@@ -307,6 +307,8 @@ spec:
           - name: NUODB_JOURNAL_DIR
             value: {{ printf "/mnt/journal/%s/%s" ( include "admin.domainName" . ) ( include "database.dbName" . ) }}
           {{- end }}
+          - name: NUODB_CORES_DIR
+            value: "/mnt/log"
           {{- if eq (include "backupHooks.freezeMode" . ) "hotsnap" }}
           - { name: NUOCMD_API_SERVER,   value: "{{ template "admin.address" . }}:8888" }
           {{- end }}
@@ -333,6 +335,13 @@ spec:
         - name: journal-volume
           mountPath: /mnt/journal
         {{- end }}
+        - mountPath: /mnt/log
+          {{- if eq (include "defaultfalse" .Values.database.sm.logPersistence.enabled) "true" }}
+          name: log-volume
+          {{- else }}
+          name: eph-volume
+          subPath: log
+          {{- end }}
         {{- if eq (include "backupHooks.freezeMode" . ) "hotsnap" }}
         {{- if eq (include "database.enableEphemeralVolume" (list . .Values.database.sm)) "true" }}
         - name: eph-volume

--- a/test/integration/template_database_test.go
+++ b/test/integration/template_database_test.go
@@ -3423,7 +3423,7 @@ func TestDatabaseBackupHooksSidecar(t *testing.T) {
 		testlib.AssertEnvContains(t, sidecar.Env, "FREEZE_TIMEOUT", "30")
 		testlib.AssertEnvContains(t, sidecar.Env, "NUOCMD_API_SERVER", "nuodb.default.svc:8888")
 		testlib.AssertEnvNotContains(t, sidecar.Env, "NUODB_JOURNAL_DIR")
-		testlib.AssertEnvContains(t, sidecar.Env, "NUODB_CORES_DIR", "/mnt/log")
+		testlib.AssertEnvContains(t, sidecar.Env, "NUODB_LOGDIR", "/mnt/log")
 		testlib.AssertEnvContains(t, sidecar.Env, "var0", "val0")
 		testlib.AssertEnvContains(t, sidecar.Env, "var1", "val1")
 		// Check volume mounts
@@ -3504,7 +3504,7 @@ func TestDatabaseBackupHooksSidecar(t *testing.T) {
 		testlib.AssertEnvNotContains(t, sidecar.Env, "FREEZE_TIMEOUT")
 		testlib.AssertEnvNotContains(t, sidecar.Env, "NUOCMD_API_SERVER")
 		testlib.AssertEnvNotContains(t, sidecar.Env, "NUODB_JOURNAL_DIR")
-		testlib.AssertEnvContains(t, sidecar.Env, "NUODB_CORES_DIR", "/mnt/log")
+		testlib.AssertEnvContains(t, sidecar.Env, "NUODB_LOGDIR", "/mnt/log")
 		testlib.AssertEnvContains(t, sidecar.Env, "var0", "val0")
 		// Check volume mounts
 		volumes := make([]string, len(sidecar.VolumeMounts))

--- a/test/integration/template_database_test.go
+++ b/test/integration/template_database_test.go
@@ -3379,6 +3379,7 @@ func TestDatabaseBackupHooksSidecar(t *testing.T) {
 				"database.sm.operationsSidecar.enabled":                   "true",
 				"database.sm.operationsSidecar.resources.limits.memory":   "5Gi",
 				"database.securityContext.enabledOnContainer":             "true",
+				"database.sm.logPersistence.enabled":                      "true",
 				"database.sm.operationsSidecar.env[0].name":               "var0",
 				"database.sm.operationsSidecar.env[0].value":              "val0",
 				"database.sm.operationsSidecar.volumeMounts[0].name":      "volume0",
@@ -3422,6 +3423,7 @@ func TestDatabaseBackupHooksSidecar(t *testing.T) {
 		testlib.AssertEnvContains(t, sidecar.Env, "FREEZE_TIMEOUT", "30")
 		testlib.AssertEnvContains(t, sidecar.Env, "NUOCMD_API_SERVER", "nuodb.default.svc:8888")
 		testlib.AssertEnvNotContains(t, sidecar.Env, "NUODB_JOURNAL_DIR")
+		testlib.AssertEnvContains(t, sidecar.Env, "NUODB_CORES_DIR", "/mnt/log")
 		testlib.AssertEnvContains(t, sidecar.Env, "var0", "val0")
 		testlib.AssertEnvContains(t, sidecar.Env, "var1", "val1")
 		// Check volume mounts
@@ -3432,8 +3434,9 @@ func TestDatabaseBackupHooksSidecar(t *testing.T) {
 		assert.Contains(t, volumes, "archive-volume")
 		assert.Contains(t, volumes, "backup-hooks")
 		assert.NotContains(t, volumes, "journal-volume")
-		assert.Contains(t, volumes, "eph-volume")
+		assert.NotContains(t, volumes, "eph-volume")
 		assert.Contains(t, volumes, "tls")
+		assert.Contains(t, volumes, "log-volume")
 		assert.Contains(t, volumes, "volume0")
 		assert.Contains(t, volumes, "volume1")
 
@@ -3464,6 +3467,7 @@ func TestDatabaseBackupHooksSidecar(t *testing.T) {
 			SetValues: map[string]string{
 				"database.te.operationsSidecar.enabled":                   "true",
 				"database.te.operationsSidecar.resources.limits.memory":   "5Gi",
+				"database.te.logPersistence.enabled":                      "true",
 				"database.securityContext.enabledOnContainer":             "true",
 				"database.te.operationsSidecar.env[0].name":               "var0",
 				"database.te.operationsSidecar.env[0].value":              "val0",
@@ -3500,6 +3504,7 @@ func TestDatabaseBackupHooksSidecar(t *testing.T) {
 		testlib.AssertEnvNotContains(t, sidecar.Env, "FREEZE_TIMEOUT")
 		testlib.AssertEnvNotContains(t, sidecar.Env, "NUOCMD_API_SERVER")
 		testlib.AssertEnvNotContains(t, sidecar.Env, "NUODB_JOURNAL_DIR")
+		testlib.AssertEnvContains(t, sidecar.Env, "NUODB_CORES_DIR", "/mnt/log")
 		testlib.AssertEnvContains(t, sidecar.Env, "var0", "val0")
 		// Check volume mounts
 		volumes := make([]string, len(sidecar.VolumeMounts))
@@ -3511,6 +3516,7 @@ func TestDatabaseBackupHooksSidecar(t *testing.T) {
 		assert.NotContains(t, volumes, "journal-volume")
 		assert.NotContains(t, volumes, "eph-volume")
 		assert.NotContains(t, volumes, "tls")
+		assert.Contains(t, volumes, "log-volume")
 		assert.Contains(t, volumes, "volume0")
 
 		// Check resource limit


### PR DESCRIPTION
The database helm chart puts both the `NUODB_CRASHDIR` and `crashbackupdir` under `NUODB_LOGDIR`. In order to expose available cores, the operations sidecar needs access to this directory.

There are no tests that actually exercise dumping a core and accessing it via the operation sidecar because the published sidecar image does not include this capability yet.