### PR TITLE
Expose trafficDistribution for services

### DIFF
--- a/stable/admin/README.md
+++ b/stable/admin/README.md
@@ -158,7 +158,7 @@ The following tables list the configurable parameters for the `admin` option of 
 | `externalAccess.internalIP` | Whether to use an internal (to the cloud) or external (public) IP address for the load balancer | `nil` |
 | `externalAccess.type` | The service type used to enable external access for NuoDB Admin. The supported types are `NodePort` and `LoadBalancer` (defaults to `LoadBalancer`) | `nil` |
 | `externalAccess.annotations` | Annotations to pass through to the Service of type `LoadBalancer` | `{}` |
-| `externalAccess.trafficDistribution` | Preference for traffic routing to Service endpoints. Supported values are `PreferSameZone`, `PreferSameNode` and `PreferClose` (deprecated). | `nil` |
+| `externalAccess.trafficDistribution` | Preference for traffic routing to Service endpoints. For more information see [Traffic distribution](https://kubernetes.io/docs/concepts/services-networking/service/#traffic-distribution). | `nil` |
 | `ingress.enabled` | Whether to deploy an Ingress resources for the NuoDB Admin. Supported starting with Kubernetes v1.19.0 | `false` |
 | `ingress.api.hostname` | The fully qualified domain name (FQDN) of the network host for the NuoDB Admin REST API | `""` |
 | `ingress.api.className` | The associated IngressClass name defines which Ingress controller will implement the resource | `""` |
@@ -235,7 +235,7 @@ The following tables list the configurable parameters for the `admin` option of 
 | `env` | Additional environment variables to pass through to the Admin container | `[]`|
 | `nuocmdPlugins` | Any `nuocmd` plugins to install in the container, as a map with ConfigMap names as keys | `{}` |
 | `service.annotations` | Annotations to pass through to the Service of type `ClusterIP` | `nil` |
-| `service.trafficDistribution` | Preference for traffic routing to Service endpoints. Supported values are `PreferSameZone`, `PreferSameNode` and `PreferClose` (deprecated). | `nil` |
+| `service.trafficDistribution` | Preference for traffic routing to Service endpoints. For more information see [Traffic distribution](https://kubernetes.io/docs/concepts/services-networking/service/#traffic-distribution). | `nil` |
 
 For example, when using GlusterFS storage class, you would supply the following parameter:
 

--- a/stable/admin/README.md
+++ b/stable/admin/README.md
@@ -158,6 +158,7 @@ The following tables list the configurable parameters for the `admin` option of 
 | `externalAccess.internalIP` | Whether to use an internal (to the cloud) or external (public) IP address for the load balancer | `nil` |
 | `externalAccess.type` | The service type used to enable external access for NuoDB Admin. The supported types are `NodePort` and `LoadBalancer` (defaults to `LoadBalancer`) | `nil` |
 | `externalAccess.annotations` | Annotations to pass through to the Service of type `LoadBalancer` | `{}` |
+| `externalAccess.trafficDistribution` | Preference for traffic routing to Service endpoints. Supported values are `PreferSameZone`, `PreferSameNode` and `PreferClose` (deprecated). | `nil` |
 | `ingress.enabled` | Whether to deploy an Ingress resources for the NuoDB Admin. Supported starting with Kubernetes v1.19.0 | `false` |
 | `ingress.api.hostname` | The fully qualified domain name (FQDN) of the network host for the NuoDB Admin REST API | `""` |
 | `ingress.api.className` | The associated IngressClass name defines which Ingress controller will implement the resource | `""` |
@@ -233,6 +234,8 @@ The following tables list the configurable parameters for the `admin` option of 
 | `adminLabels` | Admin labels to apply to each Admin Process. Supported starting from NuoDB image version 6.0.3 | `{}`|
 | `env` | Additional environment variables to pass through to the Admin container | `[]`|
 | `nuocmdPlugins` | Any `nuocmd` plugins to install in the container, as a map with ConfigMap names as keys | `{}` |
+| `service.annotations` | Annotations to pass through to the Service of type `ClusterIP` | `nil` |
+| `service.trafficDistribution` | Preference for traffic routing to Service endpoints. Supported values are `PreferSameZone`, `PreferSameNode` and `PreferClose` (deprecated). | `nil` |
 
 For example, when using GlusterFS storage class, you would supply the following parameter:
 

--- a/stable/admin/templates/_helpers.tpl
+++ b/stable/admin/templates/_helpers.tpl
@@ -613,9 +613,9 @@ Resources requested and limited
 Any additional annotations to add to services.
 */}}
 {{- define "admin.serviceAnnotations"}}
-{{/*
-Extension point that can be overriden by an embedding chart.
-*/}}
+{{- with .Values.admin.service.annotations }}
+{{ toYaml . }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/stable/admin/templates/service-clusterip.yaml
+++ b/stable/admin/templates/service-clusterip.yaml
@@ -18,5 +18,8 @@ spec:
     app: {{ template "admin.fullname" . }}
   sessionAffinity: None
   type: ClusterIP
+  {{- with .Values.admin.service.trafficDistribution }}
+  trafficDistribution: {{ . }}
+  {{- end }}
 status:
   loadBalancer: {}

--- a/stable/admin/templates/service.yaml
+++ b/stable/admin/templates/service.yaml
@@ -16,6 +16,9 @@ spec:
     app: {{ template "admin.fullname" . }}
   sessionAffinity: None
   type: {{ default "LoadBalancer" .Values.admin.externalAccess.type }}
+  {{- with .Values.admin.externalAccess.trafficDistribution }}
+  trafficDistribution: {{ . }}
+  {{- end }}
 status:
   loadBalancer: {}
 {{- end}}

--- a/stable/admin/values.yaml
+++ b/stable/admin/values.yaml
@@ -125,6 +125,7 @@ admin:
   #   internalIP: true
   #   type: LoadBalancer
   #   annotations: {}
+  #   trafficDistribution: PreferSameZone
 
   # Enable NuoDB external access via Ingress; the provisioned Ingress controller
   # should support SSL passthrough feature allowing it to send the TLS
@@ -451,6 +452,10 @@ admin:
     # scalability problem as the number of services within a namespace grows
     # and can cause exec probes to become slow and use up CPU quotas.
     enableServiceLinks: false
+
+  service: {}
+  #  annotations: {}
+  #  trafficDistribution: PreferSameZone
 
 nuocollector:
   enabled: false

--- a/stable/database/README.md
+++ b/stable/database/README.md
@@ -325,14 +325,14 @@ The following tables list the configurable parameters of the `database` chart an
 | `te.externalAccess.internalIP` | Whether to use an internal (to the cloud) or external (public) IP address for the load balancer. Only applies to external access of type `LoadBalancer` | `nil` |
 | `te.externalAccess.type` | The service type used to enable external database access. The supported types are `NodePort` and `LoadBalancer` (defaults to `LoadBalancer`) | `nil` |
 | `te.externalAccess.annotations` | Annotations to pass through to the Service of type `LoadBalancer` | `{}` |
-| `te.externalAccess.trafficDistribution` | Preference for traffic routing to Service endpoints. Supported values are `PreferSameZone`, `PreferSameNode` and `PreferClose` (deprecated). | `nil` |
+| `te.externalAccess.trafficDistribution` | Preference for traffic routing to Service endpoints. For more information see [Traffic distribution](https://kubernetes.io/docs/concepts/services-networking/service/#traffic-distribution). | `nil` |
 | `te.ingress.enabled` | Whether to deploy an Ingress resources for the NuoDB Database. Supported starting with Kubernetes v1.19.0 and NuoDB image version 4.2.3 | `false` |
 | `te.ingress.hostname` | The fully qualified domain name (FQDN) of the network host used by SQL clients to reach this database | `""` |
 | `te.ingress.className` | The associated IngressClass name defines which Ingress controller will implement the resource | `""` |
 | `te.ingress.annotations` | Custom annotations that are set on the Ingress resource. SSL passthrough feature should be configured so that SQL clients TLS connections are send directly to the Transaction Engines | `{ ingress.kubernetes.io/ssl-passthrough: "true" }` |
 | `te.dbServices.enabled` | Whether to deploy clusterip and headless services for direct TE connections (defaults true) | `nil` |
 | `te.dbServices.annotations` | Annotations to pass through to the Service of type `ClusterIP` | `nil` |
-| `te.dbServices.trafficDistribution` | Preference for traffic routing to Service endpoints. Supported values are `PreferSameZone`, `PreferSameNode` and `PreferClose` (deprecated). | `nil` |
+| `te.dbServices.trafficDistribution` | Preference for traffic routing to Service endpoints. For more information see [Traffic distribution](https://kubernetes.io/docs/concepts/services-networking/service/#traffic-distribution). | `nil` |
 | `te.logPersistence.enabled` | Whether to enable persistent storage for logs | `false` |
 | `te.logPersistence.overwriteBackoff.copies` | How many copies of the crash directory to keep within windowMinutes | `3` |
 | `te.logPersistence.overwriteBackoff.windowMinutes` | The window within which to keep the number of crash copies | `120` |

--- a/stable/database/README.md
+++ b/stable/database/README.md
@@ -316,11 +316,14 @@ The following tables list the configurable parameters of the `database` chart an
 | `te.externalAccess.internalIP` | Whether to use an internal (to the cloud) or external (public) IP address for the load balancer. Only applies to external access of type `LoadBalancer` | `nil` |
 | `te.externalAccess.type` | The service type used to enable external database access. The supported types are `NodePort` and `LoadBalancer` (defaults to `LoadBalancer`) | `nil` |
 | `te.externalAccess.annotations` | Annotations to pass through to the Service of type `LoadBalancer` | `{}` |
+| `te.externalAccess.trafficDistribution` | Preference for traffic routing to Service endpoints. Supported values are `PreferSameZone`, `PreferSameNode` and `PreferClose` (deprecated). | `nil` |
 | `te.ingress.enabled` | Whether to deploy an Ingress resources for the NuoDB Database. Supported starting with Kubernetes v1.19.0 and NuoDB image version 4.2.3 | `false` |
 | `te.ingress.hostname` | The fully qualified domain name (FQDN) of the network host used by SQL clients to reach this database | `""` |
 | `te.ingress.className` | The associated IngressClass name defines which Ingress controller will implement the resource | `""` |
 | `te.ingress.annotations` | Custom annotations that are set on the Ingress resource. SSL passthrough feature should be configured so that SQL clients TLS connections are send directly to the Transaction Engines | `{ ingress.kubernetes.io/ssl-passthrough: "true" }` |
 | `te.dbServices.enabled` | Whether to deploy clusterip and headless services for direct TE connections (defaults true) | `nil` |
+| `te.dbServices.annotations` | Annotations to pass through to the Service of type `ClusterIP` | `nil` |
+| `te.dbServices.trafficDistribution` | Preference for traffic routing to Service endpoints. Supported values are `PreferSameZone`, `PreferSameNode` and `PreferClose` (deprecated). | `nil` |
 | `te.logPersistence.enabled` | Whether to enable persistent storage for logs | `false` |
 | `te.logPersistence.overwriteBackoff.copies` | How many copies of the crash directory to keep within windowMinutes | `3` |
 | `te.logPersistence.overwriteBackoff.windowMinutes` | The window within which to keep the number of crash copies | `120` |

--- a/stable/database/templates/_helpers.tpl
+++ b/stable/database/templates/_helpers.tpl
@@ -1307,9 +1307,9 @@ Return the KEDA triggers
 Any additional annotations to add to services.
 */}}
 {{- define "database.serviceAnnotations"}}
-{{/*
-Extension point that can be overriden by an embedding chart.
-*/}}
+{{- with .Values.database.te.dbServices.annotations }}
+{{ toYaml . }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/stable/database/templates/service-clusterip.yaml
+++ b/stable/database/templates/service-clusterip.yaml
@@ -43,6 +43,9 @@ spec:
     component: te
   sessionAffinity: None
   type: ClusterIP
+  {{- with .Values.database.te.dbServices.trafficDistribution }}
+  trafficDistribution: {{ . }}
+  {{- end }}
 status:
   loadBalancer: {}
 {{- end }}

--- a/stable/database/templates/service.yaml
+++ b/stable/database/templates/service.yaml
@@ -16,6 +16,9 @@ spec:
     component: te
   sessionAffinity: None
   type: {{ default "LoadBalancer" .Values.database.te.externalAccess.type }}
+  {{- with .Values.database.te.externalAccess.trafficDistribution }}
+  trafficDistribution: {{ . }}
+  {{- end }}
 status:
   loadBalancer: {}
 {{- end}}

--- a/stable/database/values.yaml
+++ b/stable/database/values.yaml
@@ -732,6 +732,7 @@ database:
       # internalIP: true
       # type: LoadBalancer
       # annotations: {}
+      # trafficDistribution: PreferSameZone
 
     # Enable NuoDB external access via Ingress; the provisioned Ingress
     # controller should support SSL passthrough feature allowing it to send the
@@ -756,6 +757,8 @@ database:
     ## but can be optionally disabled here
     dbServices: {}
       # enabled: false
+      # annotations: {}
+      # trafficDistribution: PreferSameZone
 
     # Number of Transaction Engine (TE) replicas. A non-zero value is discarded
     # if TE autoscaling is enabled.

--- a/test/integration/template_admin_test.go
+++ b/test/integration/template_admin_test.go
@@ -238,7 +238,10 @@ func TestAdminClusterServiceRenders(t *testing.T) {
 	helmChartPath := "../../stable/admin"
 
 	options := &helm.Options{
-		SetValues: map[string]string{},
+		SetValues: map[string]string{
+			"admin.service.annotations.foo":     "fooValue",
+			"admin.service.trafficDistribution": "PreferSameZone",
+		},
 	}
 
 	// Run RenderTemplate to render the template and capture the output.
@@ -248,6 +251,9 @@ func TestAdminClusterServiceRenders(t *testing.T) {
 		assert.Equal(t, "nuodb-clusterip", obj.Name)
 		assert.Equal(t, corev1.ServiceTypeClusterIP, obj.Spec.Type)
 		assert.Empty(t, obj.Spec.ClusterIP)
+		assert.Equal(t, "fooValue", obj.Annotations["foo"])
+		assert.NotNil(t, obj.Spec.TrafficDistribution)
+		assert.Equal(t, "PreferSameZone", *obj.Spec.TrafficDistribution)
 	}
 }
 
@@ -275,9 +281,10 @@ func TestAdminServiceRenders(t *testing.T) {
 
 	options := &helm.Options{
 		SetValues: map[string]string{
-			"cloud.provider":                  "amazon",
-			"admin.externalAccess.enabled":    "true",
-			"admin.externalAccess.internalIP": "true",
+			"cloud.provider":                           "amazon",
+			"admin.externalAccess.enabled":             "true",
+			"admin.externalAccess.internalIP":          "true",
+			"admin.externalAccess.trafficDistribution": "PreferSameZone",
 		},
 	}
 
@@ -290,6 +297,8 @@ func TestAdminServiceRenders(t *testing.T) {
 		assert.Empty(t, obj.Spec.ClusterIP)
 		assert.Contains(t, obj.Annotations, "service.beta.kubernetes.io/aws-load-balancer-internal")
 		assert.Contains(t, obj.Annotations, "service.beta.kubernetes.io/aws-load-balancer-scheme")
+		assert.NotNil(t, obj.Spec.TrafficDistribution)
+		assert.Equal(t, "PreferSameZone", *obj.Spec.TrafficDistribution)
 	}
 
 	// render external AWS NLB annotations

--- a/test/integration/template_database_test.go
+++ b/test/integration/template_database_test.go
@@ -143,7 +143,10 @@ func TestDatabaseClusterServiceRenders(t *testing.T) {
 	helmChartPath := testlib.DATABASE_HELM_CHART_PATH
 
 	options := &helm.Options{
-		SetValues: map[string]string{},
+		SetValues: map[string]string{
+			"database.te.dbServices.annotations.foo":     "fooValue",
+			"database.te.dbServices.trafficDistribution": "PreferSameZone",
+		},
 	}
 
 	// Run RenderTemplate to render the template and capture the output.
@@ -156,6 +159,9 @@ func TestDatabaseClusterServiceRenders(t *testing.T) {
 		assert.Empty(t, obj.Spec.ClusterIP)
 		assert.Equal(t, "te", obj.Spec.Selector["component"])
 		assert.Equal(t, "release-name-nuodb-cluster0-demo-database", obj.Spec.Selector["app"])
+		assert.Equal(t, "fooValue", obj.Annotations["foo"])
+		assert.NotNil(t, obj.Spec.TrafficDistribution)
+		assert.Equal(t, "PreferSameZone", *obj.Spec.TrafficDistribution)
 	}
 }
 
@@ -212,9 +218,10 @@ func TestDatabaseServiceRenders(t *testing.T) {
 
 	options := &helm.Options{
 		SetValues: map[string]string{
-			"cloud.provider":                        "amazon",
-			"database.te.externalAccess.enabled":    "true",
-			"database.te.externalAccess.internalIP": "true",
+			"cloud.provider":                                 "amazon",
+			"database.te.externalAccess.enabled":             "true",
+			"database.te.externalAccess.internalIP":          "true",
+			"database.te.externalAccess.trafficDistribution": "PreferSameZone",
 		},
 	}
 
@@ -227,6 +234,8 @@ func TestDatabaseServiceRenders(t *testing.T) {
 		assert.Equal(t, "release-name-nuodb-cluster0-demo-database", obj.Spec.Selector["app"])
 		assert.Equal(t, "te", obj.Spec.Selector["component"])
 		assert.Contains(t, obj.Annotations, "service.beta.kubernetes.io/aws-load-balancer-internal")
+		assert.NotNil(t, obj.Spec.TrafficDistribution)
+		assert.Equal(t, "PreferSameZone", *obj.Spec.TrafficDistribution)
 	}
 
 	// render external AWS NLB annotations


### PR DESCRIPTION
**Changes**

This change allows users to specify `trafficDistribution` for `ClusterIP` and
`LoadBalancer` services. The default value of `null` is not changed. It also
exposes annotations for `ClusterIP` service.

**Testing**
- integration tests