### PR TITLE
Expose backup cancelation rules for SM operations sidecar

### DIFF
--- a/stable/database/README.md
+++ b/stable/database/README.md
@@ -279,12 +279,14 @@ The following tables list the configurable parameters of the `database` chart an
 | `sm.hotCopy.journalPath.accessModes` | Volume access modes enabled (must match capabilities of the storage class) | `ReadWriteOnce` |
 | `sm.hotCopy.journalPath.size` | Amount of disk space allocated for SM journal | `20Gi` |
 | `sm.hotCopy.journalPath.storageClass` | Storage class for SM journal.  This storage class must be pre-configured in the cluster | `-` |
+| `sm.hotCopy.volumeMounts` | Extra volume mounts for the `engine` container. See [here](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#volumemount-v1-core). | `[]` |
 | `sm.noHotCopy.replicas` | SM replicas with hot-copy disabled | `0` |
 | `sm.noHotCopy.enablePod` | Create StatefulSet for non-hot-copy SMs | `true` |
 | `sm.noHotCopy.journalPath.enabled` | Whether to enable separate SM journal directory. For more info, read the [Journal HowTo](../../docs/HowToArchiveJournal.md) | `false` |
 | `sm.noHotCopy.journalPath.accessModes` | Volume access modes enabled (must match capabilities of the storage class) | `ReadWriteOnce` |
 | `sm.noHotCopy.journalPath.size` | Amount of disk space allocated for SM journal | `20Gi` |
 | `sm.noHotCopy.journalPath.storageClass` | Storage class for SM journal.  This storage class must be pre-configured in the cluster | `-` |
+| `sm.noHotCopy.volumeMounts` | Extra volume mounts for the `engine` container. See [here](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#volumemount-v1-core). | `[]` |
 | `sm.labels` | Labels given to the SMs started | `{}` |
 | `sm.engineOptions` | Additional NuoDB engine options | `{}` |
 | `sm.resources` | Labels to apply to all resources | `{}` |
@@ -310,6 +312,13 @@ The following tables list the configurable parameters of the `database` chart an
 | `sm.operationsSidecar.customHandlers[*].path` | The HTTP request path to match on, which may contain path parameters in the form `{param_name}` | |
 | `sm.operationsSidecar.customHandlers[*].script` | The script to invoke when handling the matched request, which may reference path parameters, query parameters, or the request payload (as `$payload`). If the same variable name appears as a query and path parameter, or a path parameter appears named `$payload`, the path parameter takes precedence. | |
 | `sm.operationsSidecar.customHandlers[*].statusMappings` | Mapping of script exit codes to HTTP status codes | |
+| `sm.operationsSidecar.cancelBackupRules` | Backup cancelation policy rules | `[]` |
+| `sm.operationsSidecar.cancelBackupRules[*].name` | Rule name | |
+| `sm.operationsSidecar.cancelBackupRules[*].type` | Rule type. Supported values are `journalUtilization` and `script` | |
+| `sm.operationsSidecar.cancelBackupRules[*].op` | The operator for comparing rule's value with rule's threshold. Supported values are `>`, `<`, `>=`, `<=`, `==` and `!=` | |
+| `sm.operationsSidecar.cancelBackupRules[*].threshold` | The threshold for comparing the current value against | |
+| `sm.operationsSidecar.cancelBackupRules[*].duration` | The duration in seconds for which the rule's criteria must be met constantly so that the backup operation is canceled | |
+| `sm.operationsSidecar.cancelBackupRules[*].script` | The script to invoke when obtaining the rule's current value. Only supported for cancelation rules of type `script` | |
 | `te.enablePod` | Create deployment for TEs. By default, the TE Deployment is disabled if TP/SG is enabled and this is a "secondary" release. | `nil` |
 | `te.externalAccess.enabled` | Whether to deploy a Layer 4 service for the database | `false` |
 | `te.externalAccess.internalIP` | Whether to use an internal (to the cloud) or external (public) IP address for the load balancer. Only applies to external access of type `LoadBalancer` | `nil` |

--- a/stable/database/templates/_helpers.tpl
+++ b/stable/database/templates/_helpers.tpl
@@ -1438,3 +1438,14 @@ backupHooks values are used if there is an explicit value and database.backupHoo
 {{ $operationsValue }}
 {{- end }}
 {{- end }}
+
+{{- define "database.sm.operationsSidecar.handlersJson" -}}
+{{- $smHandlers := (list) -}}
+{{- if and ( eq (include "defaultfalse" .Values.database.backupHooks.enabled) "true") .Values.database.backupHooks.customHandlers -}}
+{{- $smHandlers = concat $smHandlers .Values.database.backupHooks.customHandlers -}}
+{{- end -}}
+{{- if and ( eq (include "defaultfalse" .Values.database.sm.operationsSidecar.enabled) "true") .Values.database.sm.operationsSidecar.customHandlers -}}
+{{- $smHandlers = concat $smHandlers .Values.database.sm.operationsSidecar.customHandlers -}}
+{{- end -}}
+{{ $smHandlers | toJson }}
+{{- end -}}

--- a/stable/database/templates/configmap.yaml
+++ b/stable/database/templates/configmap.yaml
@@ -35,15 +35,6 @@ metadata:
 data:
 {{ (.Files.Glob "files/readinessprobe").AsConfig | indent 2 }}
 {{- if eq (include "database.sm.operationsSidecar.enabled" . ) "true" }}
-{{- $smHandlers := (list) -}}
-{{- if and ( eq (include "defaultfalse" .Values.database.backupHooks.enabled) "true")
-    .Values.database.backupHooks.customHandlers -}}
-{{- $smHandlers = concat $smHandlers .Values.database.backupHooks.customHandlers -}}
-{{- end }}
-{{- if and ( eq (include "defaultfalse" .Values.database.sm.operationsSidecar.enabled) "true")
-    .Values.database.sm.operationsSidecar.customHandlers -}}
-{{- $smHandlers = concat $smHandlers .Values.database.sm.operationsSidecar.customHandlers -}}
-{{- end }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -54,7 +45,11 @@ metadata:
 data:
   handlers.json: |
     {
-      "handlers": {{ $smHandlers | toJson }}
+      "handlers": {{ include "database.sm.operationsSidecar.handlersJson" . }}
+    }
+  cancel-policy.json: |
+    {
+      "rules": {{ .Values.database.sm.operationsSidecar.cancelBackupRules | toJson }}
     }
 {{- end }}
 {{- if eq (include "defaultfalse" .Values.database.te.operationsSidecar.enabled) "true" }}

--- a/stable/database/templates/statefulset.yaml
+++ b/stable/database/templates/statefulset.yaml
@@ -27,7 +27,7 @@ spec:
     metadata:
       annotations:
       {{- if (or .Values.database.configFiles .Values.database.backupHooks.enabled) }}
-        checksum/config: {{ dict "configFiles" .Values.database.configFiles "customHandlers" .Values.database.backupHooks.customHandlers | toYaml | sha256sum }}
+        checksum/config: {{ (dict "configFiles" .Values.database.configFiles "customHandlers" (include "database.sm.operationsSidecar.handlersJson" . | fromJson) "cancelBackupRules" .Values.database.sm.operationsSidecar.cancelBackupRules) | toYaml | sha256sum }}
       {{- else }}
         checksum/config: "0"
       {{- end -}}
@@ -264,6 +264,9 @@ spec:
         {{- end }}
         {{- end }}
         {{- end }}
+        {{- with .Values.database.sm.noHotCopy.volumeMounts }}
+        {{- toYaml . | trim | nindent 8 }}
+        {{- end }}
         {{- ( include "database.sm.extraMounts" . ) | nindent 8 }}
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
@@ -329,6 +332,9 @@ spec:
         - name: backup-hooks
           mountPath: /etc/nuodb/handlers.json
           subPath: handlers.json
+        - name: backup-hooks
+          mountPath: /etc/nuodb/cancel-policy.json
+          subPath: cancel-policy.json
         - name: archive-volume
           mountPath: /mnt/archive
         {{- if eq (include "defaultfalse" .Values.database.sm.noHotCopy.journalPath.enabled) "true" }}
@@ -729,6 +735,9 @@ spec:
         {{- end }}
         {{- end }}
         {{- end }}
+        {{- end }}
+        {{- with .Values.database.sm.hotCopy.volumeMounts }}
+        {{- toYaml . | trim | nindent 8 }}
         {{- end }}
         {{- ( include "database.sm.extraMounts" . ) | nindent 8 }}
         terminationMessagePath: /dev/termination-log

--- a/stable/database/templates/statefulset.yaml
+++ b/stable/database/templates/statefulset.yaml
@@ -27,7 +27,10 @@ spec:
     metadata:
       annotations:
       {{- if (or .Values.database.configFiles .Values.database.backupHooks.enabled) }}
-        checksum/config: {{ (dict "configFiles" .Values.database.configFiles "customHandlers" (include "database.sm.operationsSidecar.handlersJson" . | fromJson) "cancelBackupRules" .Values.database.sm.operationsSidecar.cancelBackupRules) | toYaml | sha256sum }}
+        {{- $config := dict "configFiles" .Values.database.configFiles }}
+        {{- $_ := set $config "customHandlers" (include "database.sm.operationsSidecar.handlersJson" . | fromJson) }}
+        {{- $_ := set $config "cancelBackupRules" .Values.database.sm.operationsSidecar.cancelBackupRules }}
+        checksum/config: {{ $config | toYaml | sha256sum }}
       {{- else }}
         checksum/config: "0"
       {{- end -}}

--- a/stable/database/values.schema.json
+++ b/stable/database/values.schema.json
@@ -158,6 +158,63 @@
                             "script"
                         ]
                     }
+                },
+                "cancelBackupRules": {
+                    "type": "array",
+                    "items": {
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "type": {
+                                "type": "string",
+                                "enum": [
+                                    "journalUtilization",
+                                    "script"
+                                ]
+                            },
+                            "op": {
+                                "type": "string",
+                                "enum": [
+                                    ">",
+                                    ">=",
+                                    "<",
+                                    "<=",
+                                    "==",
+                                    "!="
+                                ]
+                            },
+                            "threshold": {
+                                "type": "number"
+                            },
+                            "duration": {
+                                "type": "number",
+                                "minimum": 0
+                            },
+                            "script": {
+                                "type": "string"
+                            }
+                        },
+                        "if": {
+                            "properties": {
+                                "type": {
+                                    "const": "script"
+                                }
+                            }
+                        },
+                        "then": {
+                            "required": [
+                                "name",
+                                "script"
+                            ]
+                        },
+                        "required": [
+                            "type",
+                            "op",
+                            "threshold",
+                            "duration"
+                        ]
+                    }
                 }
             }
         }

--- a/stable/database/values.schema.json
+++ b/stable/database/values.schema.json
@@ -185,11 +185,27 @@
                                 ]
                             },
                             "threshold": {
-                                "type": "number"
+                                "anyOf": [
+                                    {
+                                        "type": "number"
+                                    },
+                                    {
+                                        "type": "string",
+                                        "pattern": "^-?\\d+(\\.\\d+)?$"
+                                    }
+                                ]
                             },
                             "duration": {
-                                "type": "number",
-                                "minimum": 0
+                                "anyOf": [
+                                    {
+                                        "type": "number",
+                                        "minimum": 0
+                                    },
+                                    {
+                                        "type": "string",
+                                        "pattern": "^\\d+(\\.\\d+)?$"
+                                    }
+                                ]
                             },
                             "script": {
                                 "type": "string"

--- a/stable/database/values.yaml
+++ b/stable/database/values.yaml
@@ -554,6 +554,12 @@ database:
         # the requested hotcopy operation to complete
         timeout: 0
 
+      # Extra volume mounts for backup-hooks container. See
+      # https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#volumemount-v1-core
+      volumeMounts: []
+      # - name: extras
+      #   mountPath: /mnt/extras
+
     # Number of storage manager (SM) nodes that do not have hotcopy backup enabled.
     # SM Limit is 1 in CE version of NuoDB
     # These SMs do not have hotcopy enabled, to start SMs with hotcopy use
@@ -569,6 +575,12 @@ database:
           accessModes:
             - ReadWriteOnce
           # storageClass: "-"
+
+      # Extra volume mounts for backup-hooks container. See
+      # https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#volumemount-v1-core
+      volumeMounts: []
+      # - name: extras
+      #   mountPath: /mnt/extras
 
     ## resources
     # k8s resource min (request) and max (limit)
@@ -647,7 +659,7 @@ database:
       image:
         registry: ghcr.io
         repository: nuodb/nuodb-sidecar
-        tag: 1.0.3
+        tag: 1.2.0
         pullPolicy: IfNotPresent
 
       # Kubernetes resource requests and limits used for the backup hooks sidecar
@@ -697,6 +709,22 @@ database:
       #    "0": 200
       #    "1": 400
       #    "*": 500
+
+      cancelBackupRules: []
+
+      #cancelBackupRules:
+      #- type: journalUtilization
+      #  op: ">"
+      #  threshold: 80
+      #  duration: 60
+      #- type: script
+      #  name: Memory throttling
+      #  op: ">"
+      #  threshold: 0
+      #  duration: 60
+      #  script: |
+      #    curl -s http://localhost:9001/metrics | grep -E '^nuodb_MemoryThrottleTime_raw' | cut -d' ' -f2
+
 
   te:
     # Provision Transaction Engine (TE) Deployment. By default, the TE
@@ -866,7 +894,7 @@ database:
       image:
         registry: ghcr.io
         repository: nuodb/nuodb-sidecar
-        tag: 1.0.3
+        tag: 1.2.0
         pullPolicy: IfNotPresent
 
       # Kubernetes resource requests and limits used for the backup hooks sidecar
@@ -976,7 +1004,7 @@ nuocollector:
     enabled: true
     registry: ghcr.io
     repository: nuodb/nuodb-sidecar
-    tag: 1.0.3
+    tag: 1.2.0
     pullPolicy: IfNotPresent
 
   # Kubernetes resource requests and limits used for the nuocollector sidecar

--- a/stable/database/values.yaml
+++ b/stable/database/values.yaml
@@ -659,7 +659,7 @@ database:
       image:
         registry: ghcr.io
         repository: nuodb/nuodb-sidecar
-        tag: 1.2.0
+        tag: 1.2.1
         pullPolicy: IfNotPresent
 
       # Kubernetes resource requests and limits used for the backup hooks sidecar
@@ -894,7 +894,7 @@ database:
       image:
         registry: ghcr.io
         repository: nuodb/nuodb-sidecar
-        tag: 1.2.0
+        tag: 1.2.1
         pullPolicy: IfNotPresent
 
       # Kubernetes resource requests and limits used for the backup hooks sidecar
@@ -1004,7 +1004,7 @@ nuocollector:
     enabled: true
     registry: ghcr.io
     repository: nuodb/nuodb-sidecar
-    tag: 1.2.0
+    tag: 1.2.1
     pullPolicy: IfNotPresent
 
   # Kubernetes resource requests and limits used for the nuocollector sidecar

--- a/test/integration/template_database_test.go
+++ b/test/integration/template_database_test.go
@@ -1135,6 +1135,37 @@ func TestReadinessProbeDefault(t *testing.T) {
 	})
 }
 
+func TestStorageManagersExtraMounts(t *testing.T) {
+	// Path to the helm chart we will test
+	helmChartPath := testlib.DATABASE_HELM_CHART_PATH
+
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"database.sm.hotCopy.volumeMounts[0].name":        "encryptionKeys",
+			"database.sm.hotCopy.volumeMounts[0].mountPath":   "/etc/nuodb/dpe",
+			"database.sm.hotCopy.volumeMounts[0].readOnly":    "true",
+			"database.sm.noHotCopy.volumeMounts[0].name":      "encryptionKeys",
+			"database.sm.noHotCopy.volumeMounts[0].mountPath": "/etc/nuodb/dpe",
+			"database.sm.noHotCopy.volumeMounts[0].readOnly":  "true",
+		},
+	}
+
+	// Run RenderTemplate to render the template and capture the output.
+	output := helm.RenderTemplate(t, options, helmChartPath, "release-name", []string{"templates/statefulset.yaml"})
+
+	for _, obj := range testlib.SplitAndRenderStatefulSet(t, output, 2) {
+		require.NotEmpty(t, obj.Spec.Template.Spec.Containers)
+		container := obj.Spec.Template.Spec.Containers[0]
+		require.True(t, testlib.MountContains(container.VolumeMounts, "encryptionKeys"))
+		for _, vm := range container.VolumeMounts {
+			if vm.Name == "encryptionKeys" {
+				require.Equal(t, "/etc/nuodb/dpe", vm.MountPath)
+				require.True(t, vm.ReadOnly)
+			}
+		}
+	}
+}
+
 func TestDatabaseConfigDoesNotContainEmptyBlocks(t *testing.T) {
 	// Path to the helm chart we will test
 	helmChartPath := testlib.DATABASE_HELM_CHART_PATH
@@ -3067,6 +3098,181 @@ func TestBackupHooksCustomHandlersNegative(t *testing.T) {
 		require.Error(t, err, &exec.ExitError{})
 		require.Contains(t, err.Error(), "Error: values don't meet the specifications of the schema(s) in the following chart(s):")
 		require.Contains(t, err.Error(), `- database.te.operationsSidecar.customHandlers.0.path: Does not match pattern '^/?(([a-zA-Z_0-9-]+|[{][a-zA-Z_][a-zA-Z_0-9]*[}])/)*([a-zA-Z_0-9-]+|[{][a-zA-Z_][a-zA-Z_0-9]*[}])$'`)
+	})
+}
+
+func TestBackupHooksCancelRulesNegative(t *testing.T) {
+	helmChartPath := testlib.DATABASE_HELM_CHART_PATH
+
+	t.Run("testBadType", func(t *testing.T) {
+		options := &helm.Options{
+			SetValues: map[string]string{
+				"database.backupHooks.enabled":                                 "true",
+				"database.sm.operationsSidecar.cancelBackupRules[0].type":      "BOGUS",
+				"database.sm.operationsSidecar.cancelBackupRules[0].op":        ">",
+				"database.sm.operationsSidecar.cancelBackupRules[0].threshold": "0",
+				"database.sm.operationsSidecar.cancelBackupRules[0].duration":  "60",
+			},
+			KubectlOptions: &k8s.KubectlOptions{
+				Namespace: "default",
+			},
+		}
+		_, err := helm.RenderTemplateE(t, options, helmChartPath, "release-name", []string{"templates/statefulset.yaml"})
+		require.Error(t, err, &exec.ExitError{})
+		require.Contains(t, err.Error(), "Error: values don't meet the specifications of the schema(s) in the following chart(s):")
+		require.Contains(t, err.Error(), `- database.sm.operationsSidecar.cancelBackupRules.0.type: database.sm.operationsSidecar.cancelBackupRules.0.type must be one of the following: "journalUtilization", "script"`)
+	})
+
+	t.Run("testBadOperator", func(t *testing.T) {
+		options := &helm.Options{
+			SetValues: map[string]string{
+				"database.backupHooks.enabled":                                 "true",
+				"database.sm.operationsSidecar.cancelBackupRules[0].type":      "journalUtilization",
+				"database.sm.operationsSidecar.cancelBackupRules[0].op":        "<>",
+				"database.sm.operationsSidecar.cancelBackupRules[0].threshold": "100",
+				"database.sm.operationsSidecar.cancelBackupRules[0].duration":  "60",
+			},
+			KubectlOptions: &k8s.KubectlOptions{
+				Namespace: "default",
+			},
+		}
+		_, err := helm.RenderTemplateE(t, options, helmChartPath, "release-name", []string{"templates/statefulset.yaml"})
+		require.Error(t, err, &exec.ExitError{})
+		require.Contains(t, err.Error(), "Error: values don't meet the specifications of the schema(s) in the following chart(s):")
+		require.Contains(t, err.Error(), `- database.sm.operationsSidecar.cancelBackupRules.0.op: database.sm.operationsSidecar.cancelBackupRules.0.op must be one of the following: "\u003e", "\u003e=", "\u003c", "\u003c=", "==", "!="`)
+	})
+
+	t.Run("testBadDuration", func(t *testing.T) {
+		options := &helm.Options{
+			SetValues: map[string]string{
+				"database.backupHooks.enabled":                                 "true",
+				"database.sm.operationsSidecar.cancelBackupRules[0].type":      "journalUtilization",
+				"database.sm.operationsSidecar.cancelBackupRules[0].op":        ">",
+				"database.sm.operationsSidecar.cancelBackupRules[0].threshold": "80",
+				"database.sm.operationsSidecar.cancelBackupRules[0].duration":  "BOGUS",
+			},
+			KubectlOptions: &k8s.KubectlOptions{
+				Namespace: "default",
+			},
+		}
+		_, err := helm.RenderTemplateE(t, options, helmChartPath, "release-name", []string{"templates/statefulset.yaml"})
+		require.Error(t, err, &exec.ExitError{})
+		require.Contains(t, err.Error(), "Error: values don't meet the specifications of the schema(s) in the following chart(s):")
+		require.Contains(t, err.Error(), `- database.sm.operationsSidecar.cancelBackupRules.0.duration: Invalid type. Expected: number, given: string`)
+	})
+
+	t.Run("testLowDuration", func(t *testing.T) {
+		options := &helm.Options{
+			SetValues: map[string]string{
+				"database.backupHooks.enabled":                                 "true",
+				"database.sm.operationsSidecar.cancelBackupRules[0].type":      "journalUtilization",
+				"database.sm.operationsSidecar.cancelBackupRules[0].op":        ">",
+				"database.sm.operationsSidecar.cancelBackupRules[0].threshold": "80",
+				"database.sm.operationsSidecar.cancelBackupRules[0].duration":  "-10",
+			},
+			KubectlOptions: &k8s.KubectlOptions{
+				Namespace: "default",
+			},
+		}
+		_, err := helm.RenderTemplateE(t, options, helmChartPath, "release-name", []string{"templates/statefulset.yaml"})
+		require.Error(t, err, &exec.ExitError{})
+		require.Contains(t, err.Error(), "Error: values don't meet the specifications of the schema(s) in the following chart(s):")
+		require.Contains(t, err.Error(), `- database.sm.operationsSidecar.cancelBackupRules.0.duration: Must be greater than or equal to 0`)
+	})
+
+	t.Run("testBadThreshold", func(t *testing.T) {
+		options := &helm.Options{
+			SetValues: map[string]string{
+				"database.backupHooks.enabled":                                 "true",
+				"database.sm.operationsSidecar.cancelBackupRules[0].type":      "journalUtilization",
+				"database.sm.operationsSidecar.cancelBackupRules[0].op":        ">",
+				"database.sm.operationsSidecar.cancelBackupRules[0].threshold": "BOGUS",
+				"database.sm.operationsSidecar.cancelBackupRules[0].duration":  "60",
+			},
+			KubectlOptions: &k8s.KubectlOptions{
+				Namespace: "default",
+			},
+		}
+		_, err := helm.RenderTemplateE(t, options, helmChartPath, "release-name", []string{"templates/statefulset.yaml"})
+		require.Error(t, err, &exec.ExitError{})
+		require.Contains(t, err.Error(), "Error: values don't meet the specifications of the schema(s) in the following chart(s):")
+		require.Contains(t, err.Error(), `- database.sm.operationsSidecar.cancelBackupRules.0.threshold: Invalid type. Expected: number, given: string`)
+	})
+
+	t.Run("testMissingDuration", func(t *testing.T) {
+		options := &helm.Options{
+			SetValues: map[string]string{
+				"database.backupHooks.enabled":                                 "true",
+				"database.sm.operationsSidecar.cancelBackupRules[0].type":      "journalUtilization",
+				"database.sm.operationsSidecar.cancelBackupRules[0].op":        ">",
+				"database.sm.operationsSidecar.cancelBackupRules[0].threshold": "80",
+			},
+			KubectlOptions: &k8s.KubectlOptions{
+				Namespace: "default",
+			},
+		}
+		_, err := helm.RenderTemplateE(t, options, helmChartPath, "release-name", []string{"templates/statefulset.yaml"})
+		require.Error(t, err, &exec.ExitError{})
+		require.Contains(t, err.Error(), "Error: values don't meet the specifications of the schema(s) in the following chart(s):")
+		require.Contains(t, err.Error(), `- database.sm.operationsSidecar.cancelBackupRules.0: duration is required`)
+	})
+
+	t.Run("testMissingThreshold", func(t *testing.T) {
+		options := &helm.Options{
+			SetValues: map[string]string{
+				"database.backupHooks.enabled":                                "true",
+				"database.sm.operationsSidecar.cancelBackupRules[0].type":     "journalUtilization",
+				"database.sm.operationsSidecar.cancelBackupRules[0].op":       ">",
+				"database.sm.operationsSidecar.cancelBackupRules[0].duration": "60",
+			},
+			KubectlOptions: &k8s.KubectlOptions{
+				Namespace: "default",
+			},
+		}
+		_, err := helm.RenderTemplateE(t, options, helmChartPath, "release-name", []string{"templates/statefulset.yaml"})
+		require.Error(t, err, &exec.ExitError{})
+		require.Contains(t, err.Error(), "Error: values don't meet the specifications of the schema(s) in the following chart(s):")
+		require.Contains(t, err.Error(), `- database.sm.operationsSidecar.cancelBackupRules.0: threshold is required`)
+	})
+
+	t.Run("testMissingScript", func(t *testing.T) {
+		options := &helm.Options{
+			SetValues: map[string]string{
+				"database.backupHooks.enabled":                                 "true",
+				"database.sm.operationsSidecar.cancelBackupRules[0].name":      "Memory throttling",
+				"database.sm.operationsSidecar.cancelBackupRules[0].type":      "script",
+				"database.sm.operationsSidecar.cancelBackupRules[0].op":        ">",
+				"database.sm.operationsSidecar.cancelBackupRules[0].threshold": "0",
+				"database.sm.operationsSidecar.cancelBackupRules[0].duration":  "60",
+			},
+			KubectlOptions: &k8s.KubectlOptions{
+				Namespace: "default",
+			},
+		}
+		_, err := helm.RenderTemplateE(t, options, helmChartPath, "release-name", []string{"templates/statefulset.yaml"})
+		require.Error(t, err, &exec.ExitError{})
+		require.Contains(t, err.Error(), "Error: values don't meet the specifications of the schema(s) in the following chart(s):")
+		require.Contains(t, err.Error(), `database.sm.operationsSidecar.cancelBackupRules.0: script is required`)
+	})
+
+	t.Run("testMissingName", func(t *testing.T) {
+		options := &helm.Options{
+			SetValues: map[string]string{
+				"database.backupHooks.enabled":                                 "true",
+				"database.sm.operationsSidecar.cancelBackupRules[0].type":      "script",
+				"database.sm.operationsSidecar.cancelBackupRules[0].op":        ">",
+				"database.sm.operationsSidecar.cancelBackupRules[0].threshold": "0",
+				"database.sm.operationsSidecar.cancelBackupRules[0].duration":  "60",
+				"database.sm.operationsSidecar.cancelBackupRules[0].script":    `curl -s http://localhost:9001/metrics | grep -E "^nuodb_MemoryThrottleTime_raw" | cut -d' ' -f2`,
+			},
+			KubectlOptions: &k8s.KubectlOptions{
+				Namespace: "default",
+			},
+		}
+		_, err := helm.RenderTemplateE(t, options, helmChartPath, "release-name", []string{"templates/statefulset.yaml"})
+		require.Error(t, err, &exec.ExitError{})
+		require.Contains(t, err.Error(), "Error: values don't meet the specifications of the schema(s) in the following chart(s):")
+		require.Contains(t, err.Error(), `- database.sm.operationsSidecar.cancelBackupRules.0: name is required`)
 	})
 }
 

--- a/test/integration/template_database_test.go
+++ b/test/integration/template_database_test.go
@@ -3158,7 +3158,7 @@ func TestBackupHooksCancelRulesNegative(t *testing.T) {
 		_, err := helm.RenderTemplateE(t, options, helmChartPath, "release-name", []string{"templates/statefulset.yaml"})
 		require.Error(t, err, &exec.ExitError{})
 		require.Contains(t, err.Error(), "Error: values don't meet the specifications of the schema(s) in the following chart(s):")
-		require.Contains(t, err.Error(), `- database.sm.operationsSidecar.cancelBackupRules.0.duration: Invalid type. Expected: number, given: string`)
+		require.Contains(t, err.Error(), `- database.sm.operationsSidecar.cancelBackupRules.0.duration: Does not match pattern '^\d+(\.\d+)?$'`)
 	})
 
 	t.Run("testLowDuration", func(t *testing.T) {
@@ -3196,7 +3196,7 @@ func TestBackupHooksCancelRulesNegative(t *testing.T) {
 		_, err := helm.RenderTemplateE(t, options, helmChartPath, "release-name", []string{"templates/statefulset.yaml"})
 		require.Error(t, err, &exec.ExitError{})
 		require.Contains(t, err.Error(), "Error: values don't meet the specifications of the schema(s) in the following chart(s):")
-		require.Contains(t, err.Error(), `- database.sm.operationsSidecar.cancelBackupRules.0.threshold: Invalid type. Expected: number, given: string`)
+		require.Contains(t, err.Error(), `- database.sm.operationsSidecar.cancelBackupRules.0.threshold: Does not match pattern '^-?\d+(\.\d+)?$'`)
 	})
 
 	t.Run("testMissingDuration", func(t *testing.T) {

--- a/test/minikube/minikube_fsfreeze_test.go
+++ b/test/minikube/minikube_fsfreeze_test.go
@@ -332,7 +332,7 @@ func TestHotSnapBackupHook(t *testing.T) {
 		// Wait for the automatic backup canceling and metadata files removal
 		testlib.Await(t, func() bool {
 			return testlib.GetStringOccurrenceInLog(t, namespaceName, smPod,
-				fmt.Sprintf("Canceling backup with ID %s. Timeout after %ss", backupId, timeout),
+				fmt.Sprintf("Canceling backup with ID %s: Timeout after %ss", backupId, timeout),
 				&corev1.PodLogOptions{Container: "backup-hooks"}) > 0
 		}, 10*time.Second)
 		k8s.RunKubectl(t, kubectlOptions, "exec", smPod, "-c", "engine", "--",
@@ -384,5 +384,81 @@ func TestHotSnapBackupHook(t *testing.T) {
 			fmt.Sprintf("Unexpected start ID: .* SM process restarted while executing backup ID %s", backupId),
 			&corev1.PodLogOptions{Container: "backup-hooks"}),
 			"Expected to detect SM startId change")
+	})
+}
+
+func TestHooksCancelBackupRules(t *testing.T) {
+	defer testlib.Teardown(testlib.TEARDOWN_ADMIN)
+	adminReleaseName, namespaceName := testlib.StartAdmin(t, &helm.Options{}, 1, "")
+	admin0 := fmt.Sprintf("%s-nuodb-cluster0-0", adminReleaseName)
+
+	// Start database and wait for it to become running
+	defer testlib.Teardown(testlib.TEARDOWN_DATABASE)
+	databaseOptions := helm.Options{
+		SetValues: map[string]string{
+			"database.sm.resources.requests.cpu":        testlib.MINIMAL_VIABLE_ENGINE_CPU,
+			"database.sm.resources.requests.memory":     testlib.MINIMAL_VIABLE_ENGINE_MEMORY,
+			"database.te.resources.requests.cpu":        testlib.MINIMAL_VIABLE_ENGINE_CPU,
+			"database.te.resources.requests.memory":     testlib.MINIMAL_VIABLE_ENGINE_MEMORY,
+			"database.sm.hotCopy.enablePod":             "false",
+			"database.sm.noHotCopy.replicas":            "1",
+			"database.sm.noHotCopy.journalPath.enabled": "true",
+			"nuocollector.enabled":                      "true",
+			// Load database Prometheus plugin
+			"nuocollector.plugins.database.prometheus": `
+[[outputs.prometheus_client]]
+listen = ":9001"
+metric_version = 2
+path = "/metrics"`,
+			"database.backupHooks.enabled": "true",
+			"database.backupHooks.timeout": "120",
+
+			// Cancel backup if journal size is above 50MB for 5s
+			"database.sm.operationsSidecar.cancelBackupRules[0].name":      "Journal size",
+			"database.sm.operationsSidecar.cancelBackupRules[0].type":      "script",
+			"database.sm.operationsSidecar.cancelBackupRules[0].op":        ">",
+			"database.sm.operationsSidecar.cancelBackupRules[0].threshold": "50",
+			"database.sm.operationsSidecar.cancelBackupRules[0].duration":  "5",
+			"database.sm.operationsSidecar.cancelBackupRules[0].script":    `curl -s http://localhost:9001/metrics | grep -E '^JournalSize_raw' | cut -d' ' -f2`,
+		},
+	}
+	databaseReleaseName := testlib.StartDatabase(t, namespaceName, admin0, &databaseOptions)
+
+	// Get database pod names
+	opt := testlib.GetExtractedOptions(&databaseOptions)
+	smPodNameTemplate := fmt.Sprintf("sm-%s-nuodb-%s-%s", databaseReleaseName, opt.ClusterName, opt.DbName)
+	smPodName := testlib.GetPodName(t, namespaceName, smPodNameTemplate)
+	kubectlOptions := k8s.NewKubectlOptions("", "", namespaceName)
+
+	// Collect backup hooks logs on test failure
+	testlib.AddDiagnosticTeardown(testlib.TEARDOWN_DATABASE, t, func() {
+		testlib.GetAppLog(t, namespaceName, smPodName, "_hooks", &corev1.PodLogOptions{Container: "backup-hooks"})
+	})
+
+	awaitBackupCanceled := func(backupId string, reason string, timeout time.Duration) {
+		testlib.Await(t, func() bool {
+			output, err := k8s.RunKubectlAndGetOutputE(t, kubectlOptions, "exec", smPodName, "-c", "backup-hooks", "--",
+				"sh", "-c", "cat $NUODB_JOURNAL_DIR/backup.txt 2>/dev/null || exit 0")
+			require.NoError(t, err, output)
+			return strings.TrimSpace(output) != backupId
+		}, timeout)
+		require.GreaterOrEqual(t, testlib.GetStringOccurrenceInLog(t, namespaceName, smPodName,
+			fmt.Sprintf("Canceling backup with ID %s: %s", backupId, reason),
+			&corev1.PodLogOptions{Container: "backup-hooks"}), 1)
+	}
+
+	t.Run("testJournalSizeThreshold", func(t *testing.T) {
+		// Execute pre-backup hook
+		backupId := strings.ReplaceAll(t.Name(), "/", "")
+		testlib.InvokeBackupHook(t, namespaceName, smPodName, "pre-backup/"+backupId)
+
+		// Create table and insert 100MB data
+		statement := `
+		create table t1 (f1 string);
+		create table ten (f1 integer);
+		insert into ten values (1),(2),(3),(4),(5),(6),(7),(8),(9),(10);
+		insert into t1 select replicate('x', 1024) from ten as a1, ten as a2, ten as a3, ten as a4, ten as a5;`
+		testlib.RunSQL(t, namespaceName, admin0, "demo", statement)
+		awaitBackupCanceled(backupId, "Journal size", 120*time.Second)
 	})
 }


### PR DESCRIPTION
**Changes**

This change exposes backup cancellation rules for the SM operations sidecar and
`volumeMounts` for SM engine containers. The cancellation rules are validated
using JSON schema.

Bump the `nuodb/nuodb-sidecar` tag to v1.2.1.

Fixed an issue with `checksum/config` annotation where the custom handlers are
defined via `database.sm.operationsSidecar.customHandlers` instead of
`database.backupHooks.customHandlers` Helm values.

**Testing**
- integration tests
- e2e tests