### PR TITLE
Disable unused service discovery feature

### DIFF
--- a/stable/admin/templates/statefulset.yaml
+++ b/stable/admin/templates/statefulset.yaml
@@ -43,7 +43,7 @@ spec:
         {{- include "admin.podLabels" . | nindent 8 }}
         component: admin
     spec:
-      enableServiceLinks: {{ default false .Values.admin.enableServiceLinks }}
+      enableServiceLinks: {{ default false .Values.admin.internal.enableServiceLinks }}
       serviceAccountName: {{ default "" .Values.nuodb.serviceAccount }}
       priorityClassName: {{ default "" .Values.admin.priorityClass }}
       {{- include "admin.securityContext" . | indent 6 }}

--- a/stable/admin/templates/statefulset.yaml
+++ b/stable/admin/templates/statefulset.yaml
@@ -43,6 +43,7 @@ spec:
         {{- include "admin.podLabels" . | nindent 8 }}
         component: admin
     spec:
+      enableServiceLinks: {{ default false .Values.admin.enableServiceLinks }}
       serviceAccountName: {{ default "" .Values.nuodb.serviceAccount }}
       priorityClassName: {{ default "" .Values.admin.priorityClass }}
       {{- include "admin.securityContext" . | indent 6 }}

--- a/stable/admin/values.yaml
+++ b/stable/admin/values.yaml
@@ -436,6 +436,16 @@ admin:
     loadBalancerJob:
       enabled: false
 
+  # Internal configuration that is exposed only for testing purposes or expert usage.
+  # IMPORTANT: DO NOT change these values without advice from NuoDB support.
+  internal:
+    # Disable service links to avoid problematic behavior. The Kubernetes
+    # default value of enableServiceLinks=true causes environment variables for
+    # service addresses and ports to be injected into containers, which is a
+    # scalability problem as the number of services within a namespace grows
+    # and can cause exec probes to become slow and use up CPU quotas.
+    enableServiceLinks: false
+
 nuocollector:
   enabled: false
   image:

--- a/stable/database/templates/deployment.yaml
+++ b/stable/database/templates/deployment.yaml
@@ -42,7 +42,7 @@ spec:
         {{- include "database.te.podLabels" . | nindent 8 }}
         component: te
     spec:
-      enableServiceLinks: {{ default false .Values.database.enableServiceLinks }}
+      enableServiceLinks: {{ default false .Values.database.internal.enableServiceLinks }}
       serviceAccountName: {{ default "" .Values.nuodb.serviceAccount }}
       {{- if .Values.database.priorityClasses }}
       priorityClassName: {{ default "" .Values.database.priorityClasses.te }}

--- a/stable/database/templates/deployment.yaml
+++ b/stable/database/templates/deployment.yaml
@@ -42,6 +42,7 @@ spec:
         {{- include "database.te.podLabels" . | nindent 8 }}
         component: te
     spec:
+      enableServiceLinks: {{ default false .Values.database.enableServiceLinks }}
       serviceAccountName: {{ default "" .Values.nuodb.serviceAccount }}
       {{- if .Values.database.priorityClasses }}
       priorityClassName: {{ default "" .Values.database.priorityClasses.te }}

--- a/stable/database/templates/statefulset.yaml
+++ b/stable/database/templates/statefulset.yaml
@@ -41,7 +41,7 @@ spec:
         component: sm
         role: nohotcopy
     spec:
-      enableServiceLinks: {{ default false .Values.database.enableServiceLinks }}
+      enableServiceLinks: {{ default false .Values.database.internal.enableServiceLinks }}
       serviceAccountName: {{ default "" .Values.nuodb.serviceAccount }}
       terminationGracePeriodSeconds: 15
       {{- if .Values.database.priorityClasses }}
@@ -505,7 +505,7 @@ spec:
         component: sm
         role: hotcopy
     spec:
-      enableServiceLinks: {{ default false .Values.database.enableServiceLinks }}
+      enableServiceLinks: {{ default false .Values.database.internal.enableServiceLinks }}
       serviceAccountName: {{ default "" .Values.nuodb.serviceAccount }}
       terminationGracePeriodSeconds: 15
       {{- if .Values.database.priorityClasses }}

--- a/stable/database/templates/statefulset.yaml
+++ b/stable/database/templates/statefulset.yaml
@@ -41,6 +41,7 @@ spec:
         component: sm
         role: nohotcopy
     spec:
+      enableServiceLinks: {{ default false .Values.database.enableServiceLinks }}
       serviceAccountName: {{ default "" .Values.nuodb.serviceAccount }}
       terminationGracePeriodSeconds: 15
       {{- if .Values.database.priorityClasses }}
@@ -504,6 +505,7 @@ spec:
         component: sm
         role: hotcopy
     spec:
+      enableServiceLinks: {{ default false .Values.database.enableServiceLinks }}
       serviceAccountName: {{ default "" .Values.nuodb.serviceAccount }}
       terminationGracePeriodSeconds: 15
       {{- if .Values.database.priorityClasses }}

--- a/stable/database/values.yaml
+++ b/stable/database/values.yaml
@@ -961,6 +961,16 @@ database:
     directService:
       enabled: false
 
+  # Internal configuration that is exposed only for testing purposes or expert usage.
+  # IMPORTANT: DO NOT change these values without advice from NuoDB support.
+  internal:
+    # Disable service links to avoid problematic behavior. The Kubernetes
+    # default value of enableServiceLinks=true causes environment variables for
+    # service addresses and ports to be injected into containers, which is a
+    # scalability problem as the number of services within a namespace grows
+    # and can cause exec probes to become slow and use up CPU quotas.
+    enableServiceLinks: false
+
 nuocollector:
   # Enable NuoDB Collector by setting nuocollector.enabled=true
   enabled: false

--- a/test/integration/template_admin_test.go
+++ b/test/integration/template_admin_test.go
@@ -1798,7 +1798,7 @@ func TestAdminEnableServiceLinks(t *testing.T) {
 	})
 
 	t.Run("testDisabled", func(t *testing.T) {
-		options.SetValues["admin.enableServiceLinks"] = "false"
+		options.SetValues["admin.internal.enableServiceLinks"] = "false"
 		output := helm.RenderTemplate(t, options, helmChartPath, "release-name", []string{"templates/statefulset.yaml"})
 		for _, obj := range testlib.SplitAndRenderStatefulSet(t, output, 1) {
 			require.NotNil(t, obj.Spec.Template.Spec.EnableServiceLinks)
@@ -1807,7 +1807,7 @@ func TestAdminEnableServiceLinks(t *testing.T) {
 	})
 
 	t.Run("testEnabled", func(t *testing.T) {
-		options.SetValues["admin.enableServiceLinks"] = "true"
+		options.SetValues["admin.internal.enableServiceLinks"] = "true"
 		output := helm.RenderTemplate(t, options, helmChartPath, "release-name", []string{"templates/statefulset.yaml"})
 		for _, obj := range testlib.SplitAndRenderStatefulSet(t, output, 1) {
 			require.NotNil(t, obj.Spec.Template.Spec.EnableServiceLinks)

--- a/test/integration/template_admin_test.go
+++ b/test/integration/template_admin_test.go
@@ -1781,3 +1781,37 @@ func TestAdminTolerationsAsString(t *testing.T) {
 		}
 	})
 }
+
+func TestAdminEnableServiceLinks(t *testing.T) {
+	helmChartPath := testlib.ADMIN_HELM_CHART_PATH
+
+	options := &helm.Options{
+		SetValues: map[string]string{},
+	}
+
+	t.Run("testDefault", func(t *testing.T) {
+		output := helm.RenderTemplate(t, options, helmChartPath, "release-name", []string{"templates/statefulset.yaml"})
+		for _, obj := range testlib.SplitAndRenderStatefulSet(t, output, 1) {
+			require.NotNil(t, obj.Spec.Template.Spec.EnableServiceLinks)
+			require.False(t, *obj.Spec.Template.Spec.EnableServiceLinks)
+		}
+	})
+
+	t.Run("testDisabled", func(t *testing.T) {
+		options.SetValues["admin.enableServiceLinks"] = "false"
+		output := helm.RenderTemplate(t, options, helmChartPath, "release-name", []string{"templates/statefulset.yaml"})
+		for _, obj := range testlib.SplitAndRenderStatefulSet(t, output, 1) {
+			require.NotNil(t, obj.Spec.Template.Spec.EnableServiceLinks)
+			require.False(t, *obj.Spec.Template.Spec.EnableServiceLinks)
+		}
+	})
+
+	t.Run("testEnabled", func(t *testing.T) {
+		options.SetValues["admin.enableServiceLinks"] = "true"
+		output := helm.RenderTemplate(t, options, helmChartPath, "release-name", []string{"templates/statefulset.yaml"})
+		for _, obj := range testlib.SplitAndRenderStatefulSet(t, output, 1) {
+			require.NotNil(t, obj.Spec.Template.Spec.EnableServiceLinks)
+			require.True(t, *obj.Spec.Template.Spec.EnableServiceLinks)
+		}
+	})
+}

--- a/test/integration/template_database_test.go
+++ b/test/integration/template_database_test.go
@@ -4325,7 +4325,7 @@ func TestSmEnableServiceLinks(t *testing.T) {
 	})
 
 	t.Run("testDisabled", func(t *testing.T) {
-		options.SetValues["database.enableServiceLinks"] = "false"
+		options.SetValues["database.internal.enableServiceLinks"] = "false"
 		output := helm.RenderTemplate(t, options, helmChartPath, "release-name", []string{"templates/statefulset.yaml"})
 		for _, obj := range testlib.SplitAndRenderStatefulSet(t, output, 2) {
 			require.NotNil(t, obj.Spec.Template.Spec.EnableServiceLinks)
@@ -4334,7 +4334,7 @@ func TestSmEnableServiceLinks(t *testing.T) {
 	})
 
 	t.Run("testEnabled", func(t *testing.T) {
-		options.SetValues["database.enableServiceLinks"] = "true"
+		options.SetValues["database.internal.enableServiceLinks"] = "true"
 		output := helm.RenderTemplate(t, options, helmChartPath, "release-name", []string{"templates/statefulset.yaml"})
 		for _, obj := range testlib.SplitAndRenderStatefulSet(t, output, 2) {
 			require.NotNil(t, obj.Spec.Template.Spec.EnableServiceLinks)
@@ -4359,7 +4359,7 @@ func TestTeEnableServiceLinks(t *testing.T) {
 	})
 
 	t.Run("testDisabled", func(t *testing.T) {
-		options.SetValues["database.enableServiceLinks"] = "false"
+		options.SetValues["database.internal.enableServiceLinks"] = "false"
 		output := helm.RenderTemplate(t, options, helmChartPath, "release-name", []string{"templates/deployment.yaml"})
 		for _, obj := range testlib.SplitAndRenderDeployment(t, output, 1) {
 			require.NotNil(t, obj.Spec.Template.Spec.EnableServiceLinks)
@@ -4368,7 +4368,7 @@ func TestTeEnableServiceLinks(t *testing.T) {
 	})
 
 	t.Run("testEnabled", func(t *testing.T) {
-		options.SetValues["database.enableServiceLinks"] = "true"
+		options.SetValues["database.internal.enableServiceLinks"] = "true"
 		output := helm.RenderTemplate(t, options, helmChartPath, "release-name", []string{"templates/deployment.yaml"})
 		for _, obj := range testlib.SplitAndRenderDeployment(t, output, 1) {
 			require.NotNil(t, obj.Spec.Template.Spec.EnableServiceLinks)

--- a/test/integration/template_database_test.go
+++ b/test/integration/template_database_test.go
@@ -4308,3 +4308,71 @@ func TestDatabaseTolerationsAsString(t *testing.T) {
 		}
 	})
 }
+
+func TestSmEnableServiceLinks(t *testing.T) {
+	helmChartPath := testlib.DATABASE_HELM_CHART_PATH
+
+	options := &helm.Options{
+		SetValues: map[string]string{},
+	}
+
+	t.Run("testDefault", func(t *testing.T) {
+		output := helm.RenderTemplate(t, options, helmChartPath, "release-name", []string{"templates/statefulset.yaml"})
+		for _, obj := range testlib.SplitAndRenderStatefulSet(t, output, 2) {
+			require.NotNil(t, obj.Spec.Template.Spec.EnableServiceLinks)
+			require.False(t, *obj.Spec.Template.Spec.EnableServiceLinks)
+		}
+	})
+
+	t.Run("testDisabled", func(t *testing.T) {
+		options.SetValues["database.enableServiceLinks"] = "false"
+		output := helm.RenderTemplate(t, options, helmChartPath, "release-name", []string{"templates/statefulset.yaml"})
+		for _, obj := range testlib.SplitAndRenderStatefulSet(t, output, 2) {
+			require.NotNil(t, obj.Spec.Template.Spec.EnableServiceLinks)
+			require.False(t, *obj.Spec.Template.Spec.EnableServiceLinks)
+		}
+	})
+
+	t.Run("testEnabled", func(t *testing.T) {
+		options.SetValues["database.enableServiceLinks"] = "true"
+		output := helm.RenderTemplate(t, options, helmChartPath, "release-name", []string{"templates/statefulset.yaml"})
+		for _, obj := range testlib.SplitAndRenderStatefulSet(t, output, 2) {
+			require.NotNil(t, obj.Spec.Template.Spec.EnableServiceLinks)
+			require.True(t, *obj.Spec.Template.Spec.EnableServiceLinks)
+		}
+	})
+}
+
+func TestTeEnableServiceLinks(t *testing.T) {
+	helmChartPath := testlib.DATABASE_HELM_CHART_PATH
+
+	options := &helm.Options{
+		SetValues: map[string]string{},
+	}
+
+	t.Run("testDefault", func(t *testing.T) {
+		output := helm.RenderTemplate(t, options, helmChartPath, "release-name", []string{"templates/deployment.yaml"})
+		for _, obj := range testlib.SplitAndRenderDeployment(t, output, 1) {
+			require.NotNil(t, obj.Spec.Template.Spec.EnableServiceLinks)
+			require.False(t, *obj.Spec.Template.Spec.EnableServiceLinks)
+		}
+	})
+
+	t.Run("testDisabled", func(t *testing.T) {
+		options.SetValues["database.enableServiceLinks"] = "false"
+		output := helm.RenderTemplate(t, options, helmChartPath, "release-name", []string{"templates/deployment.yaml"})
+		for _, obj := range testlib.SplitAndRenderDeployment(t, output, 1) {
+			require.NotNil(t, obj.Spec.Template.Spec.EnableServiceLinks)
+			require.False(t, *obj.Spec.Template.Spec.EnableServiceLinks)
+		}
+	})
+
+	t.Run("testEnabled", func(t *testing.T) {
+		options.SetValues["database.enableServiceLinks"] = "true"
+		output := helm.RenderTemplate(t, options, helmChartPath, "release-name", []string{"templates/deployment.yaml"})
+		for _, obj := range testlib.SplitAndRenderDeployment(t, output, 1) {
+			require.NotNil(t, obj.Spec.Template.Spec.EnableServiceLinks)
+			require.True(t, *obj.Spec.Template.Spec.EnableServiceLinks)
+		}
+	})
+}


### PR DESCRIPTION
This change disables the unused service discovery feature that is automatically enabled, which is problematic in namespace where there are a large number of service resources.