### PR TITLE
Load nuocmd plugins from ConfigMaps in admin and database

### DIFF
--- a/stable/admin/README.md
+++ b/stable/admin/README.md
@@ -109,6 +109,7 @@ The following tables list the configurable parameters for the `nuodb` option:
 | `addServiceAccount` | Whether to create a new service account for NuoDB containers | `true` |
 | `addRoleBinding` | Whether to add role and role-binding giving `serviceAccount` access to Kubernetes APIs (Pods, PersistentVolumes, PersistentVolumeClaims, StatefulSets) | `true` |
 | `addClusterRoleBinding` | If `addRoleBinding` is enabled, also add cluster role and cluster role-binding giving `serviceAccount` access to Cluster wide Kubernetes APIs (read access to Nodes) | `true` |
+| `cmd.plugins` | Any `nuocmd` plugins to install in the container, as a map of filename to ConfigMap | `{}` |
 
 The `registry` option can be used to connect to private image repositories, such as Artifactory.
 

--- a/stable/admin/README.md
+++ b/stable/admin/README.md
@@ -109,7 +109,6 @@ The following tables list the configurable parameters for the `nuodb` option:
 | `addServiceAccount` | Whether to create a new service account for NuoDB containers | `true` |
 | `addRoleBinding` | Whether to add role and role-binding giving `serviceAccount` access to Kubernetes APIs (Pods, PersistentVolumes, PersistentVolumeClaims, StatefulSets) | `true` |
 | `addClusterRoleBinding` | If `addRoleBinding` is enabled, also add cluster role and cluster role-binding giving `serviceAccount` access to Cluster wide Kubernetes APIs (read access to Nodes) | `true` |
-| `cmd.plugins` | Any `nuocmd` plugins to install in the container, as a map of filename to ConfigMap | `{}` |
 
 The `registry` option can be used to connect to private image repositories, such as Artifactory.
 
@@ -233,6 +232,7 @@ The following tables list the configurable parameters for the `admin` option of 
 | `resourceLabels` | Custom labels attached to the Kubernetes resources installed by this Helm chart. The labels are immutable and can't be changed with Helm upgrade | `{}` |
 | `adminLabels` | Admin labels to apply to each Admin Process. Supported starting from NuoDB image version 6.0.3 | `{}`|
 | `env` | Additional environment variables to pass through to the Admin container | `[]`|
+| `nuocmdPlugins` | Any `nuocmd` plugins to install in the container, as a map with ConfigMap names as keys | `{}` |
 
 For example, when using GlusterFS storage class, you would supply the following parameter:
 

--- a/stable/admin/templates/_helpers.tpl
+++ b/stable/admin/templates/_helpers.tpl
@@ -628,3 +628,33 @@ Set tolerations for the AP pods.
 {{ toYaml .Values.admin.tolerations }}
 {{- end -}}
 {{- end }}
+
+{{/*
+Convert a nuocmd plugin filename into a valid kubernetes volume name.
+
+Argument: Plugin file name
+*/}}
+{{- define "nuodb.cmd.pluginNameToKey" -}}
+cmd-plugin-{{ . | replace "." "-" | replace "_" "-" }}
+{{- end -}}
+
+{{/*
+Get the file system path where a nuocmd plugin should be mounted.
+
+Argument: Plugin file name
+*/}}
+{{- define "nuodb.cmd.pluginNameToPath" -}}
+/opt/nuodb/etc/nuocmd-plugins/{{ . }}
+{{- end -}}
+
+{{/*
+Generate the NUOCMD_PLUGINS value, including any configured plugins.
+*/}}
+{{- define "nuodb.cmd.joinPluginNames" -}}
+{{- $plugins := keys .Values.nuodb.cmd.plugins -}}
+{{- $path := "/opt/nuodb/etc/nuodocker.py" -}}
+{{- range  $plugins -}}
+{{- $path = (printf "%s:%s" $path (include "nuodb.cmd.pluginNameToPath" . )) -}}
+{{- end -}}
+{{ $path }}
+{{- end -}}

--- a/stable/admin/templates/_helpers.tpl
+++ b/stable/admin/templates/_helpers.tpl
@@ -630,12 +630,12 @@ Set tolerations for the AP pods.
 {{- end }}
 
 {{/*
-Get the file system path where a nuocmd plugin should be mounted.
+Get the file system path where a given nuocmd plugin should be.
 
-Argument: Plugin file name
+Argument: Plugin file path relative to the plugin directory.
 */}}
 {{- define "admin.cmd.pluginNameToPath" -}}
-/opt/nuodb/etc/nuocmd-plugins/{{ . }}
+/etc/nuodb/nuocmd-plugins/{{ . }}
 {{- end -}}
 
 {{/*

--- a/stable/admin/templates/_helpers.tpl
+++ b/stable/admin/templates/_helpers.tpl
@@ -630,31 +630,62 @@ Set tolerations for the AP pods.
 {{- end }}
 
 {{/*
-Convert a nuocmd plugin filename into a valid kubernetes volume name.
-
-Argument: Plugin file name
-*/}}
-{{- define "nuodb.cmd.pluginNameToKey" -}}
-cmd-plugin-{{ . | replace "." "-" | replace "_" "-" }}
-{{- end -}}
-
-{{/*
 Get the file system path where a nuocmd plugin should be mounted.
 
 Argument: Plugin file name
 */}}
-{{- define "nuodb.cmd.pluginNameToPath" -}}
+{{- define "admin.cmd.pluginNameToPath" -}}
 /opt/nuodb/etc/nuocmd-plugins/{{ . }}
 {{- end -}}
 
 {{/*
 Generate the NUOCMD_PLUGINS value, including any configured plugins.
+
+Arguments:
+0: root context
+1: nuocmdPlugins map from values
 */}}
-{{- define "nuodb.cmd.joinPluginNames" -}}
-{{- $plugins := keys .Values.nuodb.cmd.plugins -}}
+{{- define "admin.cmd.joinPluginNames" -}}
+{{- $root := index . 0 -}}
+{{- $plugins := index . 1 -}}
 {{- $path := "/opt/nuodb/etc/nuodocker.py" -}}
-{{- range  $plugins -}}
-{{- $path = (printf "%s:%s" $path (include "nuodb.cmd.pluginNameToPath" . )) -}}
+{{- range $cmName, $keys := include "admin.getCmdPlugins" (list $root $plugins) | fromYaml }}
+  {{- range $key := $keys | fromYamlArray }}
+    {{- $path = (printf "%s:%s" $path (include "admin.cmd.pluginNameToPath" (printf "%s/%s" $cmName $key) )) -}}
+  {{- end }}
 {{- end -}}
 {{ $path }}
+{{- end -}}
+
+{{/*
+Get the keys from a ConfigMap.
+
+Arguments:
+0: root context
+1: ConfigMap name
+*/}}
+{{- define "admin.cmKeys" -}}
+{{- $root := index . 0 -}}
+{{- $cmName := index . 1 -}}
+{{- $namespace := default $root.Release.Namespace $root.Values.admin.namespace -}}
+{{- $cmBody := (lookup "v1" "ConfigMap" $namespace $cmName ) -}}
+{{ keys (dig "data" (dict) $cmBody) | toYaml }}
+{{- end -}}
+
+{{/*
+Get configured nuocmd plugins as a map of ConfigMap name to a list of key names.
+The return value is formatted as a YAML string.
+
+Arguments:
+0: root context
+1: nuocmdPlugins map from values
+*/}}
+{{- define "admin.getCmdPlugins" -}}
+{{- $root := index . 0 -}}
+{{- $plugins := index . 1 -}}
+{{- $pluginsByCm := dict -}}
+{{- range $cmName, $ignored := $plugins }}
+{{- $_ := set $pluginsByCm $cmName (include "admin.cmKeys" (list $root $cmName)) -}}
+{{- end }}
+{{ $pluginsByCm | toYaml }}
 {{- end -}}

--- a/stable/admin/templates/statefulset.yaml
+++ b/stable/admin/templates/statefulset.yaml
@@ -28,10 +28,9 @@ spec:
     metadata:
       name: {{ template "admin.fullname" . }}
       annotations:
-      {{- if .Values.admin.configFiles }}
-        {{- with .Values.admin.configFiles }}
-        checksum/config: {{ toYaml . | sha256sum }}
-        {{- end }}
+      {{- if (or .Values.admin.configFiles .Values.admin.nuocmdPlugins) }}
+        checksum/config: {{ dict "configFiles" .Values.admin.configFiles
+          "nuocmdPlugins" (include "admin.cmd.joinPluginNames" (list . .Values.admin.nuocmdPlugins) | quote) | toYaml | sha256sum }}
       {{- else }}
         checksum/config: "0"
       {{- end }}
@@ -152,9 +151,9 @@ spec:
         - { name: NUODOCKER_CONF_DIR, value: "/tmp"}
         {{- end }}
         {{- end }}
-        {{- if .Values.nuodb.cmd.plugins }}
+        {{- if .Values.admin.nuocmdPlugins }}
         - name: NUOCMD_PLUGINS
-          value: {{include "nuodb.cmd.joinPluginNames" . | quote}}
+          value: {{include "admin.cmd.joinPluginNames" (list . .Values.admin.nuocmdPlugins) | quote}}
         {{- end }}
         args:
           - "nuoadmin"
@@ -250,10 +249,9 @@ spec:
         {{- end }}
         {{- end }}
         {{- end }}
-        {{- range $name, $cm := .Values.nuodb.cmd.plugins }}
-        - name: {{ include "nuodb.cmd.pluginNameToKey" $name }}
-          mountPath: {{ include "nuodb.cmd.pluginNameToPath" $name }}
-          subPath: {{ $name }}
+        {{- if .Values.admin.nuocmdPlugins  }}
+        - name: nuocmd-plugins
+          mountPath: {{ include "admin.cmd.pluginNameToPath" "" }}
         {{- end }}
       {{- include "admin.nuodb.sidecar.collector" . | nindent 6 }}
       {{- include "nuodb.imagePullSecrets" . | indent 6 }}
@@ -313,10 +311,19 @@ spec:
           name: {{ template "admin.fullname" . }}-livenessprobe
           defaultMode: 0755
       {{- end }}
-      {{- range $name, $cm := .Values.nuodb.cmd.plugins }}
-      - name: {{ include "nuodb.cmd.pluginNameToKey" $name }}
-        configMap:
-          name: {{ $cm }}
+      {{- if .Values.admin.nuocmdPlugins }}
+      - name: nuocmd-plugins
+        projected:
+          sources:
+          {{- range $cmName, $keys := include "admin.getCmdPlugins" (list . .Values.admin.nuocmdPlugins) | fromYaml }}
+          - configMap:
+              name: {{ $cmName }}
+              items:
+              {{- range $key := $keys | fromYamlArray }}
+              - key: {{ $key }}
+                path: {{ printf "%s/%s" $cmName $key }}
+              {{- end }}
+          {{- end }}
       {{- end }}
   volumeClaimTemplates:
   - metadata:

--- a/stable/admin/templates/statefulset.yaml
+++ b/stable/admin/templates/statefulset.yaml
@@ -152,6 +152,10 @@ spec:
         - { name: NUODOCKER_CONF_DIR, value: "/tmp"}
         {{- end }}
         {{- end }}
+        {{- if .Values.nuodb.cmd.plugins }}
+        - name: NUOCMD_PLUGINS
+          value: {{include "nuodb.cmd.joinPluginNames" . | quote}}
+        {{- end }}
         args:
           - "nuoadmin"
           {{- if .Values.admin.evicted}}
@@ -246,6 +250,11 @@ spec:
         {{- end }}
         {{- end }}
         {{- end }}
+        {{- range $name, $cm := .Values.nuodb.cmd.plugins }}
+        - name: {{ include "nuodb.cmd.pluginNameToKey" $name }}
+          mountPath: {{ include "nuodb.cmd.pluginNameToPath" $name }}
+          subPath: {{ $name }}
+        {{- end }}
       {{- include "admin.nuodb.sidecar.collector" . | nindent 6 }}
       {{- include "nuodb.imagePullSecrets" . | indent 6 }}
       volumes:
@@ -303,6 +312,11 @@ spec:
         configMap:
           name: {{ template "admin.fullname" . }}-livenessprobe
           defaultMode: 0755
+      {{- end }}
+      {{- range $name, $cm := .Values.nuodb.cmd.plugins }}
+      - name: {{ include "nuodb.cmd.pluginNameToKey" $name }}
+        configMap:
+          name: {{ $cm }}
       {{- end }}
   volumeClaimTemplates:
   - metadata:

--- a/stable/admin/values.yaml
+++ b/stable/admin/values.yaml
@@ -72,12 +72,6 @@ nuodb:
   # StatefulSets is added to nuodb.serviceAccount
   addRoleBinding: true
 
-  # nuocmd plugins to install
-  cmd:
-    # map of ConfigMap key to ConfigMap name
-    plugins: {}
-      # nuocmd_plugin.py: myplugin-cm
-
 admin:
   # nameOverride: east
   # fullnameOverride: admin-east
@@ -441,6 +435,12 @@ admin:
   legacy:
     loadBalancerJob:
       enabled: false
+
+  # nuocmd plugins to install
+  # The format is a dictionary with ConfigMap names as keys. The value should be an
+  # empty dictionary and may be used in the future.
+  nuocmdPlugins: {}
+  #  myplugin-cm: {}
 
 nuocollector:
   enabled: false

--- a/stable/admin/values.yaml
+++ b/stable/admin/values.yaml
@@ -72,6 +72,12 @@ nuodb:
   # StatefulSets is added to nuodb.serviceAccount
   addRoleBinding: true
 
+  # nuocmd plugins to install
+  cmd:
+    # map of ConfigMap key to ConfigMap name
+    plugins: {}
+      # nuocmd_plugin.py: myplugin-cm
+
 admin:
   # nameOverride: east
   # fullnameOverride: admin-east

--- a/stable/database/README.md
+++ b/stable/database/README.md
@@ -104,6 +104,7 @@ The following tables list the configurable parameters for the `nuodb` option:
 | `image.pullSecrets` | Specify docker-registry secret names as an array | `[]` (does not add image pull secrets to deployed pods) |
 | `serviceAccount` | The name of the service account used by NuoDB Pods | `nuodb` |
 | `addRoleBinding` | Whether to add role and role-binding giving `serviceAccount` access to Kubernetes APIs (Pods, PersistentVolumes, PersistentVolumeClaims, StatefulSets) | `true` |
+| `cmd.plugins` | Any `nuocmd` plugins to install in the container, as a map of filename to ConfigMap | `{}` |
 
 The `registry` option can be used to connect to private image repositories, such as Artifactory.
 

--- a/stable/database/README.md
+++ b/stable/database/README.md
@@ -104,7 +104,6 @@ The following tables list the configurable parameters for the `nuodb` option:
 | `image.pullSecrets` | Specify docker-registry secret names as an array | `[]` (does not add image pull secrets to deployed pods) |
 | `serviceAccount` | The name of the service account used by NuoDB Pods | `nuodb` |
 | `addRoleBinding` | Whether to add role and role-binding giving `serviceAccount` access to Kubernetes APIs (Pods, PersistentVolumes, PersistentVolumeClaims, StatefulSets) | `true` |
-| `cmd.plugins` | Any `nuocmd` plugins to install in the container, as a map of filename to ConfigMap | `{}` |
 
 The `registry` option can be used to connect to private image repositories, such as Artifactory.
 
@@ -311,6 +310,7 @@ The following tables list the configurable parameters of the `database` chart an
 | `sm.operationsSidecar.customHandlers[*].path` | The HTTP request path to match on, which may contain path parameters in the form `{param_name}` | |
 | `sm.operationsSidecar.customHandlers[*].script` | The script to invoke when handling the matched request, which may reference path parameters, query parameters, or the request payload (as `$payload`). If the same variable name appears as a query and path parameter, or a path parameter appears named `$payload`, the path parameter takes precedence. | |
 | `sm.operationsSidecar.customHandlers[*].statusMappings` | Mapping of script exit codes to HTTP status codes | |
+| `sm.nuocmdPlugins` | Any `nuocmd` plugins to install in the container, as a map with ConfigMap names as keys | `{}` |
 | `te.enablePod` | Create deployment for TEs. By default, the TE Deployment is disabled if TP/SG is enabled and this is a "secondary" release. | `nil` |
 | `te.externalAccess.enabled` | Whether to deploy a Layer 4 service for the database | `false` |
 | `te.externalAccess.internalIP` | Whether to use an internal (to the cloud) or external (public) IP address for the load balancer. Only applies to external access of type `LoadBalancer` | `nil` |
@@ -363,6 +363,7 @@ The following tables list the configurable parameters of the `database` chart an
 | `te.autoscaling.keda.fallback` | The number of replicas to fall back to if a scaler is in an error state. See https://keda.sh/docs/latest/reference/scaledobject-spec/ | `{}` |
 | `te.autoscaling.keda.triggers` | List of triggers to activate scaling of the target resource. See https://keda.sh/docs/latest/scalers/ | `[]` |
 | `te.autoscaling.keda.annotations` | Custom annotations set on the ScaledObject resource | `{}` |
+| `te.nuocmdPlugins` | Any `nuocmd` plugins to install in the container, as a map with ConfigMap names as keys | `{}` |
 | `automaticProtocolUpgrade.enabled` | Enable automatic database protocol upgrade and a Transaction Engine (TE) restart as an upgrade finalization step done by Kubernetes Aware Admin (KAA). Applicable for NuoDB major versions upgrade only. Requires NuoDB 4.2.3+ | `false` |
 | `automaticProtocolUpgrade.tePreferenceQuery` | LBQuery expression to select the TE that will be restarted after a successful database protocol upgrade. Defaults to random Transaction Engine (TE) in MONITORED state | `""` |
 | `resourceLabels` | Custom labels attached to the Kubernetes resources installed by this Helm chart. The labels are immutable and can't be changed with Helm upgrade | `{}` |

--- a/stable/database/templates/_helpers.tpl
+++ b/stable/database/templates/_helpers.tpl
@@ -1440,12 +1440,12 @@ backupHooks values are used if there is an explicit value and database.backupHoo
 {{- end }}
 
 {{/*
-Get the file system path where a nuocmd plugin should be mounted.
+Get the file system path where a given nuocmd plugin should be.
 
-Argument: Plugin file name
+Argument: Plugin file path relative to the plugin directory.
 */}}
 {{- define "database.cmd.pluginNameToPath" -}}
-/opt/nuodb/etc/nuocmd-plugins/{{ . }}
+/etc/nuodb/nuocmd-plugins/{{ . }}
 {{- end -}}
 
 {{/*

--- a/stable/database/templates/_helpers.tpl
+++ b/stable/database/templates/_helpers.tpl
@@ -1440,31 +1440,62 @@ backupHooks values are used if there is an explicit value and database.backupHoo
 {{- end }}
 
 {{/*
-Convert a nuocmd plugin filename into a valid kubernetes volume name.
-
-Argument: Plugin file name
-*/}}
-{{- define "nuodb.cmd.pluginNameToKey" -}}
-cmd-plugin-{{ . | replace "." "-" | replace "_" "-" }}
-{{- end -}}
-
-{{/*
 Get the file system path where a nuocmd plugin should be mounted.
 
 Argument: Plugin file name
 */}}
-{{- define "nuodb.cmd.pluginNameToPath" -}}
+{{- define "database.cmd.pluginNameToPath" -}}
 /opt/nuodb/etc/nuocmd-plugins/{{ . }}
 {{- end -}}
 
 {{/*
 Generate the NUOCMD_PLUGINS value, including any configured plugins.
+
+Arguments:
+0: root context
+1: nuocmdPlugins map from values
 */}}
-{{- define "nuodb.cmd.joinPluginNames" -}}
-{{- $plugins := keys .Values.nuodb.cmd.plugins -}}
+{{- define "database.cmd.joinPluginNames" -}}
+{{- $root := index . 0 -}}
+{{- $plugins := index . 1 -}}
 {{- $path := "/opt/nuodb/etc/nuodocker.py" -}}
-{{- range  $plugins -}}
-{{- $path = (printf "%s:%s" $path (include "nuodb.cmd.pluginNameToPath" . )) -}}
+{{- range $cmName, $keys := include "database.getCmdPlugins" (list $root $plugins) | fromYaml }}
+  {{- range $key := $keys | fromYamlArray }}
+    {{- $path = (printf "%s:%s" $path (include "database.cmd.pluginNameToPath" (printf "%s/%s" $cmName $key) )) -}}
+  {{- end }}
 {{- end -}}
 {{ $path }}
+{{- end -}}
+
+{{/*
+Get the keys from a ConfigMap.
+
+Arguments:
+0: root context
+1: ConfigMap name
+*/}}
+{{- define "database.cmKeys" -}}
+{{- $root := index . 0 -}}
+{{- $cmName := index . 1 -}}
+{{- $namespace := default $root.Release.Namespace $root.Values.admin.namespace -}}
+{{- $cmBody := (lookup "v1" "ConfigMap" $namespace $cmName ) -}}
+{{ keys (dig "data" (dict) $cmBody) | toYaml }}
+{{- end -}}
+
+{{/*
+Get configured nuocmd plugins as a map of ConfigMap name to a list of key names.
+The return value is formatted as a YAML string.
+
+Arguments:
+0: root context
+1: nuocmdPlugins map from values
+*/}}
+{{- define "database.getCmdPlugins" -}}
+{{- $root := index . 0 -}}
+{{- $plugins := index . 1 -}}
+{{- $pluginsByCm := dict -}}
+{{- range $cmName, $ignored := $plugins }}
+{{- $_ := set $pluginsByCm $cmName (include "database.cmKeys" (list $root $cmName)) -}}
+{{- end }}
+{{ $pluginsByCm | toYaml }}
 {{- end -}}

--- a/stable/database/templates/_helpers.tpl
+++ b/stable/database/templates/_helpers.tpl
@@ -1438,3 +1438,33 @@ backupHooks values are used if there is an explicit value and database.backupHoo
 {{ $operationsValue }}
 {{- end }}
 {{- end }}
+
+{{/*
+Convert a nuocmd plugin filename into a valid kubernetes volume name.
+
+Argument: Plugin file name
+*/}}
+{{- define "nuodb.cmd.pluginNameToKey" -}}
+cmd-plugin-{{ . | replace "." "-" | replace "_" "-" }}
+{{- end -}}
+
+{{/*
+Get the file system path where a nuocmd plugin should be mounted.
+
+Argument: Plugin file name
+*/}}
+{{- define "nuodb.cmd.pluginNameToPath" -}}
+/opt/nuodb/etc/nuocmd-plugins/{{ . }}
+{{- end -}}
+
+{{/*
+Generate the NUOCMD_PLUGINS value, including any configured plugins.
+*/}}
+{{- define "nuodb.cmd.joinPluginNames" -}}
+{{- $plugins := keys .Values.nuodb.cmd.plugins -}}
+{{- $path := "/opt/nuodb/etc/nuodocker.py" -}}
+{{- range  $plugins -}}
+{{- $path = (printf "%s:%s" $path (include "nuodb.cmd.pluginNameToPath" . )) -}}
+{{- end -}}
+{{ $path }}
+{{- end -}}

--- a/stable/database/templates/deployment.yaml
+++ b/stable/database/templates/deployment.yaml
@@ -148,6 +148,10 @@ spec:
                 key: {{ .Values.admin.tlsKeyStore.passwordKey | default "password" }}
         {{- end }}
       {{- end }}
+          {{- if .Values.nuodb.cmd.plugins }}
+          - name: NUOCMD_PLUGINS
+            value: {{include "nuodb.cmd.joinPluginNames" . | quote}}
+          {{- end }}
         ports:
         - containerPort: 48006
           protocol: TCP
@@ -185,6 +189,11 @@ spec:
         - name: tls
           mountPath: /etc/nuodb/keys
           readOnly: true
+        {{- end }}
+        {{- range $name, $cm := .Values.nuodb.cmd.plugins }}
+        - name: {{ include "nuodb.cmd.pluginNameToKey" $name }}
+          mountPath: {{ include "nuodb.cmd.pluginNameToPath" $name }}
+          subPath: {{ $name }}
         {{- end }}
         readinessProbe:
           initialDelaySeconds: {{ default 5 .Values.database.te.readinessProbe.initialDelaySeconds }}
@@ -270,6 +279,11 @@ spec:
           configMap:
             name: {{ template "database.fullname" . }}-te-operations
             defaultMode: 0666
+        {{- end }}
+        {{- range $name, $cm := .Values.nuodb.cmd.plugins }}
+        - name: {{ include "nuodb.cmd.pluginNameToKey" $name }}
+          configMap:
+            name: {{ $cm }}
         {{- end }}
       dnsPolicy: ClusterFirst
       restartPolicy: Always

--- a/stable/database/templates/deployment.yaml
+++ b/stable/database/templates/deployment.yaml
@@ -285,7 +285,7 @@ spec:
         - name: nuocmd-plugins
           projected:
             sources:
-            {{- range $cmName, $keys := include "database.getCmdPlugins" (list . .Values.database.sm.nuocmdPlugins) | fromYaml }}
+            {{- range $cmName, $keys := include "database.getCmdPlugins" (list . .Values.database.te.nuocmdPlugins) | fromYaml }}
             - configMap:
                 name: {{ $cmName }}
                 items:

--- a/stable/database/templates/deployment.yaml
+++ b/stable/database/templates/deployment.yaml
@@ -29,8 +29,10 @@ spec:
   template:
     metadata:
       annotations:
-      {{- if (or .Values.database.configFiles .Values.database.te.operationsSidecar.enabled) }}
-        checksum/config: {{ dict "configFiles" .Values.database.configFiles "customHandlers" .Values.database.te.operationsSidecar.customHandlers | toYaml | sha256sum }}
+      {{- if (or .Values.database.configFiles .Values.database.te.operationsSidecar.enabled .Values.database.te.nuocmdPlugins) }}
+        checksum/config: {{ dict "configFiles" .Values.database.configFiles
+        "customHandlers" .Values.database.te.operationsSidecar.customHandlers
+        "nuocmdPlugins" (include "database.cmd.joinPluginNames" (list . .Values.database.te.nuocmdPlugins) | quote) | toYaml | sha256sum }}
       {{- else }}
         checksum/config: "0"
       {{- end }}
@@ -148,9 +150,9 @@ spec:
                 key: {{ .Values.admin.tlsKeyStore.passwordKey | default "password" }}
         {{- end }}
       {{- end }}
-          {{- if .Values.nuodb.cmd.plugins }}
+          {{- if .Values.database.te.nuocmdPlugins }}
           - name: NUOCMD_PLUGINS
-            value: {{include "nuodb.cmd.joinPluginNames" . | quote}}
+            value: {{include "database.cmd.joinPluginNames" (list . .Values.database.te.nuocmdPlugins) | quote}}
           {{- end }}
         ports:
         - containerPort: 48006
@@ -190,10 +192,9 @@ spec:
           mountPath: /etc/nuodb/keys
           readOnly: true
         {{- end }}
-        {{- range $name, $cm := .Values.nuodb.cmd.plugins }}
-        - name: {{ include "nuodb.cmd.pluginNameToKey" $name }}
-          mountPath: {{ include "nuodb.cmd.pluginNameToPath" $name }}
-          subPath: {{ $name }}
+        {{- if .Values.database.te.nuocmdPlugins  }}
+        - name: nuocmd-plugins
+          mountPath: {{ include "database.cmd.pluginNameToPath" "" }}
         {{- end }}
         readinessProbe:
           initialDelaySeconds: {{ default 5 .Values.database.te.readinessProbe.initialDelaySeconds }}
@@ -280,10 +281,19 @@ spec:
             name: {{ template "database.fullname" . }}-te-operations
             defaultMode: 0666
         {{- end }}
-        {{- range $name, $cm := .Values.nuodb.cmd.plugins }}
-        - name: {{ include "nuodb.cmd.pluginNameToKey" $name }}
-          configMap:
-            name: {{ $cm }}
+        {{- if .Values.database.te.nuocmdPlugins }}
+        - name: nuocmd-plugins
+          projected:
+            sources:
+            {{- range $cmName, $keys := include "database.getCmdPlugins" (list . .Values.database.sm.nuocmdPlugins) | fromYaml }}
+            - configMap:
+                name: {{ $cmName }}
+                items:
+                {{- range $key := $keys | fromYamlArray }}
+                - key: {{ $key }}
+                  path: {{ printf "%s/%s" $cmName $key }}
+                {{- end }}
+            {{- end }}
         {{- end }}
       dnsPolicy: ClusterFirst
       restartPolicy: Always

--- a/stable/database/templates/statefulset.yaml
+++ b/stable/database/templates/statefulset.yaml
@@ -198,6 +198,10 @@ spec:
               key: {{ .Values.admin.tlsKeyStore.passwordKey | default "password" }}
       {{- end }}
     {{- end }}
+        {{- if .Values.nuodb.cmd.plugins }}
+        - name: NUOCMD_PLUGINS
+          value: {{include "nuodb.cmd.joinPluginNames" . | quote}}
+        {{- end }}
         ports:
         - containerPort: 48006
           protocol: TCP
@@ -265,6 +269,11 @@ spec:
         {{- end }}
         {{- end }}
         {{- ( include "database.sm.extraMounts" . ) | nindent 8 }}
+        {{- range $name, $cm := .Values.nuodb.cmd.plugins }}
+        - name: {{ include "nuodb.cmd.pluginNameToKey" $name }}
+          mountPath: {{ include "nuodb.cmd.pluginNameToPath" $name }}
+          subPath: {{ $name }}
+        {{- end }}
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         readinessProbe:
@@ -420,6 +429,11 @@ spec:
       {{- include "nuocollector.volume" . | nindent 6 }}
       {{- end }}
       {{- include "database.sm.extraVolumes" . | nindent 6  }}
+      {{- range $name, $cm := .Values.nuodb.cmd.plugins }}
+      - name: {{ include "nuodb.cmd.pluginNameToKey" $name }}
+        configMap:
+          name: {{ $cm }}
+      {{- end }}
   volumeClaimTemplates:
   - metadata:
       name: archive-volume
@@ -662,6 +676,10 @@ spec:
               key: {{ .Values.admin.tlsKeyStore.passwordKey | default "password" }}
       {{- end }}
     {{- end }}
+        {{- if .Values.nuodb.cmd.plugins }}
+        - name: NUOCMD_PLUGINS
+          value: {{include "nuodb.cmd.joinPluginNames" . | quote}}
+        {{- end }}
         ports:
         - containerPort: 48006
           protocol: TCP
@@ -731,6 +749,11 @@ spec:
         {{- end }}
         {{- end }}
         {{- ( include "database.sm.extraMounts" . ) | nindent 8 }}
+        {{- range $name, $cm := .Values.nuodb.cmd.plugins }}
+        - name: {{ include "nuodb.cmd.pluginNameToKey" $name }}
+          mountPath: {{ include "nuodb.cmd.pluginNameToPath" $name }}
+          subPath: {{ $name }}
+        {{- end }}
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         readinessProbe:
@@ -793,6 +816,11 @@ spec:
       {{- include "nuocollector.volume" . | nindent 6 }}
       {{- end }}
       {{- include "database.sm.extraVolumes" . | nindent 6  }}
+      {{- range $name, $cm := .Values.nuodb.cmd.plugins }}
+      - name: {{ include "nuodb.cmd.pluginNameToKey" $name }}
+        configMap:
+          name: {{ $cm }}
+      {{- end }}
   volumeClaimTemplates:
   - metadata:
       name: archive-volume

--- a/stable/database/templates/statefulset.yaml
+++ b/stable/database/templates/statefulset.yaml
@@ -26,8 +26,11 @@ spec:
   template:
     metadata:
       annotations:
-      {{- if (or .Values.database.configFiles .Values.database.backupHooks.enabled) }}
-        checksum/config: {{ dict "configFiles" .Values.database.configFiles "customHandlers" .Values.database.backupHooks.customHandlers | toYaml | sha256sum }}
+      {{- if (or .Values.database.configFiles .Values.database.backupHooks.enabled .Values.database.sm.operationsSidecar.customHandlers .Values.database.sm.nuocmdPlugins) }}
+        checksum/config: {{ dict "configFiles" .Values.database.configFiles
+          "customHandlers" .Values.database.backupHooks.customHandlers
+          "operationsHandlers" .Values.database.sm.operationsSidecar.customHandlers
+          "nuocmdPlugins" (include "database.cmd.joinPluginNames" (list . .Values.database.sm.nuocmdPlugins) | quote) | toYaml | sha256sum }}
       {{- else }}
         checksum/config: "0"
       {{- end -}}
@@ -198,9 +201,9 @@ spec:
               key: {{ .Values.admin.tlsKeyStore.passwordKey | default "password" }}
       {{- end }}
     {{- end }}
-        {{- if .Values.nuodb.cmd.plugins }}
+        {{- if .Values.database.sm.nuocmdPlugins }}
         - name: NUOCMD_PLUGINS
-          value: {{include "nuodb.cmd.joinPluginNames" . | quote}}
+          value: {{include "database.cmd.joinPluginNames" (list . .Values.database.sm.nuocmdPlugins) | quote}}
         {{- end }}
         ports:
         - containerPort: 48006
@@ -269,10 +272,9 @@ spec:
         {{- end }}
         {{- end }}
         {{- ( include "database.sm.extraMounts" . ) | nindent 8 }}
-        {{- range $name, $cm := .Values.nuodb.cmd.plugins }}
-        - name: {{ include "nuodb.cmd.pluginNameToKey" $name }}
-          mountPath: {{ include "nuodb.cmd.pluginNameToPath" $name }}
-          subPath: {{ $name }}
+        {{- if .Values.database.sm.nuocmdPlugins  }}
+        - name: nuocmd-plugins
+          mountPath: {{ include "database.cmd.pluginNameToPath" "" }}
         {{- end }}
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
@@ -429,10 +431,19 @@ spec:
       {{- include "nuocollector.volume" . | nindent 6 }}
       {{- end }}
       {{- include "database.sm.extraVolumes" . | nindent 6  }}
-      {{- range $name, $cm := .Values.nuodb.cmd.plugins }}
-      - name: {{ include "nuodb.cmd.pluginNameToKey" $name }}
-        configMap:
-          name: {{ $cm }}
+      {{- if .Values.database.sm.nuocmdPlugins }}
+      - name: nuocmd-plugins
+        projected:
+          sources:
+          {{- range $cmName, $keys := include "database.getCmdPlugins" (list . .Values.database.sm.nuocmdPlugins) | fromYaml }}
+          - configMap:
+              name: {{ $cmName }}
+              items:
+              {{- range $key := $keys | fromYamlArray }}
+              - key: {{ $key }}
+                path: {{ printf "%s/%s" $cmName $key }}
+              {{- end }}
+          {{- end }}
       {{- end }}
   volumeClaimTemplates:
   - metadata:
@@ -501,10 +512,11 @@ spec:
   template:
     metadata:
       annotations:
-      {{- if .Values.database.configFiles }}
-        {{- with .Values.database.configFiles }}
-        checksum/config: {{ toYaml . | sha256sum }}
-        {{- end }}
+      {{- if (or .Values.database.configFiles .Values.database.backupHooks.enabled .Values.database.sm.operationsSidecar.customHandlers .Values.database.sm.nuocmdPlugins) }}
+        checksum/config: {{ dict "configFiles" .Values.database.configFiles
+          "customHandlers" .Values.database.backupHooks.customHandlers
+          "operationsHandlers" .Values.database.sm.operationsSidecar.customHandlers
+          "nuocmdPlugins" (include "database.cmd.joinPluginNames" (list . .Values.database.sm.nuocmdPlugins) | quote) | toYaml | sha256sum }}
       {{- else }}
         checksum/config: "0"
       {{- end }}
@@ -676,9 +688,9 @@ spec:
               key: {{ .Values.admin.tlsKeyStore.passwordKey | default "password" }}
       {{- end }}
     {{- end }}
-        {{- if .Values.nuodb.cmd.plugins }}
+        {{- if .Values.database.sm.nuocmdPlugins }}
         - name: NUOCMD_PLUGINS
-          value: {{include "nuodb.cmd.joinPluginNames" . | quote}}
+          value: {{include "database.cmd.joinPluginNames" (list . .Values.database.sm.nuocmdPlugins) | quote}}
         {{- end }}
         ports:
         - containerPort: 48006
@@ -749,10 +761,9 @@ spec:
         {{- end }}
         {{- end }}
         {{- ( include "database.sm.extraMounts" . ) | nindent 8 }}
-        {{- range $name, $cm := .Values.nuodb.cmd.plugins }}
-        - name: {{ include "nuodb.cmd.pluginNameToKey" $name }}
-          mountPath: {{ include "nuodb.cmd.pluginNameToPath" $name }}
-          subPath: {{ $name }}
+        {{- if .Values.database.sm.nuocmdPlugins  }}
+        - name: nuocmd-plugins
+          mountPath: {{ include "database.cmd.pluginNameToPath" "" }}
         {{- end }}
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
@@ -816,10 +827,19 @@ spec:
       {{- include "nuocollector.volume" . | nindent 6 }}
       {{- end }}
       {{- include "database.sm.extraVolumes" . | nindent 6  }}
-      {{- range $name, $cm := .Values.nuodb.cmd.plugins }}
-      - name: {{ include "nuodb.cmd.pluginNameToKey" $name }}
-        configMap:
-          name: {{ $cm }}
+      {{- if .Values.database.sm.nuocmdPlugins }}
+      - name: nuocmd-plugins
+        projected:
+          sources:
+          {{- range $cmName, $keys := include "database.getCmdPlugins" (list . .Values.database.sm.nuocmdPlugins) | fromYaml }}
+          - configMap:
+              name: {{ $cmName }}
+              items:
+              {{- range $key := $keys | fromYamlArray }}
+              - key: {{ $key }}
+                path: {{ printf "%s/%s" $cmName $key }}
+              {{- end }}
+          {{- end }}
       {{- end }}
   volumeClaimTemplates:
   - metadata:

--- a/stable/database/values.yaml
+++ b/stable/database/values.yaml
@@ -66,6 +66,12 @@ nuodb:
   # the name of the ServiceAccount to use for all NuoDB Pods
   serviceAccount: nuodb
 
+  # nuocmd plugins to install
+  cmd:
+    # map of ConfigMap key to ConfigMap name
+    plugins: {}
+      # nuocmd_plugin.py: myplugin-cm
+
 admin:
   # domain is the name of the NuoDB administration domain (e.g. the cluster name)
   domain: nuodb

--- a/stable/database/values.yaml
+++ b/stable/database/values.yaml
@@ -66,12 +66,6 @@ nuodb:
   # the name of the ServiceAccount to use for all NuoDB Pods
   serviceAccount: nuodb
 
-  # nuocmd plugins to install
-  cmd:
-    # map of ConfigMap key to ConfigMap name
-    plugins: {}
-      # nuocmd_plugin.py: myplugin-cm
-
 admin:
   # domain is the name of the NuoDB administration domain (e.g. the cluster name)
   domain: nuodb
@@ -704,6 +698,12 @@ database:
       #    "1": 400
       #    "*": 500
 
+    # nuocmd plugins to install
+    # The format is a dictionary with ConfigMap names as keys. The value should be an
+    # empty dictionary and may be used in the future.
+    nuocmdPlugins: {}
+    #  myplugin-cm: {}
+
   te:
     # Provision Transaction Engine (TE) Deployment. By default, the TE
     # Deployment is disabled if TP/SG is enabled and this is a "secondary"
@@ -922,6 +922,12 @@ database:
       #    "0": 200
       #    "1": 400
       #    "*": 500
+
+    # nuocmd plugins to install
+    # The format is a dictionary with ConfigMap names as keys. The value should be an
+    # empty dictionary and may be used in the future.
+    nuocmdPlugins: {}
+    #  myplugin-cm: {}
 
   # These annotations will pass through to the pod as supplied, useful for integrating 3rd party products such as Vault.
   podAnnotations: {}

--- a/test/integration/template_admin_test.go
+++ b/test/integration/template_admin_test.go
@@ -1787,8 +1787,8 @@ func TestAdminNuoCmdPlugins(t *testing.T) {
 	helmChartPath := testlib.ADMIN_HELM_CHART_PATH
 
 	options := &helm.Options{
-		SetValues: map[string]string{
-			"nuodb.cmd.plugins.nuocmd_plugin\\.py": "myplugin-cm",
+		SetJsonValues: map[string]string{
+			"admin.nuocmdPlugins.myplugin-cm": "{}",
 		},
 	}
 
@@ -1797,16 +1797,18 @@ func TestAdminNuoCmdPlugins(t *testing.T) {
 
 	for _, obj := range testlib.SplitAndRenderStatefulSet(t, output, 1) {
 		testlib.AssertEnvContains(t, obj.Spec.Template.Spec.Containers[0].Env, "NUOCMD_PLUGINS",
-			"/opt/nuodb/etc/nuodocker.py:/opt/nuodb/etc/nuocmd-plugins/nuocmd_plugin.py")
+			"/opt/nuodb/etc/nuodocker.py")
 
-		pluginVolumeMount, found := testlib.GetMount(obj.Spec.Template.Spec.Containers[0].VolumeMounts, "cmd-plugin-nuocmd-plugin-py")
-		require.True(t, found, "Expected to find a volume mount for nuocmd_plugin.py")
-		assert.Equal(t, "/opt/nuodb/etc/nuocmd-plugins/nuocmd_plugin.py", pluginVolumeMount.MountPath)
-		assert.Equal(t, "nuocmd_plugin.py", pluginVolumeMount.SubPath)
+		pluginVolumeMount, found := testlib.GetMount(obj.Spec.Template.Spec.Containers[0].VolumeMounts, "nuocmd-plugins")
+		require.True(t, found, "Expected to find a volume mount for nuocmd-plugins")
+		assert.Equal(t, "/opt/nuodb/etc/nuocmd-plugins/", pluginVolumeMount.MountPath)
 
-		pluginVolume, found := testlib.GetVolume(obj.Spec.Template.Spec.Volumes, "cmd-plugin-nuocmd-plugin-py")
-		require.True(t, found, "Expected to find a volume mount for nuocmd_plugin.py")
-		assert.NotNil(t, pluginVolume.ConfigMap)
-		assert.Equal(t, "myplugin-cm", pluginVolume.ConfigMap.Name)
+		pluginVolume, found := testlib.GetVolume(obj.Spec.Template.Spec.Volumes, "nuocmd-plugins")
+		require.True(t, found, "Expected to find a volume for nuocmd-plugins")
+		require.NotNil(t, pluginVolume.Projected)
+		require.NotNil(t, pluginVolume.Projected.Sources)
+		require.Equal(t, 1, len(pluginVolume.Projected.Sources))
+		require.NotNil(t, pluginVolume.Projected.Sources[0].ConfigMap)
+		assert.Equal(t, "myplugin-cm", pluginVolume.Projected.Sources[0].ConfigMap.Name)
 	}
 }

--- a/test/integration/template_admin_test.go
+++ b/test/integration/template_admin_test.go
@@ -1801,7 +1801,7 @@ func TestAdminNuoCmdPlugins(t *testing.T) {
 
 		pluginVolumeMount, found := testlib.GetMount(obj.Spec.Template.Spec.Containers[0].VolumeMounts, "nuocmd-plugins")
 		require.True(t, found, "Expected to find a volume mount for nuocmd-plugins")
-		assert.Equal(t, "/opt/nuodb/etc/nuocmd-plugins/", pluginVolumeMount.MountPath)
+		assert.Equal(t, "/etc/nuodb/nuocmd-plugins/", pluginVolumeMount.MountPath)
 
 		pluginVolume, found := testlib.GetVolume(obj.Spec.Template.Spec.Volumes, "nuocmd-plugins")
 		require.True(t, found, "Expected to find a volume for nuocmd-plugins")

--- a/test/integration/template_admin_test.go
+++ b/test/integration/template_admin_test.go
@@ -1781,3 +1781,32 @@ func TestAdminTolerationsAsString(t *testing.T) {
 		}
 	})
 }
+
+func TestAdminNuoCmdPlugins(t *testing.T) {
+	// Path to the helm chart we will test
+	helmChartPath := testlib.ADMIN_HELM_CHART_PATH
+
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"nuodb.cmd.plugins.nuocmd_plugin\\.py": "myplugin-cm",
+		},
+	}
+
+	// Run RenderTemplate to render the template and capture the output.
+	output := helm.RenderTemplate(t, options, helmChartPath, "release-name", []string{"templates/statefulset.yaml"})
+
+	for _, obj := range testlib.SplitAndRenderStatefulSet(t, output, 1) {
+		testlib.AssertEnvContains(t, obj.Spec.Template.Spec.Containers[0].Env, "NUOCMD_PLUGINS",
+			"/opt/nuodb/etc/nuodocker.py:/opt/nuodb/etc/nuocmd-plugins/nuocmd_plugin.py")
+
+		pluginVolumeMount, found := testlib.GetMount(obj.Spec.Template.Spec.Containers[0].VolumeMounts, "cmd-plugin-nuocmd-plugin-py")
+		require.True(t, found, "Expected to find a volume mount for nuocmd_plugin.py")
+		assert.Equal(t, "/opt/nuodb/etc/nuocmd-plugins/nuocmd_plugin.py", pluginVolumeMount.MountPath)
+		assert.Equal(t, "nuocmd_plugin.py", pluginVolumeMount.SubPath)
+
+		pluginVolume, found := testlib.GetVolume(obj.Spec.Template.Spec.Volumes, "cmd-plugin-nuocmd-plugin-py")
+		require.True(t, found, "Expected to find a volume mount for nuocmd_plugin.py")
+		assert.NotNil(t, pluginVolume.ConfigMap)
+		assert.Equal(t, "myplugin-cm", pluginVolume.ConfigMap.Name)
+	}
+}

--- a/test/integration/template_database_test.go
+++ b/test/integration/template_database_test.go
@@ -4316,7 +4316,7 @@ func TestDatabaseNuoCmdPlugins(t *testing.T) {
 
 		pluginVolumeMount, found := testlib.GetMount(pod.Spec.Containers[0].VolumeMounts, "nuocmd-plugins")
 		require.True(t, found, "Expected to find a volume mount for nuocmd-plugins")
-		assert.Equal(t, "/opt/nuodb/etc/nuocmd-plugins/", pluginVolumeMount.MountPath)
+		assert.Equal(t, "/etc/nuodb/nuocmd-plugins/", pluginVolumeMount.MountPath)
 
 		pluginVolume, found := testlib.GetVolume(pod.Spec.Volumes, "nuocmd-plugins")
 		require.True(t, found, "Expected to find a volume for nuocmd-plugins")

--- a/test/integration/template_database_test.go
+++ b/test/integration/template_database_test.go
@@ -4308,3 +4308,46 @@ func TestDatabaseTolerationsAsString(t *testing.T) {
 		}
 	})
 }
+
+func TestDatabaseNuoCmdPlugins(t *testing.T) {
+	testPod := func(t *testing.T, pod corev1.PodTemplateSpec) {
+		testlib.AssertEnvContains(t, pod.Spec.Containers[0].Env, "NUOCMD_PLUGINS",
+			"/opt/nuodb/etc/nuodocker.py:/opt/nuodb/etc/nuocmd-plugins/nuocmd_plugin.py")
+
+		pluginVolumeMount, found := testlib.GetMount(pod.Spec.Containers[0].VolumeMounts, "cmd-plugin-nuocmd-plugin-py")
+		require.True(t, found, "Expected to find a volume mount for nuocmd_plugin.py")
+		assert.Equal(t, "/opt/nuodb/etc/nuocmd-plugins/nuocmd_plugin.py", pluginVolumeMount.MountPath)
+		assert.Equal(t, "nuocmd_plugin.py", pluginVolumeMount.SubPath)
+
+		pluginVolume, found := testlib.GetVolume(pod.Spec.Volumes, "cmd-plugin-nuocmd-plugin-py")
+		require.True(t, found, "Expected to find a volume mount for nuocmd_plugin.py")
+		require.NotNil(t, pluginVolume.ConfigMap)
+		assert.Equal(t, "myplugin-cm", pluginVolume.ConfigMap.Name)
+	}
+
+	// Path to the helm chart we will test
+	helmChartPath := testlib.DATABASE_HELM_CHART_PATH
+
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"nuodb.cmd.plugins.nuocmd_plugin\\.py": "myplugin-cm",
+		},
+	}
+
+	// Run RenderTemplate to render the template and capture the output.
+	output := helm.RenderTemplate(t, options, helmChartPath, "release-name", []string{"templates/statefulset.yaml"})
+
+	for _, obj := range testlib.SplitAndRenderStatefulSet(t, output, 2) {
+		t.Run("testSm_"+obj.Name, func(t *testing.T) {
+			testPod(t, obj.Spec.Template)
+		})
+	}
+
+	output = helm.RenderTemplate(t, options, helmChartPath, "release-name", []string{"templates/deployment.yaml"})
+
+	for _, obj := range testlib.SplitAndRenderDeployment(t, output, 1) {
+		t.Run("testTe", func(t *testing.T) {
+			testPod(t, obj.Spec.Template)
+		})
+	}
+}

--- a/test/integration/template_database_test.go
+++ b/test/integration/template_database_test.go
@@ -4312,17 +4312,19 @@ func TestDatabaseTolerationsAsString(t *testing.T) {
 func TestDatabaseNuoCmdPlugins(t *testing.T) {
 	testPod := func(t *testing.T, pod corev1.PodTemplateSpec) {
 		testlib.AssertEnvContains(t, pod.Spec.Containers[0].Env, "NUOCMD_PLUGINS",
-			"/opt/nuodb/etc/nuodocker.py:/opt/nuodb/etc/nuocmd-plugins/nuocmd_plugin.py")
+			"/opt/nuodb/etc/nuodocker.py")
 
-		pluginVolumeMount, found := testlib.GetMount(pod.Spec.Containers[0].VolumeMounts, "cmd-plugin-nuocmd-plugin-py")
-		require.True(t, found, "Expected to find a volume mount for nuocmd_plugin.py")
-		assert.Equal(t, "/opt/nuodb/etc/nuocmd-plugins/nuocmd_plugin.py", pluginVolumeMount.MountPath)
-		assert.Equal(t, "nuocmd_plugin.py", pluginVolumeMount.SubPath)
+		pluginVolumeMount, found := testlib.GetMount(pod.Spec.Containers[0].VolumeMounts, "nuocmd-plugins")
+		require.True(t, found, "Expected to find a volume mount for nuocmd-plugins")
+		assert.Equal(t, "/opt/nuodb/etc/nuocmd-plugins/", pluginVolumeMount.MountPath)
 
-		pluginVolume, found := testlib.GetVolume(pod.Spec.Volumes, "cmd-plugin-nuocmd-plugin-py")
-		require.True(t, found, "Expected to find a volume mount for nuocmd_plugin.py")
-		require.NotNil(t, pluginVolume.ConfigMap)
-		assert.Equal(t, "myplugin-cm", pluginVolume.ConfigMap.Name)
+		pluginVolume, found := testlib.GetVolume(pod.Spec.Volumes, "nuocmd-plugins")
+		require.True(t, found, "Expected to find a volume for nuocmd-plugins")
+		require.NotNil(t, pluginVolume.Projected)
+		require.NotNil(t, pluginVolume.Projected.Sources)
+		require.Equal(t, 1, len(pluginVolume.Projected.Sources))
+		require.NotNil(t, pluginVolume.Projected.Sources[0].ConfigMap)
+		assert.Equal(t, "myplugin-cm", pluginVolume.Projected.Sources[0].ConfigMap.Name)
 	}
 
 	// Path to the helm chart we will test
@@ -4330,7 +4332,8 @@ func TestDatabaseNuoCmdPlugins(t *testing.T) {
 
 	options := &helm.Options{
 		SetValues: map[string]string{
-			"nuodb.cmd.plugins.nuocmd_plugin\\.py": "myplugin-cm",
+			"database.sm.nuocmdPlugins.myplugin-cm": "{}",
+			"database.te.nuocmdPlugins.myplugin-cm": "{}",
 		},
 	}
 

--- a/test/minikube/minikube_base_database_test.go
+++ b/test/minikube/minikube_base_database_test.go
@@ -635,3 +635,92 @@ func TestKubernetesRestrictedDatabase(t *testing.T) {
 
 	t.Run("verifyNuoSQL", func(t *testing.T) { verifyNuoSQL(t, namespaceName, admin0, "demo") })
 }
+
+func TestNuocmdPluginInjection(t *testing.T) {
+	defer testlib.VerifyTeardown(t)
+
+	defer testlib.Teardown(testlib.TEARDOWN_ADMIN)
+	randomSuffix := strings.ToLower(random.UniqueId())
+	callerName := "TestNuocmdPluginInjection"
+	namespaceName := fmt.Sprintf("%s-%s", strings.ToLower(callerName), randomSuffix)
+
+	testlib.CreateNamespace(t, namespaceName)
+
+	adminPlugin := `from pynuoadmin import nuodb_cli
+class AdminPlugin(nuodb_cli.AdminCommands):
+	@nuodb_cli.subcommand
+	def admin_command(self):
+		self._print("ADMIN COMMAND")
+`
+
+	defer testlib.Teardown(testlib.TEARDOWN_CONFIG_MAP)
+	testlib.CreateConfigMap(t, namespaceName, "admin-plugin", map[string]string{
+		"plugin.py": adminPlugin,
+	})
+
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"admin.nuocmdPlugins.admin-plugin": "",
+		},
+	}
+
+	helmChartReleaseName, namespaceName := testlib.StartAdmin(t, options, 1, namespaceName)
+
+	admin0 := fmt.Sprintf("%s-nuodb-cluster0-0", helmChartReleaseName)
+
+	kubectlOptions := k8s.NewKubectlOptions("", "", namespaceName)
+	out, err := k8s.RunKubectlAndGetOutputE(t, kubectlOptions, "exec", admin0, "-c", "admin", "--",
+		"nuocmd", "admin", "command")
+	require.NoError(t, err)
+	require.Contains(t, out, "ADMIN COMMAND")
+
+	smPlugin := `from pynuoadmin import nuodb_cli
+class SmPlugin(nuodb_cli.AdminCommands):
+	@nuodb_cli.subcommand
+	def sm_command(self):
+		self._print("SM COMMAND")
+`
+	testlib.CreateConfigMap(t, namespaceName, "sm-plugin", map[string]string{
+		"plugin.py": smPlugin,
+	})
+
+	tePlugin := `from pynuoadmin import nuodb_cli
+class TePlugin(nuodb_cli.AdminCommands):
+	@nuodb_cli.subcommand
+	def te_command(self):
+		self._print("TE COMMAND")
+`
+	testlib.CreateConfigMap(t, namespaceName, "te-plugin", map[string]string{
+		"plugin.py": tePlugin,
+	})
+
+	defer testlib.Teardown(testlib.TEARDOWN_DATABASE)
+
+	databaseOptions := helm.Options{
+		SetValues: map[string]string{
+			"database.sm.resources.requests.cpu":    testlib.MINIMAL_VIABLE_ENGINE_CPU,
+			"database.sm.resources.requests.memory": testlib.MINIMAL_VIABLE_ENGINE_MEMORY,
+			"database.te.resources.requests.cpu":    testlib.MINIMAL_VIABLE_ENGINE_CPU,
+			"database.te.resources.requests.memory": testlib.MINIMAL_VIABLE_ENGINE_MEMORY,
+			"database.sm.nuocmdPlugins.sm-plugin":   "",
+			"database.te.nuocmdPlugins.te-plugin":   "",
+		},
+	}
+	databaseChartName := testlib.StartDatabase(t, namespaceName, admin0, &databaseOptions)
+
+	opt := testlib.GetExtractedOptions(&databaseOptions)
+	tePodNameTemplate := fmt.Sprintf("te-%s-nuodb-%s-%s", databaseChartName, opt.ClusterName, opt.DbName)
+	smPodNameTemplate := fmt.Sprintf("sm-%s-nuodb-%s-%s", databaseChartName, opt.ClusterName, opt.DbName)
+	tePodName := testlib.GetPodName(t, namespaceName, tePodNameTemplate)
+	smPodName := testlib.GetPodName(t, namespaceName, smPodNameTemplate)
+
+	out, err = k8s.RunKubectlAndGetOutputE(t, kubectlOptions, "exec", smPodName, "-c", "engine", "--",
+		"nuocmd", "sm", "command")
+	require.NoError(t, err)
+	require.Contains(t, out, "SM COMMAND")
+
+	out, err = k8s.RunKubectlAndGetOutputE(t, kubectlOptions, "exec", tePodName, "-c", "engine", "--",
+		"nuocmd", "te", "command")
+	require.NoError(t, err)
+	require.Contains(t, out, "TE COMMAND")
+}

--- a/test/testlib/constants.go
+++ b/test/testlib/constants.go
@@ -30,6 +30,7 @@ const TEARDOWN_MULTICLUSTER = "multicluster"
 const TEARDOWN_NGINX = "nginx"
 const TEARDOWN_HAPROXY = "haproxy"
 const TEARDOWN_CSIDRIVER_FS = "csidriver-fs"
+const TEARDOWN_CONFIG_MAP = "config-map"
 
 const ADMIN_HELM_CHART_PATH = "../../stable/admin"
 const DATABASE_HELM_CHART_PATH = "../../stable/database"

--- a/test/testlib/minikube_utilities.go
+++ b/test/testlib/minikube_utilities.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/Masterminds/semver/v3"
+	"github.com/ghodss/yaml"
 	"github.com/gruntwork-io/terratest/modules/helm"
 	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/stretchr/testify/require"
@@ -1452,4 +1453,31 @@ func Retry(t *testing.T, fn func() error, attempts int, interval time.Duration) 
 		return err
 	}
 	return nil
+}
+
+const CONFIG_MAP_YAML_TEMPLATE = `---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: %s
+  namespace: %s
+apiVersion: v1
+data:
+  %s
+`
+
+func CreateConfigMap(t *testing.T, namespaceName string, cmName string, data map[string]string) {
+	kubectlOptions := k8s.NewKubectlOptions("", "", namespaceName)
+
+	var dataItems []string
+	for k, v := range data {
+		encodedValue, err := yaml.Marshal(v)
+		require.NoError(t, err)
+		dataItems = append(dataItems, fmt.Sprintf("%s: %s", k, encodedValue))
+	}
+
+	text := fmt.Sprintf(CONFIG_MAP_YAML_TEMPLATE, cmName, namespaceName, strings.Join(dataItems, "\n  "))
+	k8s.KubectlApplyFromString(t, kubectlOptions, text)
+
+	AddTeardown(TEARDOWN_CONFIG_MAP, func() { k8s.KubectlDeleteFromStringE(t, kubectlOptions, text) })
 }


### PR DESCRIPTION
Add support for loading `nuocmd` plugins stored in ConfigMaps.

Review note:
The changes under `stable/database/` are copied from the `admin` chart, feel free to skim them.